### PR TITLE
Fix: docs deploy action

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - master
-      - fix/docs-deploy-action
+  workflow_dispatch:
+    
 jobs:
   build:
     name: Deploy docs

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - fix/docs-deploy-action
 jobs:
   build:
     name: Deploy docs
@@ -18,7 +19,8 @@ jobs:
         # Github pages fails when expecting LFS, so remove hook
         run: rm .git/hooks/pre-push
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        # TODO - check if working on latest or pin to version (rather than commit)
+        uses: mhausenblas/mkdocs-deploy-gh-pages@e55ecab6718b449a90ebd4313f1320f9327f1386
         # Or use mhausenblas/mkdocs-deploy-gh-pages@nomaterial to build without the mkdocs-material theme
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
The documentation site currently redeploys any time there is a push to master branch, and uses the latest commit from the mkdocs-deploy github action.

It appears that recent commits to the action have broken deploy [Example failed action](https://github.com/IDEMSInternational/open-app-builder/actions/runs/9667038054), so this PR simply pins the version of the mkdocs-deploy action to a previous working commit.

## Review Notes
I've manually triggered the docs deploy from this branch and confirm passing: 
[example passed action](https://github.com/IDEMSInternational/open-app-builder/actions/runs/9667166110)

## Dev Notes
This is a short term workaround, it might be worth pinning to a more defined/stable version in the future (although [release cycle](https://github.com/mhausenblas/mkdocs-deploy-gh-pages/releases) for the action is very intermittent), and likely only running the action if meaningful changes have been made to documentation files (will need to identify also considering component templates and such)

## Git Issues

Closes #

## Screenshots/Videos
Example of previously failed and now passing docs deploy actions
![image](https://github.com/IDEMSInternational/open-app-builder/assets/10515065/c73fb647-8d97-4f03-b6c6-8b5922d94864)
