### PR TITLE
review: task-journey-component

### DIFF
--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -34,6 +34,7 @@
     "templatename",
     "tmpl",
     "venv",
+    "viewbox",
   ]
 # flagWords - list of words to be always considered incorrect
 # This is useful for offensive words and common spelling errors.

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.html
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.html
@@ -6,14 +6,16 @@
       [style.margin-bottom]="contentHeight"
       [style.width]="width"
     >
-      <div class="progress-path-child-content">
-        <plh-template-component
-          [row]="childRow"
-          [parent]="parent"
-          [attr.data-rowname]="_row.name"
-          [style.--progress-path-flex-align]="$odd ? 'flex-end' : 'flex-start'"
-        >
-        </plh-template-component>
+      <div class="progress-path-child-content-wrapper" [style.--container-width]="width">
+        <div class="progress-path-child-content">
+          <plh-template-component
+            [row]="childRow"
+            [parent]="parent"
+            [attr.data-rowname]="_row.name"
+            [style.--progress-path-flex-align]="$odd ? 'flex-end' : 'flex-start'"
+          >
+          </plh-template-component>
+        </div>
       </div>
       <div class="path-segment">
         <svg [attr.viewBox]="svgViewBox" stroke="currentColor">

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.html
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.html
@@ -11,28 +11,8 @@
         </plh-template-component>
       </div>
       <div class="path-segment">
-        <svg
-          viewBox="0 0 574 478"
-          version="1.1"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
-          xml:space="preserve"
-          xmlns:serif="http://www.serif.com/"
-          style="
-            fill-rule: evenodd;
-            clip-rule: evenodd;
-            stroke-linejoin: round;
-            stroke-miterlimit: 1.5;
-          "
-        >
-          <g transform="matrix(1,0,0,1,-278.796,-1016.63)">
-            <g transform="matrix(-0.70439,0,0,0.70439,1238.73,580.835)">
-              <path
-                d="M798.413,1259.89C692.245,1259.89 604.118,1182.03 588.072,1080.34C586.355,1069.46 585.463,1058.3 585.463,1046.94L585.463,867.833C585.463,750.303 680.883,654.883 798.413,654.883L1326.58,654.883"
-                style="fill: none"
-              />
-            </g>
-          </g>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 624 351" stroke="currentColor">
+          <path fill="none" d="M447.54 325.5c82.79 0 150-67.21 150-150s-67.21-150-150-150H25.51" />
         </svg>
       </div>
     </div>

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.html
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.html
@@ -1,6 +1,11 @@
 <div class="progress-path-wrapper">
   @for (childRow of _row.rows | filterDisplayComponent; track trackByRow($index, childRow)) {
-    <div class="progress-path-child-wrapper" [class.odd-index]="$odd">
+    <div
+      class="progress-path-child-wrapper"
+      [class.odd-index]="$odd"
+      [style.margin-bottom]="contentHeight"
+      [style.width]="width"
+    >
       <div class="progress-path-child-content">
         <plh-template-component
           [row]="childRow"
@@ -11,8 +16,8 @@
         </plh-template-component>
       </div>
       <div class="path-segment">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 624 351" stroke="currentColor">
-          <path fill="none" d="M447.54 325.5c82.79 0 150-67.21 150-150s-67.21-150-150-150H25.51" />
+        <svg [attr.viewBox]="svgViewBox" stroke="currentColor">
+          <path fill="none" [attr.d]="svgPath" />
         </svg>
       </div>
     </div>

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.scss
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.scss
@@ -1,5 +1,6 @@
-$path-background: var(--progress-path-line-background, var(--ion-color-gray-100));
+$path-background: var(--progress-path-line-background, var(--ion-color-primary-200));
 $path-segment-width: 264px;
+$path-stroke-width: 51px;
 
 .progress-path-wrapper {
   position: relative;
@@ -29,7 +30,7 @@ $path-segment-width: 264px;
       inline-size: 100%;
       block-size: 100%;
       stroke: $path-background;
-      stroke-width: 51px;
+      stroke-width: $path-stroke-width;
     }
   }
 

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.scss
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.scss
@@ -1,5 +1,4 @@
-$path-background: var(--progress-path-line-background, var(--ion-color-primary-200));
-$path-weight: var(--progress-path-line-weight, 72px);
+$path-background: var(--progress-path-line-background, var(--ion-color-gray-100));
 $path-segment-width: 264px;
 
 .progress-path-wrapper {
@@ -15,7 +14,7 @@ $path-segment-width: 264px;
   $path-segment-spacing: 24px;
 
   position: relative;
-  margin-bottom: 96px;
+  margin-bottom: 27px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -30,7 +29,7 @@ $path-segment-width: 264px;
       inline-size: 100%;
       block-size: 100%;
       stroke: $path-background;
-      stroke-width: $path-weight;
+      stroke-width: 51px;
     }
   }
 

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.scss
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.scss
@@ -1,31 +1,28 @@
 $path-background: var(--progress-path-line-background, var(--ion-color-primary-200));
