### PR TITLE
Fix/data pipe merge nested

### DIFF
--- a/packages/shared/src/models/dataPipe/operators/merge.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.spec.ts
@@ -58,17 +58,4 @@ describe("Merge Operator", () => {
     const expectedNested = ['{"value":"test"}', "undefined", "undefined", "undefined"];
     expect(output.column("nested").values).toEqual(expectedNested as any);
   });
-  it("Merges multiple lists from args_list, with no input_source", () => {
-    const emptyDf = new DataFrame([]);
-    // merges data - additional nationality column appended for all entries and populated for available
-    const output = new merge(emptyDf, ["names", "nationality_data"], testPipe).apply();
-
-    expect(output.index).toEqual(["id_1", "id_2", "id_3", "id_4"]);
-    // merges new nationality column
-    const expectedNationalities = ["British", "French", undefined, undefined];
-    expect(output.column("nationality").values).toEqual(expectedNationalities);
-    // merges existing name overrides
-    const expectedNames = ["override", "Blaise", "Charles", "Daniel"];
-    expect(output.column("first_name").values).toEqual(expectedNames);
-  });
 });

--- a/packages/shared/src/models/dataPipe/operators/merge.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.spec.ts
@@ -72,4 +72,13 @@ describe("Merge Operator", () => {
     expect(output.values.length).toEqual(1);
     expect(output.values[0] as any).toEqual(["id_1", "Hello", { eng: "Hello" }, 2, 2]);
   });
+
+  // QC
+  it("Throws error if no no input_source provided", () => {
+    const emptyDf = new DataFrame([]);
+    // merges data - additional nationality column appended for all entries and populated for available
+    expect(() => new merge(emptyDf, ["names", "nationality_data"], testPipe).apply()).toThrowError(
+      "Merge: No data in base dataframe - an input_source must be provided"
+    );
+  });
 });

--- a/packages/shared/src/models/dataPipe/operators/merge.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.spec.ts
@@ -49,7 +49,8 @@ describe("Merge Operator", () => {
     const expectedNames = ["override", "Blaise", "Charles", "Daniel"];
     expect(output.column("first_name").values).toEqual(expectedNames);
   });
