### PR TITLE
Fix: item parameter_list dynamic context

### DIFF
--- a/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
+++ b/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
@@ -20,7 +20,7 @@ describe("App String Evaluator", () => {
   // TODO - doesn't work, should address in follow-up
   // replaces string part first without quotation, i.e.
   // `Ada === 'Ada'` and returns just as a string (can't evaluate)
-  fit("@row.first_name === 'Ada'", () => {
+  it("@row.first_name === 'Ada'", () => {
     pending("TODO - fix implementation to support");
     expect(evaluator.evaluate("@row.first_name === 'Ada'")).toEqual(true);
   });

--- a/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
+++ b/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
@@ -16,4 +16,12 @@ describe("App String Evaluator", () => {
       "Hello Ada Lovelace"
     );
   });
+
+  // TODO - doesn't work, should address in follow-up
+  // replaces string part first without quotation, i.e.
+  // `Ada === 'Ada'` and returns just as a string (can't evaluate)
+  fit("@row.first_name === 'Ada'", () => {
+    pending("TODO - fix implementation to support");
+    expect(evaluator.evaluate("@row.first_name === 'Ada'")).toEqual(true);
+  });
 });

--- a/src/app/shared/components/template/components/data-items/data-items.component.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.ts
@@ -43,7 +43,7 @@ export class TmplDataItemsComponent extends TemplateBaseComponent implements OnD
   @Input() set row(row: FlowTypes.TemplateRow) {
     this._row = row;
     this.dataListName = this.hackGetRawDataListName(row);
-    this.parameterList = this.hackGetRawParameterList(row);
+    this.parameterList = this.row.parameter_list;
     this.subscribeToData();
   }
 
@@ -183,15 +183,6 @@ export class TmplDataItemsComponent extends TemplateBaseComponent implements OnD
     return row._dynamicFields?.value?.[0]?.fieldName;
   }
 
