### PR TITLE
spike: wip mock-fs node 20 fix

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -126,6 +126,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
+          # NOTE - if upgrading to node 20 will need to resolve issue with scripts tests
+          # https://github.com/tschaub/mock-fs/issues/384
           node-version: 18.x
 
       #############################################################################

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -47,6 +47,7 @@
     "@types/fs-extra": "^9.0.4",
     "@types/inquirer": "^7.3.1",
     "@types/jasmine": "^3.10.6",
+    "@types/mock-fs": "^4.13.4",
     "@types/node-rsa": "^1.1.1",
     "@types/semver": "^7.3.9",
     "jasmine": "^3.99.0",

--- a/packages/shared/src/utils/file-utils.ts
+++ b/packages/shared/src/utils/file-utils.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import * as path from "path";
 import * as os from "os";
 import { createHash, randomUUID } from "crypto";
@@ -524,6 +524,14 @@ export function createTempDir() {
   const dirPath = path.join(os.tmpdir(), dirName);
   fs.ensureDirSync(dirPath);
   fs.emptyDirSync(dirPath);
+  return dirPath;
+}
+export async function createTempDirAsync() {
+  const dirName = randomUUID();
+  const dirPath = path.join(os.tmpdir(), dirName);
+  await fs.promises.mkdir(dirPath, { recursive: true });
+  await fs.promises.rm(dirPath, { recursive: true, force: true });
+  await fs.promises.mkdir(dirPath, { recursive: true });
   return dirPath;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7550,6 +7550,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mock-fs@npm:^4.13.4":
+  version: 4.13.4
+  resolution: "@types/mock-fs@npm:4.13.4"
+  dependencies:
+    "@types/node": "*"
+  checksum: 9f886d67186da2e5cdabc32835c49ede9749146768e22c7f0f2548587e5201235d3726adef917fa6efbb9b73ad51278858a5d34e7cdc0a4b413c8396b37c350d
+  languageName: node
+  linkType: hard
+
 "@types/ms@npm:*":
   version: 0.7.31
   resolution: "@types/ms@npm:0.7.31"
@@ -24652,6 +24661,7 @@ __metadata:
     "@types/fs-extra": ^9.0.4
     "@types/inquirer": ^7.3.1
     "@types/jasmine": ^3.10.6
+    "@types/mock-fs": ^4.13.4
     "@types/node-rsa": ^1.1.1
     "@types/semver": ^7.3.9
     actions: "workspace:*"


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Attempt at fixing issue around mockFs incompatibility with node 20

Current draft replaces most fs invocations with promise-based alternatives (suggested to work), however it still doesn't appear that the service methods are calling correctly (still tries to create physical folders which virtual system cannot detect). 

## Git Issues

Closes #2185

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
