### PR TITLE
fix: data pipe merge operator handles case of no input source

### DIFF
--- a/packages/shared/src/models/dataPipe/operators/filter.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/filter.spec.ts
@@ -23,10 +23,10 @@ describe("Filter", () => {
     expect(outputIDs).toEqual(["id_1", "id_3", "id_4"]);
   });
   it("Filters with 'this' context", () => {
-    const nestedData = testData.names.map((entry) => {
-      entry["nested"] = { first_name: entry.first_name };
-      return entry;
-    });
+    const nestedData = testData.names.map((entry) => ({
+      ...entry,
+      nested: { first_name: entry.first_name },
+    }));
     const testDf = new DataFrame(nestedData);
     const output = new filter(testDf, ["this.nested.first_name === 'Ada'"]).apply();
     const outputIDs = output.column("first_name").values;

--- a/packages/shared/src/models/dataPipe/operators/merge.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.spec.ts
@@ -58,17 +58,4 @@ describe("Merge Operator", () => {
     const expectedNested = ['{"value":"test"}', "undefined", "undefined", "undefined"];
     expect(output.column("nested").values).toEqual(expectedNested as any);
   });
-  it("Merges multiple lists from args_list, with no input_source", () => {
-    const emptyDf = new DataFrame([]);
-    // merges data - additional nationality column appended for all entries and populated for available
-    const output = new merge(emptyDf, ["names", "nationality_data"], testPipe).apply();
-
-    expect(output.index).toEqual(["id_1", "id_2", "id_3", "id_4"]);
-    // merges new nationality column
-    const expectedNationalities = ["British", "French", undefined, undefined];
-    expect(output.column("nationality").values).toEqual(expectedNationalities);
-    // merges existing name overrides
-    const expectedNames = ["override", "Blaise", "Charles", "Daniel"];
-    expect(output.column("first_name").values).toEqual(expectedNames);
-  });
 });

--- a/packages/shared/src/models/dataPipe/operators/merge.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.spec.ts
@@ -40,10 +40,29 @@ describe("Merge Operator", () => {
     const expectedNames = ["override", "Blaise", "Charles", "Daniel"];
     expect(output.column("first_name").values).toEqual(expectedNames);
   });