-  /** Copied from template-row service */
-  private hackGetRawParameterList(row: FlowTypes.TemplateRow) {
-    const list = row.parameter_list;
-    const unparsedFilter = row._dynamicFields?.parameter_list?.filter?.[0].fullExpression;
-    if (list && unparsedFilter) {
-      list.filter = unparsedFilter;
-    }
-    return list;
-  }
   /** Copied from template-row service */
   private async parseDataList(dataList: { [id: string]: any }) {
     const parsed: { [id: string]: any } = {};

--- a/src/app/shared/components/template/components/data-items/data-items.component.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.ts
@@ -43,7 +43,7 @@ export class TmplDataItemsComponent extends TemplateBaseComponent implements OnD
   @Input() set row(row: FlowTypes.TemplateRow) {
     this._row = row;
     this.dataListName = this.hackGetRawDataListName(row);
-    this.parameterList = this.row.parameter_list;
+    this.parameterList = row.parameter_list;
     this.subscribeToData();
   }
 

--- a/src/app/shared/components/template/processors/item.ts
+++ b/src/app/shared/components/template/processors/item.ts
@@ -135,7 +135,7 @@ class ItemDataPipe {
       if (!expression) return;
       return items.filter((item) => {
         // NOTE - expects all non-item condition to be evaluated
-        // e.g. @item.field > @local.other_value
+        // e.g. `@item.field > @local.some_value` already be evaluated to `this.item.field > "local value"`
         const evaluator = new JSEvaluator();
         const evaluated = evaluator.evaluate(expression, { item });
         return evaluated;

--- a/src/app/shared/components/template/processors/item.ts
+++ b/src/app/shared/components/template/processors/item.ts
@@ -1,6 +1,6 @@
 // NOTE - importing from 'shared' will fail as contains non-browser packages and
 // name conflicts with local 'shared' folder. Import full path from packages instead
-import { AppStringEvaluator } from "packages/shared/src/models/appStringEvaluator/appStringEvaluator";
+import { JSEvaluator } from "packages/shared/src/models/jsEvaluator/jsEvaluator";
 import { TemplatedData } from "packages/shared/src/models/templatedData/templatedData";
 
 import { shuffleArray } from "src/app/shared/utils";
@@ -8,7 +8,10 @@ import { FlowTypes } from "../models";
 import { objectToArray } from "../utils";
 
 export class ItemProcessor {
-  constructor(private dataList: any, private parameterList?: any) {}
+  constructor(
+    private dataList: any,
+    private parameterList?: any
+  ) {}
 
   public process(templateRows: any) {
     const data = objectToArray(this.dataList);
@@ -131,9 +134,10 @@ class ItemDataPipe {
     filter: (items: any[] = [], expression: string) => {
       if (!expression) return;
       return items.filter((item) => {
-        const evaluator = new AppStringEvaluator();
-        evaluator.setExecutionContext({ item });
-        const evaluated = evaluator.evaluate(expression);
+        // NOTE - expects all non-item condition to be evaluated
+        // e.g. @item.field > @local.other_value
+        const evaluator = new JSEvaluator();
+        const evaluated = evaluator.evaluate(expression, { item });
         return evaluated;
       });
     },

--- a/src/app/shared/components/template/services/instance/template-row.service.ts
+++ b/src/app/shared/components/template/services/instance/template-row.service.ts
@@ -288,9 +288,9 @@ export class TemplateRowService extends SyncServiceBase {
     if (type === "items") {
       // extract raw parameter list
       const itemDataList: { [id: string]: any } = row.value;
-      const parameterList = this.hackUnparseItemParameterList(row);
       const parsedItemDataList = await this.parseDataList(itemDataList);
-      const { itemRows } = new ItemProcessor(parsedItemDataList, parameterList).process(row.rows);
+      const { parameter_list, rows } = row;
+      const { itemRows } = new ItemProcessor(parsedItemDataList, parameter_list).process(rows);
       const parsedItemRows = await this.processRows(itemRows, isNestedTemplate, row.name);
       return parsedItemRows;
     }
@@ -370,19 +370,6 @@ export class TemplateRowService extends SyncServiceBase {
       }
     }
     return parsed;
-  }
-
-  /**
-   * When parsing item parameter lists filter references to @item will be replaced before processing
-   * Hacky workaround to replace back with unparsed value
-   */
-  private hackUnparseItemParameterList(row: FlowTypes.TemplateRow) {
-    const list = row.parameter_list;
-    const unparsedFilter = row._dynamicFields?.parameter_list?.filter?.[0].fullExpression;
-    if (list && unparsedFilter) {
-      list.filter = unparsedFilter;
-    }
-    return list;
   }
 
   /** recursively filter out any rows that have a false condition */

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -192,9 +192,9 @@ export class TemplateVariablesService extends AsyncServiceBase {
         return evaluator.fullExpression.replace(/`/gi, "");
       }
 
-      // Do not evaluate if the appropriate context is not available
+      // If the appropriate context is not available, do not evaluate that particular evaluator
       // NOTE - this will mean compound expressions will need to be evaluated later
-      // E.g. @item.some_field = @local.other_field
+      // E.g. @item.some_field === @local.other_field -> this.item.id === "local value", which needs further evaluation
       if (type === "item" && !context.itemContext) {
         return this.hackProcessItemEvaluators(evaluators, context);
       }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

**TODO**

- [x] Builds on #2323 should merge after

## Description

Add support for using dynamic values within the parameter list of `items` and `data_items` components. E.g.
```
filter: @item.number < @local.test_value
filter: @item.string === @local.some_string
```

## Author Notes
Should confirm if passing tests cases from [example_items_pipe_2](https://docs.google.com/spreadsheets/d/1n82prWaYx-HWKW0ibxv-sO_Vuw9WxvuNLRJ_jI_WXtk/edit#gid=1871410965) (see current output in screenshot below)

I expect this won't solve the issue in https://github.com/IDEMSInternational/parenting-app-ui/issues/2303 (but could be tested). If confirmed not working should probably handle in a follow-up instead of this PR

## Review Notes
Worth testing against both `items` and `data_items` syntax to test if working as expected. The fix did have to change a couple parts of the items code that isn't very well documented or tested, and so does have some scope for unexpected errors. So would be good to test against current debug sheets and with cases where the item lists are dynamically updated

## Dev Notes
As all the code changes are made within the `template-row.service` there weren't any more tests to to `items` or `data-items` specs, although I have tested that existing specs still pass. The `template-row.service` has no existing infrastructure, and given this is mostly a workaround it seemed beyond scope to start adding (but could be done as a follow-up).

Unpicking the issue was a bit of a challenge given the complexity of the template-row service and item implementation. See more details in the comments on #1598. This PR goes for the first proposed solution, replacing the app-string evaluator with a pure JS evaluator and attempting to pre-evaluate all non-item dynamic expressions in advance.

I also independently noticed an issue when using the app-string evaluator to evaluator any sort of string comparison (not-working). I've added a placeholder test to identify but beyond scope of this PR to fix (the more I unpick the more that starts to unravel - I think really a lot of this would be better-off with templating system refactor)

The part of the fix I'm least certain about is the parameter list revert hack that was included in both items and data-items component. The comments suggested this is because parameter lists would have item context replaced, although looking at the code it seems that it wouldn't be until render, so not sure if either the fix was legacy or I'm missing something (might be worth confirming against cases where the items get updated)

I'm not sure if related to this PR or not but starting to see issue with modifying final fields
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/ae67326f-99cd-4347-9e72-cbb943117665)

(update - seeing on main - possibly may want to address after merge #2323)

## Git Issues

Closes #1598

## Screenshots/Videos
output from [example_items_pipe_2](https://docs.google.com/spreadsheets/d/1n82prWaYx-HWKW0ibxv-sO_Vuw9WxvuNLRJ_jI_WXtk/edit#gid=1871410965)
![localhost_4200_template](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/32635f57-0a39-427d-9bf1-7d8fb83d5d8d)
