### PR TITLE
fix: warning log invalid naming

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/index.ts
+++ b/packages/scripts/src/commands/app-data/convert/index.ts
@@ -153,9 +153,9 @@ export class AppDataConverter {
   private logOutputs(result: IParsedWorkbookData) {
     this.writeOutputJsons(result);
     logSheetsSummary(result);
-    const warnings = getLogs("warning");
+    const warnings = getLogs("warn");
     if (warnings.length > 0) {
-      const warningLogFile = getLogFiles().warning;
+      const warningLogFile = getLogFiles().warn;
       logWarning({
         msg1: `Completed with ${warnings.length} warnings`,
         msg2: warningLogFile,

--- a/packages/shared/src/utils/logging/file-logger.ts
+++ b/packages/shared/src/utils/logging/file-logger.ts
@@ -6,7 +6,7 @@ import { existsSync } from "fs";
 import { SCRIPTS_LOGS_DIR } from "../../paths";
 import { getGlobalMemoryLoggerTransport } from "./memory-logger";
 
-const logLevels = ["debug", "info", "warning", "error"] as const;
+const logLevels = ["debug", "info", "warn", "error"] as const;
 type ILogLevel = (typeof logLevels)[number];
 
 /** Retrieve all logs from current session for a given variable */

--- a/packages/shared/src/utils/logging/memory-logger.ts
+++ b/packages/shared/src/utils/logging/memory-logger.ts
@@ -1,6 +1,6 @@
 import Transport from "winston-transport";
 
-const logLevels = ["debug", "info", "warning", "error"] as const;
+const logLevels = ["debug", "info", "warn", "error"] as const;
 type ILogLevel = (typeof logLevels)[number];
 
 interface ILogEntry {
@@ -29,7 +29,7 @@ export class MemoryLogger extends Transport {
       debug: [],
       error: [],
       info: [],
-      warning: [],
+      warn: [],
     };
   }
   log(entry: ILogEntry, callback) {


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

fix regression from #2376  where script warnings were not been logged correctly (due to typo on `warn` vs `warning`)

## Git Issues

Closes #

## Screenshots/Videos
**Example issue**
![image](https://github.com/user-attachments/assets/f55260dc-8196-4391-8564-38ba8547f8c1)