+  // TODO: currently fails
+  it("Merges multiple lists including list with nested data", () => {
+    const nestedData = testData.names.map((entry) => {
+      entry["nested"] = { first_name: entry.first_name };
+      return entry;
+    });
+    const testDfWithNestedData = new DataFrame(nestedData);
+
+    // merges data - additional nationality column appended for all entries and populated for available
+    const output = new merge(testDfWithNestedData, ["merge_nationality"], testPipe).apply();
+    expect(output.index).toEqual(["id_1", "id_2", "id_3", "id_4"]);
+    // merges new nationality column
+    const expectedNationalities = ["British", "French", undefined, undefined];
+    expect(output.column("nationality").values).toEqual(expectedNationalities);
+    // merges existing name overrides
+    const expectedNames = ["override", "Blaise", "Charles", "Daniel"];
+    expect(output.column("first_name").values).toEqual(expectedNames);
+  });
   it("Merges multiple lists from args_list, with no input_source", () => {
     const emptyDf = new DataFrame([]);
     // merges data - additional nationality column appended for all entries and populated for available
     const output = new merge(emptyDf, ["names", "merge_nationality"], testPipe).apply();
+
     expect(output.index).toEqual(["id_1", "id_2", "id_3", "id_4"]);
     // merges new nationality column
     const expectedNationalities = ["British", "French", undefined, undefined];

--- a/packages/shared/src/models/dataPipe/operators/merge.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.spec.ts
@@ -1,4 +1,5 @@
 import { DataFrame } from "danfojs";
+import testData from "../testData.spec";
 import { DataPipe } from "../pipe";
 import merge from "./merge";
 
@@ -28,16 +29,8 @@ const nested_data = [
 ];
 
 describe("Merge Operator", () => {
-  let testDf: DataFrame;
-  let testPipe: DataPipe;
-
-  beforeEach(async () => {
-    // HACK - some other test suites appear to
-    const { default: importedData } = await import("../testData.spec");
-    testDf = new DataFrame(importedData.names);
-    // ensure testPipe has access to all required data lists
-    testPipe = new DataPipe([], { ...importedData, nationality_data, nested_data });
-  });
+  const testDf = new DataFrame(testData.names);
+  const testPipe = new DataPipe([], { ...testData, nationality_data, nested_data });
 
   it("Throws on missing list", () => {
     // throws on missing list

--- a/packages/shared/src/models/dataPipe/operators/merge.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.spec.ts
@@ -40,4 +40,16 @@ describe("Merge Operator", () => {
     const expectedNames = ["override", "Blaise", "Charles", "Daniel"];
     expect(output.column("first_name").values).toEqual(expectedNames);
   });
+  it("Merges multiple lists from args_list, with no input_source", () => {
+    const emptyDf = new DataFrame([]);
+    // merges data - additional nationality column appended for all entries and populated for available
+    const output = new merge(emptyDf, ["names", "merge_nationality"], testPipe).apply();
+    expect(output.index).toEqual(["id_1", "id_2", "id_3", "id_4"]);
+    // merges new nationality column
+    const expectedNationalities = ["British", "French", undefined, undefined];
+    expect(output.column("nationality").values).toEqual(expectedNationalities);
+    // merges existing name overrides
+    const expectedNames = ["override", "Blaise", "Charles", "Daniel"];
+    expect(output.column("first_name").values).toEqual(expectedNames);
+  });
 });

--- a/packages/shared/src/models/dataPipe/operators/merge.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.ts
@@ -51,20 +51,20 @@ class MergeOperator extends BaseOperator {
 
   /** Replace any values updated from the data in the original dataframe **/
   private replaceUpdatedValues(data: any[]) {
-    const replacments = new DataFrame(data);
-    setIndexColumn(replacments, this.indexColumn);
+    const replacements = new DataFrame(data);
+    setIndexColumn(replacements, this.indexColumn);
 
     // remove any columns that does not exist in left
-    const droppedColumns = replacments.columns.filter(
+    const droppedColumns = replacements.columns.filter(
       (column) => column !== this.indexColumn && !this.df.columns.includes(column)
     );
-    replacments.drop({ columns: droppedColumns, inplace: true });
+    replacements.drop({ columns: droppedColumns, inplace: true });
     // remove any rows that does not exist in left
-    const droppedIndexes = replacments.index.filter((i) => !this.df.index.includes(i));
-    replacments.drop({ index: droppedIndexes, inplace: true });
+    const droppedIndexes = replacements.index.filter((i) => !this.df.index.includes(i));
+    replacements.drop({ index: droppedIndexes, inplace: true });
 
-    // replace all values in left with values from replacments where defined
-    const replaceHashmap = arrayToHashmap(toJSON(replacments) as any, this.indexColumn);
+    // replace all values in left with values from replacements where defined
+    const replaceHashmap = arrayToHashmap(toJSON(replacements) as any, this.indexColumn);
 
     // handle replacement by looping over all rows and replacing values where override defined
     const replaceDf = this.df.apply((row: any[]) => {

--- a/packages/shared/src/models/dataPipe/operators/merge.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.ts
@@ -12,8 +12,6 @@ class MergeOperator extends BaseOperator {
   private indexColumn = "id";
   constructor(df: DataFrame, args_list: string[], pipe: DataPipe) {
     super(df, args_list, pipe);
-    // If a base dataframe is not explicitly provided, e.g. input_source is empty, use first data list from args_list as base dataframe
-    if (this.df.shape[0] === 0) this.df = new DataFrame(this.args_list.shift());
   }
   // load input data list from arg, populate error object if not exist for use in validation step
   parseArg(arg: string): ILoadedDatalist {
@@ -24,6 +22,8 @@ class MergeOperator extends BaseOperator {
   }
 
   apply() {
+    if (this.df.shape[0] === 0)
+      console.error("Merge: No data in base dataframe - an input_source must be provided");
     setIndexColumn(this.df, this.indexColumn);
     for (const dataList of this.args_list) {
       this.df = this.replaceUpdatedValues(dataList);

--- a/packages/shared/src/models/dataPipe/operators/merge.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.ts
@@ -12,6 +12,8 @@ class MergeOperator extends BaseOperator {
   private indexColumn = "id";
   constructor(df: DataFrame, args_list: string[], pipe: DataPipe) {
     super(df, args_list, pipe);
+    // If dataframe from input_source is empty, use first datalist from args_list as base dataframe
+    if (this.df.shape[0] === 0) this.df = new DataFrame(this.args_list.shift());
   }
   // load input data list from arg, populate error object if not exist for use in validation step
   parseArg(arg: string): ILoadedDatalist {

--- a/packages/shared/src/models/dataPipe/operators/merge.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.ts
@@ -12,7 +12,7 @@ class MergeOperator extends BaseOperator {
   private indexColumn = "id";
   constructor(df: DataFrame, args_list: string[], pipe: DataPipe) {
     super(df, args_list, pipe);
-    // If dataframe from input_source is empty, use first datalist from args_list as base dataframe
+    // If a base dataframe is not explicitly provided, e.g. input_source is empty, use first data list from args_list as base dataframe
     if (this.df.shape[0] === 0) this.df = new DataFrame(this.args_list.shift());
   }
   // load input data list from arg, populate error object if not exist for use in validation step


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

The data pipe `merge` fails and throws an unhandled error in the case that no `input_source` is provided. This PR handles that case by throwing a custom error in that case. 

Also tidies some of the pre-existing data pipe operator tests (thanks, @chrismclarke).

#2341 also suggests the existence of another possible issue to do with applying the merge operator to data lists that contain nested JSON data. I think it is sensible to handle this case as a follow-up if it does persist after applying the changes of this PR. In that case, a new debug sheet that exhibits the broken behaviour would be required.

## Testing

See [example_data_pipe_merge](https://docs.google.com/spreadsheets/d/1imxKEBQ31qpdu7NeXuH3UyK88G_G1jitLdw9CRZ9ZIY/edit#gid=751466229). Run a sync and ensure no errors are thrown, then inspect the outputs of the data pipe to confirm they are as expected.

## Git Issues

Closes #2341 

## Screenshots/Videos

Attempting to run the data pipe as defined by [example_data_pipe_merge](https://docs.google.com/spreadsheets/d/1imxKEBQ31qpdu7NeXuH3UyK88G_G1jitLdw9CRZ9ZIY/edit#gid=751466229) in the following state:
<img width="800" alt="Screenshot 2024-06-21 at 10 33 15" src="https://github.com/IDEMSInternational/open-app-builder/assets/64838927/f6c1688b-49d8-4408-aafd-6bb48effe2da">
now logs the following error:
<img width="440" alt="Screenshot 2024-06-25 at 12 51 02" src="https://github.com/IDEMSInternational/open-app-builder/assets/64838927/8020541c-7dcf-471b-808a-a87462832d43">


### Passing tests
<img width="440" alt="Screenshot 2024-06-25 at 12 51 55" src="https://github.com/IDEMSInternational/open-app-builder/assets/64838927/ebdd1978-28c2-44fc-b209-bf6d314634b5">

