### PR TITLE
feat: markdown interprets ASCII punctuation characters into typographic HTML punctuation characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "katex": "^0.16.10",
     "lottie-web": "^5.12.2",
     "marked": "^2.1.3",
+    "marked-smartypants-lite": "^1.0.2",
     "mergexml": "^1.2.3",
     "ng2-nouislider": "^2.0.0",
     "ngx-extended-pdf-viewer": "18.1.9",

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -6,6 +6,7 @@ import * as Sentry from "@sentry/angular-ivy";
 import { FlowTypes } from "../model";
 import { objectToArray } from "../components/template/utils";
 import marked from "marked";
+import { markedSmartypantsLite } from "marked-smartypants-lite";
 
 /**
  * Generate a random string of characters in base-36 (a-z and 0-9 characters)
@@ -495,6 +496,7 @@ export function parseMarkdown(src: string, options?: marked.MarkedOptions) {
     const link = marked.Renderer.prototype.link.apply(this, arguments);
     return link.replace("<a", "<a target='_blank' rel='noopener noreferrer'");
   };
+  marked.use(markedSmartypantsLite());
   marked.setOptions({
     renderer,
   });

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -496,10 +496,24 @@ export function parseMarkdown(src: string, options?: marked.MarkedOptions) {
     const link = marked.Renderer.prototype.link.apply(this, arguments);
     return link.replace("<a", "<a target='_blank' rel='noopener noreferrer'");
   };
-  marked.use(markedSmartypantsLite());
   marked.setOptions({
     renderer,
   });
+
+  /**
+   * Interpret quotes and dashes into typographic HTML entities
+   * e.g.
+   * `She said, -- "A 'simple' sentence..." --- unknown`
+   * becomes
+   * `She said, – “A ‘simple’ sentence…” — unknown`
+   *
+   * See
+   * https://github.com/calculuschild/marked-smartypants-lite
+   * and
+   * https://marked.js.org/using_advanced#extensions
+   */
+  marked.use(markedSmartypantsLite());
+
   return marked(src, options);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14874,6 +14874,7 @@ __metadata:
     lint-staged: ^15.2.2
     lottie-web: ^5.12.2
     marked: ^2.1.3
+    marked-smartypants-lite: ^1.0.2
     mergexml: ^1.2.3
     ng2-nouislider: ^2.0.0
     ngx-extended-pdf-viewer: 18.1.9
@@ -19253,6 +19254,15 @@ __metadata:
   bin:
     markdown-it: bin/markdown-it.js
   checksum: 890555711c1c00fa03b936ca2b213001a3b9b37dea140d8445ae4130ce16628392aad24b12e2a0a9935336ca5951f2957a38f4e5309a2e38eab44e25ff32a41e
+  languageName: node
+  linkType: hard
+
+"marked-smartypants-lite@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "marked-smartypants-lite@npm:1.0.2"
+  peerDependencies:
+    marked: ">=4 <12"
+  checksum: 0ae237f603e43e628d56c11d4b2910a586757bcf6818ad9503203cc819f99f5ee5deecaeec749533bdf980f3b75441a039d7bbed932b649936c5b07916edf13c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Configures our markdown parser to interpret shorthand for punctuation, e.g. for quotes and dashes, and "smartly" render a typographic symbol equivalent. For example "--" will be rendered as "–", the en dash, and generic quotation marks will be replaced with their opening and closing counterparts.

## Git Issues

Closes #

## Screenshots/Videos

[comp_text](https://docs.google.com/spreadsheets/d/1iZHeAAZAQ8q-XNKrW_ww3yvPUVGwc407uhAF7vu1TtM/edit?gid=569531329#gid=569531329)

<img width="540" alt="Screenshot 2024-07-23 at 15 56 02" src="https://github.com/user-attachments/assets/84b2e09f-d377-455c-ad61-0b777e9157c3">

| Before | After |
|--------|-------|
| <img width="280" alt="Screenshot 2024-07-23 at 15 57 17" src="https://github.com/user-attachments/assets/77c0b66e-6cee-4bc1-a6fc-42b5d0676350"> | <img width="280" alt="Screenshot 2024-07-23 at 15 56 13" src="https://github.com/user-attachments/assets/b5a8320d-d170-45da-bd9d-53449e59df4a"> |

