### PR TITLE
Fix: fullscreen pop ups

### DIFF
--- a/src/app/shared/components/template/components/layout/popup/popup.component.ts
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.ts
@@ -37,6 +37,9 @@ export class TemplatePopupComponent {
   }
 
   dismiss(value?: { emit_value: string; emit_data: any }) {
+    // if !includeInHistory {
+    // this.templateNavService.removeFromHistory() // i.e. history.replaceState({}, "", location.href);
+    // }
     this.modalCtrl.dismiss(value);
   }
 }

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -35,7 +35,10 @@ export class TemplateActionService extends SyncServiceBase {
   private actionsQueue: FlowTypes.TemplateRowAction[] = [];
   private actionsQueueProcessing$ = new BehaviorSubject<boolean>(false);
 
-  constructor(private injector: Injector, public container?: TemplateContainerComponent) {
+  constructor(
+    private injector: Injector,
+    public container?: TemplateContainerComponent
+  ) {
     super("TemplateAction");
   }
   // Retrive all services on demand from global injector
@@ -205,6 +208,9 @@ export class TemplateActionService extends SyncServiceBase {
       case "pop_up":
         if (action.params?.fullscreen) {
           return this.templateService.runStandaloneTemplate(action.args[0], action.params);
+        }
+        if (action.params?.fullscreen_alt) {
+          return this.templateNavService.handlePopupAction(action, this.container);
         }
         return this.templateNavService.handlePopupAction(action, this.container);
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes various issues with fullscreen popups triggered from the template action:
- Fixes an issue where a child pop-up on a full screen pop-up closes only on the second attempt (#2195)
- Allows navigating back to close a fullscreen pop-up (previously this would navigate to the page in history preceding the template that launched the pop-up. This seems desirable to me but can be discussed, perhaps this should be exposed as a parameter that authors can set.

Currently, this new implementation of fullscreen pop-ups can be triggered using the parameter `fullscreen_alt` passed to the `pop_up` action, e.g. `click | pop_up: a_template_name | fullscreen_alt: true`. This is in order to preserve existing functionality for deployments that already use the `fullscreen` property. I would welcome suggestions of how we might go about making the migration to using the new logic, or else supporting both options with a nicer syntax.

## Dev notes

We currently have two distinct methods triggered by the `pop_up` action:
- If not fullscreen, the `pop_up` action calls `templateNavService.handlePopupAction()`
- If fullscreen, the `pop_up` action calls `templateService.runStandaloneTemplate()`
The `runStandaloneTemplate()` method is used elsewhere in the code, so we don't want to replace it, but it makes sense to me for the `pop_up` template action to use the `handlePopUp()` method with a fullscreen param. This PR therefore tries to incorporate some of the functionality of the former method into the latter, in particular so that navigation functions as expected.

## Testing

See [debug_fullscreen_pop_up_1](https://docs.google.com/spreadsheets/d/1YW7zE4CPt_osn3NzwXwvFCBPjseo1LE5kpYBo190U0s/edit#gid=868243677)

## Git Issues

Closes #2195

## Screenshots/Videos


