### PR TITLE
Fix/fullscreen pop ups alt

### DIFF
--- a/src/app/shared/components/template/components/layout/popup/popup.component.ts
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.ts
@@ -1,9 +1,8 @@
-import { Component, HostListener, Input, OnDestroy, OnInit } from "@angular/core";
+import { Component, HostListener, Input } from "@angular/core";
 import { ModalController } from "@ionic/angular";
 import { FlowTypes, ITemplateContainerProps } from "../../../models";
 import { TemplateContainerComponent } from "../../../template-container.component";
-import { Router } from "@angular/router";
-import { POPUP_DISMISS_PARAMS, TemplateNavService } from "../../../services/template-nav.service";
+import { TemplateNavService } from "../../../services/template-nav.service";
 
 @Component({
   templateUrl: "./popup.component.html",
@@ -13,46 +12,16 @@ import { POPUP_DISMISS_PARAMS, TemplateNavService } from "../../../services/temp
  * When opening a template as a popup, provide a minimal interface and load
  * the template directly as a regular template-container element
  */
-export class TemplatePopupComponent implements OnInit {
+export class TemplatePopupComponent {
   @Input() props: ITemplatePopupComponentProps;
 
   constructor(
     private modalCtrl: ModalController,
-    private router: Router,
     private templateNavService: TemplateNavService
   ) {}
 
-  ngOnInit() {
-    console.log("adding state");
-    const modalState = {
-      modal: true,
-      popUpName: this.props.name,
-      fullscreen: this.props.fullscreen,
-      description: "custom state when presenting modal",
-    };
-    history.pushState(modalState, null);
-  }
-
-  // ngOnDestroy() {
-  //   // console.log("window.history.state", window.history.state)
-  //   // if (window.history.state.modal) {
-  //   // Navigate back and remove query params
-
-  //   //   history.back();
-  //   //   setTimeout(() => {
-  //   //     this.router.navigate([], {
-  //   //       queryParams: POPUP_DISMISS_PARAMS,
-  //   //       replaceUrl: true,
-  //   //       queryParamsHandling: "merge",
-  //   //     });
-  //   //   }, 100)
-  //   // }
-  //   console.log("hi")
-  //   this.dismiss()
-  // }
-
   @HostListener("window:popstate", ["$event"])
-  dismissOnBack() {
+  dismissOnNavBack() {
     this.dismiss();
   }
 
@@ -77,16 +46,11 @@ export class TemplatePopupComponent implements OnInit {
   }
 
   async dismiss(value?: { emit_value: string; emit_data: any }) {
-    // For popups that are not fullscreen, remove record from history when dismissing
-    // if (history.state.modal && !history.state.fullscreen) {
-    //   history.replaceState({}, "", location.href);
-    //   // history.back();
-    // }
     // If launched as popup via template nav service, dismiss via service to ensure proper handling
     if (this.templateNavService.openPopupsByName[this.props.name]) {
       await this.templateNavService.dismissPopup(this.props.name, value);
     }
-    // Else, e.g. if launched by templateService.runStandaloneTemplate(), simply dismiss
+    // Else, e.g. if launched by TemplateService.runStandaloneTemplate(), simply dismiss
     else {
       await this.modalCtrl.dismiss(value);
     }
@@ -105,4 +69,6 @@ export interface ITemplatePopupComponentProps extends ITemplateContainerProps {
   waitForDismiss?: boolean;
   /** Display fullscreen overlayed on top of all other app content */
   fullscreen?: boolean;
+  /** Track value of "triggered by" on action to repopulate query params */
+  popupParentTriggeredBy?: string;
 }

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -35,7 +35,10 @@ export class TemplateActionService extends SyncServiceBase {
   private actionsQueue: FlowTypes.TemplateRowAction[] = [];
   private actionsQueueProcessing$ = new BehaviorSubject<boolean>(false);
 
-  constructor(private injector: Injector, public container?: TemplateContainerComponent) {
+  constructor(
+    private injector: Injector,
+    public container?: TemplateContainerComponent
+  ) {
     super("TemplateAction");
   }
   // Retrive all services on demand from global injector
@@ -205,6 +208,9 @@ export class TemplateActionService extends SyncServiceBase {
       case "pop_up":
         if (action.params?.fullscreen) {
           return this.templateService.runStandaloneTemplate(action.args[0], action.params);
+        }
+        if (action.params?.fullscreen_alt) {
+          return this.templateNavService.handlePopupAction(action, this.container);
         }
         return this.templateNavService.handlePopupAction(action, this.container);
 

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -296,8 +296,12 @@ export class TemplateNavService extends SyncServiceBase {
     container: TemplateContainerComponent,
     fullscreen?: boolean
   ) {
-    const childTemplateModal = await this.createChildPopupModal(popup_child, container, fullscreen);
-    if (childTemplateModal) {
+    const newChildTemplateModal = await this.ensureChildPopupModal(
+      popup_child,
+      container,
+      fullscreen
+    );
+    if (newChildTemplateModal) {
       // For fullscreen popups, add a state to history so that navigation functions as if popup is a new page
       // Inspired by https://dev.to/nicolus/closing-a-modal-with-the-back-button-in-ionic-5-angular-9-50pk
       if (fullscreen) {
@@ -309,8 +313,8 @@ export class TemplateNavService extends SyncServiceBase {
         };
         history.pushState(modalState, null);
       }
-      await childTemplateModal.present();
-      const { data } = await childTemplateModal.onDidDismiss();
+      await newChildTemplateModal.present();
+      const { data } = await newChildTemplateModal.onDidDismiss();
       log("dismissed", data);
       return data;
     }
@@ -323,7 +327,7 @@ export class TemplateNavService extends SyncServiceBase {
       delete this.openPopupsByName[name];
     }
     const historyState = this.location.getState() as IPopupHistoryState;
-    if (historyState.modal && historyState.popUpName === name) {
+    if (historyState?.modal && historyState?.popUpName === name) {
       this.location.back();
     }
     // If no other popups are open, clear any existing popup query params
@@ -337,7 +341,7 @@ export class TemplateNavService extends SyncServiceBase {
         });
       }, 100);
     }
-    // HACK: Else assume one other open popup and update query params to reflect this
+    // HACK: Else assume first other open popup should be visible and update query params to reflect this
     // TODO: handle case of an arbitrary number of nested popups
     else {
       const [openPopup] = Object.values(this.openPopupsByName);
@@ -361,7 +365,7 @@ export class TemplateNavService extends SyncServiceBase {
     }
   }
 
-  private async createChildPopupModal(
+  private async ensureChildPopupModal(
     popup_child: string,
     container: TemplateContainerComponent,
     fullscreen?: boolean

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -300,6 +300,7 @@ export class TemplateNavService extends SyncServiceBase {
     const childTemplateModal = await this.createChildPopupModal(popup_child, container, fullscreen);
     if (childTemplateModal) {
       // For fullscreen popups, add a state to history so that navigation functions as if popup is a new page
+      // Inspired by https://dev.to/nicolus/closing-a-modal-with-the-back-button-in-ionic-5-angular-9-50pk
       if (fullscreen) {
         const modalState: IPopupHistoryState = {
           modal: true,
@@ -337,6 +338,7 @@ export class TemplateNavService extends SyncServiceBase {
       }, 100);
     }
     // HACK: Else assume one other open popup and update query params to reflect this
+    // TODO: handle case of arbitrary levels of popups
     else {
       const [openPopup] = Object.values(this.openPopupsByName);
       this.setPopupQueryParams(openPopup.props);

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -220,6 +220,8 @@ export class TemplateNavService extends SyncServiceBase {
       return this.createPopupAndWaitForDismiss(templatename, null, fullscreen);
     }
 
+    // Set query params related to popup, which will be handled in separate method so that
+    // opening can also be handled following navigation or on refresh
     this.setPopupQueryParams({
       templatename,
       parent: container,
@@ -228,10 +230,7 @@ export class TemplateNavService extends SyncServiceBase {
     });
   }
 
-  /**
-   * Set query params related to popup, which will be handled in separate method so that
-   * opening can also be handled following navigation or on refresh
-   * */
+  /** Set query params related to popup */
   private async setPopupQueryParams(popupProps: Partial<ITemplatePopupComponentProps>) {
     const { templatename, parent, fullscreen, popupParentTriggeredBy } = popupProps;
     const queryParams: INavQueryParams = {
@@ -313,6 +312,7 @@ export class TemplateNavService extends SyncServiceBase {
       await childTemplateModal.present();
       const { data } = await childTemplateModal.onDidDismiss();
       log("dismissed", data);
+      return data;
     }
   }
 
@@ -338,7 +338,7 @@ export class TemplateNavService extends SyncServiceBase {
       }, 100);
     }
     // HACK: Else assume one other open popup and update query params to reflect this
-    // TODO: handle case of arbitrary levels of popups
+    // TODO: handle case of an arbitrary number of nested popups
     else {
       const [openPopup] = Object.values(this.openPopupsByName);
       this.setPopupQueryParams(openPopup.props);

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -1,8 +1,8 @@
 import { Location } from "@angular/common";
 import { Injectable } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, NavigationSkipped, NavigationStart, Router } from "@angular/router";
 import { ModalController } from "@ionic/angular";
-import { first } from "rxjs/operators";
+import { filter, first, take } from "rxjs/operators";
 import { FlowTypes } from "src/app/shared/model";
 import { SyncServiceBase } from "src/app/shared/services/syncService.base";
 import { arrayToHashmapArray, parseBoolean } from "src/app/shared/utils";
@@ -16,6 +16,14 @@ import { TemplateContainerComponent } from "../template-container.component";
 // Toggle logs used across full service for debugging purposes (there's quite a few and tedious to comment)
 const SHOW_DEBUG_LOGS = false;
 const log = SHOW_DEBUG_LOGS ? console.log : () => null;
+
+// Used to clear any existing popup query params
+export const POPUP_DISMISS_PARAMS: INavQueryParams = {
+  popup_child: null,
+  popup_parent: null,
+  popup_parent_triggered_by: null,
+  popup_fullscreen: null,
+};
 
 @Injectable({
   providedIn: "root",
@@ -39,7 +47,7 @@ export class TemplateNavService extends SyncServiceBase {
    * We also want to retain modal open state following circular navigate (a->b->c->a), so by default we leave modals opened
    * unless specifically closed (e.g. nav triggered from modal)
    */
-  private openPopupsByName: {
+  public openPopupsByName: {
     [templatename: string]: { modal: HTMLIonModalElement; props: ITemplateContainerProps };
   } = {};
 
@@ -92,15 +100,10 @@ export class TemplateNavService extends SyncServiceBase {
     if (key === "dismiss_pop_up" && parseBoolean(value)) {
       const { popup_child } = this.route.snapshot.queryParams;
       if (popup_child) {
-        const popupDismissParams: INavQueryParams = {
-          popup_child: null,
-          popup_parent: null,
-          popup_parent_triggered_by: null,
-        };
         // alter route history so that on back-nav popup will not be present
         await this.router.navigate([], {
           relativeTo: this.route,
-          queryParams: popupDismissParams,
+          queryParams: POPUP_DISMISS_PARAMS,
           queryParamsHandling: "merge",
           replaceUrl: true,
         });
@@ -210,11 +213,12 @@ export class TemplateNavService extends SyncServiceBase {
     container?: TemplateContainerComponent
   ) {
     const templatename = action.args[0];
+    const fullscreen = parseBoolean(action.params?.fullscreen_alt);
     // if triggered outside templating system (e.g. via notification action) still enable
     // popup creation and dismiss on nav changes
     if (!container) {
       this.router.events.pipe(first()).subscribe(() => this.dismissPopup(templatename));
-      return this.createPopupAndWaitForDismiss(templatename, null);
+      return this.createPopupAndWaitForDismiss(templatename, null, fullscreen);
     }
 
     const { name } = container;
@@ -224,6 +228,7 @@ export class TemplateNavService extends SyncServiceBase {
       popup_child: templatename,
       popup_parent: name,
       popup_parent_triggered_by: action._triggeredBy?.name || null,
+      popup_fullscreen: fullscreen,
     };
     this.router.navigate([], { queryParams, replaceUrl: true, queryParamsHandling: "merge" });
   }
@@ -232,7 +237,8 @@ export class TemplateNavService extends SyncServiceBase {
     params: INavQueryParams,
     container: TemplateContainerComponent
   ) {
-    const { popup_child, nav_child_emit, popup_parent_triggered_by } = params;
+    const { popup_child, nav_child_emit, popup_parent_triggered_by, popup_fullscreen } = params;
+    const fullscreen = parseBoolean(popup_fullscreen);
     const { template } = container;
     const existingPopup = this.openPopupsByName[popup_child];
     log("[Popup] - parent", { params, parent: container.name });
@@ -272,16 +278,18 @@ export class TemplateNavService extends SyncServiceBase {
     }
     // If no popup already exists, create, present, and react to dismiss
     else {
-      await this.createPopupAndWaitForDismiss(popup_child, container);
+      await this.createPopupAndWaitForDismiss(popup_child, container, fullscreen);
     }
   }
 
   private async createPopupAndWaitForDismiss(
     popup_child: string,
-    container: TemplateContainerComponent
+    container: TemplateContainerComponent,
+    fullscreen?: boolean
   ) {
-    const childTemplateModal = await this.createChildPopupModal(popup_child, container);
+    const childTemplateModal = await this.createChildPopupModal(popup_child, container, fullscreen);
     if (childTemplateModal) {
+      console.log("presenting");
       await childTemplateModal.present();
       const { data } = await childTemplateModal.onDidDismiss();
       // remove reference to popup (will be auto removed if dismissed programatically, but not by background dismiss)
@@ -290,15 +298,15 @@ export class TemplateNavService extends SyncServiceBase {
       }
       log("dismissed", data);
       // clear any existing popup query params on dismiss
-      const queryParams: INavQueryParams = {
-        popup_child: null,
-        popup_parent: null,
-        popup_parent_triggered_by: null,
-      };
-      this.router.navigate([], { queryParams, replaceUrl: true, queryParamsHandling: "merge" });
+      this.router.navigate([], {
+        queryParams: POPUP_DISMISS_PARAMS,
+        replaceUrl: true,
+        queryParamsHandling: "merge",
+      });
     }
   }
-  private async dismissPopup(name: string, data: any = undefined) {
+
+  public async dismissPopup(name: string, data: any = undefined) {
     const existingPopup = this.openPopupsByName[name];
     if (existingPopup) {
       await existingPopup.modal.dismiss(data);
@@ -312,16 +320,21 @@ export class TemplateNavService extends SyncServiceBase {
     container: TemplateContainerComponent
   ) {
     // Hide any open popup that was trigggered on a previous page prior to navigation (unless new popup)
-    const { popup_child } = params;
+    const { popup_child, popup_fullscreen } = params;
+    const fullscreen = parseBoolean(popup_fullscreen);
     const existingPopup = this.openPopupsByName[popup_child];
     if (existingPopup) {
       existingPopup.modal.classList.add("hide-popup-on-template");
     } else {
-      this.createPopupAndWaitForDismiss(params.popup_child, container);
+      this.createPopupAndWaitForDismiss(params.popup_child, container, fullscreen);
     }
   }
 
-  private async createChildPopupModal(popup_child: string, container: TemplateContainerComponent) {
+  private async createChildPopupModal(
+    popup_child: string,
+    container: TemplateContainerComponent,
+    fullscreen?: boolean
+  ) {
     const childContainerProps: ITemplatePopupComponentProps = {
       // make the popup share the same name as the container so that nav events return to parent container page
       name: popup_child,
@@ -329,6 +342,7 @@ export class TemplateNavService extends SyncServiceBase {
       parent: container,
       showCloseButton: true,
       dismissOnEmit: true,
+      fullscreen,
     };
     // If trying to recreate a popup that already exists simply mark as visible
     const existingPopup = this.openPopupsByName[popup_child];
@@ -361,4 +375,5 @@ export interface INavQueryParams {
   popup_child?: string; //
   popup_parent?: string;
   popup_parent_triggered_by?: string; //
+  popup_fullscreen?: boolean;
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes various issues with fullscreen popups triggered from the template action:
- Fixes an issue where a child pop-up on a full screen pop-up closes only on the second attempt (#2195)
- Allows navigating back to close a fullscreen pop-up (previously this would navigate to the page in history preceding the template that launched the pop-up. This makes sense to me as a default but can be discussed, perhaps this should be exposed as a parameter that authors can set.
- Fixes an issue where navigating back whilst a non-fullscreen popup is open would not dismiss the popup (the navigation would occur, but the popup would still display over the new screen)
- The URL query params should now match the popup state. Previously, a fullscreen popup would not add associated query params to the URL. This should allow better direct linking to fullscreen popups.

Currently, this new implementation of fullscreen pop-ups can be triggered using the parameter `fullscreen_alt` passed to the `pop_up` action, e.g. `click | pop_up: a_template_name | fullscreen_alt: true`. This is in order to preserve existing functionality for deployments that already use the `fullscreen` property. I would welcome suggestions of how we might go about making the migration to using the new logic, or else supporting both options with a nicer syntax.

There are still some edge cases that cause navigation to behave unexpectedly, see videos below. It's a shame that this implementation hasn't fully fixed all pop-up functionality, but I think we should discuss how much of a priority this is and whether the improvements made by this PR make it worth merging, or whether we want to abandon this attempt to patch up our current system and invest time into more of an overhaul.

## Testing

As well as the functionality of the [debug_fullscreen_pop_up_1](https://docs.google.com/spreadsheets/d/1YW7zE4CPt_osn3NzwXwvFCBPjseo1LE5kpYBo190U0s/edit#gid=868243677) series of templates (see video below for an example), we should test various combinations of existing pop-up functionality to ensure all of our use cases are still handled correctly.

## Dev notes

We currently have two distinct methods triggered by the `pop_up` action:
- If not fullscreen, the `pop_up` action calls `templateNavService.handlePopupAction()`
- If fullscreen, the `pop_up` action calls `templateService.runStandaloneTemplate()`
The `runStandaloneTemplate()` method is used elsewhere in the code, so we don't want to replace it, but it makes sense to me for the `pop_up` template action to use the `handlePopUp()` method with a fullscreen param. This PR therefore tries to incorporate some of the functionality of the former method into the latter, whilst fixing some of the issues with the former.

Working on the template nav service was a headache. There is lots of complicated logic and handling of various specific cases, so it's difficult to make changes without risking breaking something. I've tried to confine all of the changes to only apply when the new `fullscreen` option is passed to minimise unintended knock-ons. The exception is when it comes to dismissing popups: now the popup component itself handles dismissing on back and, if relevant, calls the `templateNavService.dismissPopup()` to handle its dismissal, which in turn now handles updating the query params. 

### Alternative approach

I am wary of overhauling the whole popup system, as it seems to handle a lot of edge cases that are difficult to understand. However, if we were to start from scratch, it may be sensible to consider the following.

We have three different ways of tracking popups
1.  Query params
2. The `TemplateNavService.openPopupsByName` object
3. Browser history state
  - the history must occasionally be manipulated to preserve expected nav behaviour
It would seem sensible to keep these three in sync. Perhaps we could use signals to observe `TemplateNavService.openPopupsByName` and update the query params accordingly to keep the two in sync. To properly handle launching popups within popups (one of the major motivations for this PR), we would likely need the query params to store values for parent pop ups as well as children, essentially maintaining a history of popups to handle cases of navigation and refresh, so this could get complicated fast.
Possibly, we would want to use a queue system for closing popups to properly handle the case of closing multiple popups at once (e.g. when navigating back from a fullscreen parent with a non-fullscreen child).

## Git Issues

Closes #2319 (previous, buggy implementation)
Closes #2195 

## Screenshots/Videos

### [debug_fullscreen_pop_up_1](https://docs.google.com/spreadsheets/d/1YW7zE4CPt_osn3NzwXwvFCBPjseo1LE5kpYBo190U0s/edit#gid=868243677)
<img width="600" alt="Screenshot 2024-05-31 at 16 11 08" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/ea00edd1-43ba-4d44-8040-53efd32ad653">

#### Fullscreen pop-up and child working as expected

https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/1121c122-76e7-4a11-a97f-c0093170d363

#### Nav issue
There is an issue where closing a popup that is the child of a fullscreen popup causes the browser history to be in a state such that navigating back from the top-level parent that launched the fullscreen pop-up goes back to the open fullscreen pop-up, rather than the previous page

https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/57a83e0b-cab2-45e2-a13d-3c0e86e4b15f



