### PR TITLE
Fix/task card border

### DIFF
--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -153,6 +153,7 @@
 
 .circle-card-wrapper {
   $circle-width: 100px;
+  $circle-clip-width: $circle-width / 2 - 4px;
 
   width: 100%;
   display: flex;
@@ -191,8 +192,10 @@
       border: 1px solid rgba(black, 0.07);
       filter: drop-shadow(var(--ion-default-box-shadow));
 
-      .img {
-        width: $circle-width;
+      img {
+        width: 100%;
+        height: 100%;
+        clip-path: circle($circle-clip-width at center);
       }
     }
 

--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -153,7 +153,6 @@
 
 .circle-card-wrapper {
   $circle-width: 100px;
-  $circle-clip-width: $circle-width / 2 - 4px;
 
   width: 100%;
   display: flex;
@@ -195,7 +194,7 @@
       img {
         width: 100%;
         height: 100%;
-        clip-path: circle($circle-clip-width at center);
+        clip-path: circle(#{$circle-width / 2 - 4px} at center);
       }
     }
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
Task cards don't appear to be applying consistent borders due to a combination of factors:
1. Images stretch to try to fill all available space
2. Content issues where images are not perfectly square, centered and applying their own white backgrounds

This is a small fix to apply a separate clipping at the image level to ensure images are contained within a circular region, and that circular region has a minimum distance to the outer container.

## Review Notes
Image whitespace still may look a little off due to the way some images include their own white regions (see red-line version for emphasis). If wanting full consistency the source images will require editing.

## Git Issues

Closes #

## Screenshots/Videos

**Before**
![localhost_4200_template_home_screen](https://github.com/user-attachments/assets/e2b80663-1199-4c4b-96c7-7dc36e6f4a92)

If changing white line to red for emphasis

![localhost_4200_template_home_screen (1)](https://github.com/user-attachments/assets/9959662c-582b-4250-b7b2-055675f0b23e)

**After**
![localhost_4200_template_home_screen (2)](https://github.com/user-attachments/assets/0b869f4a-8b19-408a-bd9e-ceec37f5166e)

If changing white line to red for emphasis

![localhost_4200_template_home_screen (3)](https://github.com/user-attachments/assets/f0b34ce8-ddf0-4a67-a98e-c80f7ee9d97a)