-$path-segment-width: 264px;
-$path-stroke-width: 51px;
+$path-stroke-width: 32px;
 
 .progress-path-wrapper {
   position: relative;
   display: flex;
   flex-direction: column;
-  min-width: $path-segment-width;
-  max-width: 380px;
   margin: auto;
+  align-items: center;
 }
 
 .progress-path-child-wrapper {
   $path-segment-spacing: 24px;
 
   position: relative;
-  margin-bottom: 27px;
   display: flex;
   flex-direction: column;
   align-items: center;
 
   .path-segment {
     position: absolute;
-    top: 40px;
-    margin-left: $path-segment-spacing;
+    top: 0;
+    left: 0;
+    width: 100%;
     z-index: -1;
-    width: $path-segment-width;
     svg {
       inline-size: 100%;
       block-size: 100%;

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.scss
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.scss
@@ -1,5 +1,5 @@
 $path-background: var(--progress-path-line-background, var(--ion-color-primary-200));
-$path-stroke-width: 32px;
+$path-stroke-width: 28px;
 
 .progress-path-wrapper {
   position: relative;
@@ -31,6 +31,13 @@ $path-stroke-width: 32px;
     }
   }
 
+  .progress-path-child-content-wrapper {
+    width: 100vw;
+    max-width: calc(var(--container-width) + 20px);
+    min-width: calc(var(--container-width) - 44px);
+    display: flex;
+    flex-direction: column;
+  }
   .progress-path-child-content {
     width: 150px;
     align-self: flex-start;

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.ts
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.ts
@@ -1,9 +1,73 @@
 import { Component } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 
+// HACK - hardcoded sizing values to make content fit reasonably well
+const SIZING = {
+  /** Total width for container */
+  widthPx: 384,
+  /** Target height for text content */
+  textContentHeight: 72,
+  /** Adjust start of line for task card */
+  xOffset: 64,
+  /** Adjust start of line for task card */
+  yOffset: 56,
+};
+
 @Component({
   selector: "plh-progress-path",
   templateUrl: "./progress-path.component.html",
   styleUrls: ["./progress-path.component.scss"],
 })
-export class TmplProgressPathComponent extends TemplateBaseComponent {}
+export class TmplProgressPathComponent extends TemplateBaseComponent {
+  public svgPath: string;
+  public svgViewBox: string;
+  public contentHeight: string;
+  public width = `${SIZING.widthPx}px`;
+
+  constructor() {
+    super();
+    this.generateSVGPath("wavy");
+  }
+
+  /**
+   * Generate a base SVG segment used to connect 2 progress items together
+   * Roughly a horizontal line and smooth bend, adjusted for sizing
+   */
+  private generateSVGPath(variant: "basic" | "wavy" = "basic") {
+    // arbitrary values used to make base width/height fit
+    const { widthPx, xOffset, yOffset, textContentHeight } = SIZING;
+
+    // adjust viewbox to include both title content and 100px card (+overlap)
+    const viewboxHeight = textContentHeight + 128;
+
+    // SVG Generation (https://www.aleksandrhovhannisyan.com/blog/svg-tutorial/)
+
+    // M - start point (allow space for stroke width and content offset)
+    // h - horizontal line, relative length
+    // c - bezier curve (64 unit rounded)
+    // v - vertical line, relative length
+
+    // Basic generation, smooth
+    // https://svg-path-visualizer.netlify.app/#M%20128%2C128%0Ah%20384%20%0Ac%2064%2C0%2064%2C64%2064%2C64%0Av%20352
+    const basic = () =>
+      `
+    M ${xOffset},${yOffset}
+    h ${widthPx - 2 * xOffset - 32}
+    c 32,0 32,32 32,32
+    v ${viewboxHeight - yOffset - 32}
+    `.trim();
+
+    // Alt generation that is a bit more wavy
+    // https://svg-path-visualizer.netlify.app/#M%20128%2C128%0Ah%20384%20%0Ac%2064%2C0%20128%2C64%2064%2C200%0A
+    const wavy = () =>
+      `
+    M ${xOffset},${yOffset}
+    h ${widthPx - 2 * xOffset - 48}
+    c 48,0 72,64 48,${viewboxHeight - yOffset - 16}
+    `.trim();
+
+    this.svgPath = variant === "basic" ? basic() : wavy();
+    this.svgViewBox = `0 0 ${widthPx} ${viewboxHeight}`;
+    this.contentHeight = `${textContentHeight}px`;
+  }
+}

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.ts
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.ts
@@ -7,9 +7,9 @@ const SIZING = {
   widthPx: 384,
   /** Target height for text content */
   textContentHeight: 72,
-  /** Adjust start of line for task card */
+  /** Adjust x for task card overlap */
   xOffset: 64,
-  /** Adjust start of line for task card */
+  /** Adjust y for task card overlap */
   yOffset: 56,
 };
 
@@ -58,7 +58,7 @@ export class TmplProgressPathComponent extends TemplateBaseComponent {
     `.trim();
 
     // Alt generation that is a bit more wavy
-    // https://svg-path-visualizer.netlify.app/#M%20128%2C128%0Ah%20384%20%0Ac%2064%2C0%20128%2C64%2064%2C200%0A
+    // https://svg-path-visualizer.netlify.app/#M%2064%2C56%0Ah%20208%0Ac%2048%2C0%2072%2C64%2048%2C128%0A
     const wavy = () =>
       `
     M ${xOffset},${yOffset}

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.ts
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.ts
@@ -1,5 +1,11 @@
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
+import { getStringParamFromTemplateRow } from "src/app/shared/utils";
+
+interface IProgressPathParams {
+  /** TEMPLATE_PARAMETER: "variant" */
+  variant: "basic" | "wavy";
+}
 
 // HACK - hardcoded sizing values to make content fit reasonably well
 const SIZING = {
@@ -18,15 +24,25 @@ const SIZING = {
   templateUrl: "./progress-path.component.html",
   styleUrls: ["./progress-path.component.scss"],
 })
-export class TmplProgressPathComponent extends TemplateBaseComponent {
+export class TmplProgressPathComponent extends TemplateBaseComponent implements OnInit {
+  private params: Partial<IProgressPathParams> = {};
+  private pathVariant: "basic" | "wavy";
+
   public svgPath: string;
   public svgViewBox: string;
   public contentHeight: string;
   public width = `${SIZING.widthPx}px`;
 
-  constructor() {
-    super();
-    this.generateSVGPath("wavy");
+  ngOnInit() {
+    this.getParams();
+    this.generateSVGPath(this.pathVariant);
+  }
+
+  private getParams() {
+    this.params.variant = getStringParamFromTemplateRow(this._row, "variant", "basic")
+      .split(",")
+      .join(" ") as IProgressPathParams["variant"];
+    this.pathVariant = this.params.variant.includes("wavy") ? "wavy" : "basic";
   }
 
   /**

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.ts
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.ts
@@ -4,13 +4,13 @@ import { TemplateBaseComponent } from "../base";
 // HACK - hardcoded sizing values to make content fit reasonably well
 const SIZING = {
   /** Total width for container */
-  widthPx: 384,
+  widthPx: 364,
   /** Target height for text content */
-  textContentHeight: 72,
+  textContentHeight: 82,
   /** Adjust x for task card overlap */
-  xOffset: 64,
+  xOffset: 68,
   /** Adjust y for task card overlap */
-  yOffset: 56,
+  yOffset: 48,
 };
 
 @Component({
@@ -63,7 +63,7 @@ export class TmplProgressPathComponent extends TemplateBaseComponent {
       `
     M ${xOffset},${yOffset}
     h ${widthPx - 2 * xOffset - 48}
-    c 48,0 72,64 48,${viewboxHeight - yOffset - 16}
+    c 48,0 72,64 48,${viewboxHeight - yOffset - 4}
     `.trim();
 
     this.svgPath = variant === "basic" ? basic() : wavy();

--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -201,11 +201,12 @@
     top: $circle-width;
     min-width: 150px;
     max-width: 240px;
+    padding: 0 12px;
 
     p {
       text-align: center;
       line-height: var(--line-height-text);
-      font-size: var(--font-size-text-large);
+      font-size: var(--font-size-text-medium);
       color: var(--ion-color-primary);
       font-weight: var(--font-weight-bold);
     }

--- a/src/theme/themes/default.scss
+++ b/src/theme/themes/default.scss
@@ -53,7 +53,6 @@
       // task-progress-bar-color: var(--ion-color-primary),
       // checkbox-background-color: white,
       // progress-path-line-background, var(--ion-color-gray-100),
-      // progress-path-line-weight: 72px,
     );
     @include utils.generateTheme($color-primary, $color-secondary, $page-background);
     @each $name, $value in $variable-overrides {

--- a/src/theme/themes/early_family_math.scss
+++ b/src/theme/themes/early_family_math.scss
@@ -49,7 +49,6 @@
       task-progress-bar-color: var(--ion-color-green),
       // checkbox-background-color: white,
       // progress-path-line-background, var(--ion-color-gray-100),
-      // progress-path-line-weight: 72px,
     );
     @include utils.generateTheme($color-primary, $color-secondary, $page-background);
     @each $name, $value in $variable-overrides {

--- a/src/theme/themes/pfr.scss
+++ b/src/theme/themes/pfr.scss
@@ -50,7 +50,6 @@
       // task-progress-bar-color: var(--ion-color-primary),
       // checkbox-background-color: white,
       // progress-path-line-background, var(--ion-color-gray-100),
-      // progress-path-line-weight: 72px,
     );
     @include utils.generateTheme($color-primary, $color-secondary, $page-background, $g: $green);
     @each $name, $value in $variable-overrides {

--- a/src/theme/themes/plh_facilitator_mx.scss
+++ b/src/theme/themes/plh_facilitator_mx.scss
@@ -49,7 +49,6 @@
       task-progress-bar-color: var(--ion-color-green),
       // checkbox-background-color: white,
       // progress-path-line-background, var(--ion-color-gray-100),
-      // progress-path-line-weight: 72px,
     );
     @include utils.generateTheme($color-primary, $color-secondary, $page-background);
     @each $name, $value in $variable-overrides {

--- a/src/theme/themes/professional.scss
+++ b/src/theme/themes/professional.scss
@@ -49,7 +49,6 @@
       task-progress-bar-color: var(--ion-color-green),
       // checkbox-background-color: white,
       progress-path-line-background: var(--ion-color-gray-100),
-      // progress-path-line-weight: 72px,
     );
     @include utils.generateTheme($color-primary, $color-secondary, $page-background);
     @each $name, $value in $variable-overrides {


### PR DESCRIPTION
Targets branch for PR #2370

- Recreate svg element to avoid use of nested groups and transformations. 
- Make SVG generation dynamic (to support variable width and height)
- Fix inheritance of stroke color. 
- Remove path-line-weight variable (as image distorts when using different weight)

## Dev Notes
The changes started as minor edits to SVG to inherit color properly and remove unnecessary grouping, however I noticed that the SVG I was working from had been altered since to include more vertical space, which had knock-ons of breaking various layout aspects. It didn't help that the SVG itself had viewbox for one static size and rendering at another (auto-scaling), whitespace within the SVG element and then deeply nested fixed sizes for components that it had to adjust for (e.g task card text content)

This all felt quite fragile, so to address this PR moves more towards programmatic svg generation instead of fixed file, so that at least height and width can be reasonably adjustable (albeit with a few extra offset changes).

I'm still not 100% satisfied with the final result, but interested to see what you think @jfmcquade (see possible variants for _basic_ and _wavy_ ). See example links in the code for a better explanation of generating SVGs programmatically and a preview of the outputs

Longer term I think likely would want to de-couple from the task-card, and/or calculate the task-card sizes programmatically after view init and generate a full svg path once sizes are known. 


PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

_What this PR does_

## Git Issues

Closes #

## Screenshots/Videos
**Generated SVG** - wavy variant
![localhost_4200_template_comp_progress_path (3)](https://github.com/user-attachments/assets/9b5df573-92f9-4875-8a6f-ddfb525295b6)

**Generated SVG** - basic variant
![localhost_4200_template_comp_progress_path (4)](https://github.com/user-attachments/assets/5afb6498-3dc7-4409-b4ba-5d91e135ddfe)