-  it("Merges multiple lists including list with nested data", () => {
+
+  it("Supports nested json in merge list", () => {
     // merges data - additional nationality column appended for all entries and populated for available
     const output = new merge(testDf, ["nested_data"], testPipe).apply();
     expect(output.index).toEqual(["id_1", "id_2", "id_3", "id_4"]);
@@ -57,5 +58,18 @@ describe("Merge Operator", () => {
     // TODO - danfo stringifies nested data, should it be handled differently?
     const expectedNested = ['{"value":"test"}', "undefined", "undefined", "undefined"];
     expect(output.column("nested").values).toEqual(expectedNested as any);
+  });
+
+  it("Supports translations in base list (nested json)", () => {
+    // test for issue raised in #2343
+    const sourceDf = new DataFrame([
+      { id: "id_1", text: "Hello", _translations: { eng: "Hello" } },
+    ]);
+    const sourcePipe = new DataPipe([], {
+      nested_data: [{ id: "id_1", column_b: 2, column_c: 2 }],
+    });
+    const output = new merge(sourceDf, ["nested_data"], sourcePipe).apply();
+    expect(output.values.length).toEqual(1);
+    expect(output.values[0] as any).toEqual(["id_1", "Hello", { eng: "Hello" }, 2, 2]);
   });
 });

--- a/packages/shared/src/models/dataPipe/operators/merge.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.ts
@@ -68,8 +68,15 @@ class MergeOperator extends BaseOperator {
 
     // handle replacement by looping over all rows and replacing values where override defined
     const replaceDf = this.df.apply((row: any[]) => {
-      const id = row[0];
-      return row.map((value, columnIndex) => {
+      const [id] = row;
+
+      // HACK - apply operator fails to include array entry for any columns where
+      // data formatted as nested json, returning data with invalid dimensions (assumed bug).
+      // Manually lookup the original row and iterate on that instead of included row
+      const index = this.df.index.indexOf(id);
+      const rowComplete = this.df.values[index] as any[];
+
+      return rowComplete.map((value, columnIndex) => {
         const columnName = this.df.columns[columnIndex];
         const replaceValue = replaceHashmap[id]?.[columnName];
         if (replaceValue !== undefined && replaceValue !== value) {

--- a/packages/shared/src/models/dataPipe/operators/merge.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.ts
@@ -1,5 +1,5 @@
 import { DataFrame, merge, toJSON } from "danfojs";
-import { arrayToHashmap } from "../../../utils";
+import { arrayToHashmap, Logger } from "../../../utils";
 import { DataPipe } from "../pipe";
 import { replaceNaN, setIndexColumn } from "../utils";
 import BaseOperator from "./base";
@@ -22,8 +22,9 @@ class MergeOperator extends BaseOperator {
   }
 
   apply() {
-    if (this.df.shape[0] === 0)
-      console.error("Merge: No data in base dataframe - an input_source must be provided");
+    if (this.df.shape[0] === 0) {
+      throw new Error("Merge: No data in base dataframe - an input_source must be provided");
+    }
     setIndexColumn(this.df, this.indexColumn);
     for (const dataList of this.args_list) {
       this.df = this.replaceUpdatedValues(dataList);

--- a/packages/shared/src/models/dataPipe/operators/merge.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.ts
@@ -12,8 +12,6 @@ class MergeOperator extends BaseOperator {
   private indexColumn = "id";
   constructor(df: DataFrame, args_list: string[], pipe: DataPipe) {
     super(df, args_list, pipe);
-    // If a base dataframe is not explicitly provided, e.g. input_source is empty, use first data list from args_list as base dataframe
-    if (this.df.shape[0] === 0) this.df = new DataFrame(this.args_list.shift());
   }
   // load input data list from arg, populate error object if not exist for use in validation step
   parseArg(arg: string): ILoadedDatalist {
@@ -24,6 +22,8 @@ class MergeOperator extends BaseOperator {
   }
 
   apply() {
+    if (this.df.shape[0] === 0)
+      console.error("Merge: No data in base dataframe - an input_source must be provided");
     setIndexColumn(this.df, this.indexColumn);
     for (const dataList of this.args_list) {
       this.df = this.replaceUpdatedValues(dataList);

--- a/packages/shared/src/models/dataPipe/operators/merge.ts
+++ b/packages/shared/src/models/dataPipe/operators/merge.ts
@@ -1,5 +1,5 @@
 import { DataFrame, merge, toJSON } from "danfojs";
-import { arrayToHashmap, Logger } from "../../../utils";
+import { arrayToHashmap } from "../../../utils";
 import { DataPipe } from "../pipe";
 import { replaceNaN, setIndexColumn } from "../utils";
 import BaseOperator from "./base";


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
Builds on top of #2342 to address specific bug where `_translations` data could not be included in in the base data_list of a merge operator.

## Review Notes
Only changes beyond #2342 are to address the bug identified in #2343. So if functional testing passed should be able to assume good to go (I've already reviewed the code written in #2342 and seen changes since)

## Dev Notes
The core issue appeared to be a bug within the `danfo.js` dataframe `apply` method - this should pass an array of all row values to manipulate, however it omitted any values that were formatted as nested json, and hence when using a _translations column the overall return array would be 1 element shorter than expected (dimension error).

I've updated the test spec to cover, runnable via `yarn workspace shared test`
See screenshots below for before/after (should capture same issue seen).

I've also changed the console error on empty data frame to throw, and included in the tests so that it is more explicit to any author (thrown errors are identified in final output logs whereas console errors can be more easily missed)

## Git Issues
Closes #2343

## Screenshots/Videos

Tests - Before
![image](https://github.com/IDEMSInternational/open-app-builder/assets/10515065/471ccffc-ec11-49d6-a42c-2de3147ccd30)

Tests - After
![image](https://github.com/IDEMSInternational/open-app-builder/assets/10515065/ce1ab7af-77e3-4ad0-a998-53692386b0ac)
