### PR TITLE
Feat: runtime deployment config

### DIFF
--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -31,6 +31,7 @@
     "rxdb",
     "sidemenu",
     "sourcemaps",
+    "supabase",
     "swiper",
     "templatename",
     "tmpl",

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -7,7 +7,7 @@ export const DEPLOYMENT_CONFIG_VERSION = 20240910.0;
 /** Configuration settings available to runtime application */
 export interface IDeploymentRuntimeConfig {
   /** version of open-app-builder used to compile */
-  _core_version: string;
+  _app_builder_version: string;
   /** tag of content version provided by content git repo*/
   _content_version: string;
 
@@ -153,7 +153,7 @@ export interface IDeploymentConfigJson extends IDeploymentConfig {
 
 export const DEPLOYMENT_RUNTIME_CONFIG_DEFAULTS: IDeploymentRuntimeConfig = {
   _content_version: "",
-  _core_version: "",
+  _app_builder_version: "",
   name: "",
   api: {
     db_name: "plh",

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -2,10 +2,15 @@ import type { IGdriveEntry } from "../@idemsInternational/gdrive-tools";
 import type { IAppConfig } from "./appConfig";
 
 /** Update version to force recompile next time deployment set (e.g. after default config update) */
-export const DEPLOYMENT_CONFIG_VERSION = 20240314.0;
+export const DEPLOYMENT_CONFIG_VERSION = 20240910.0;
 
 /** Configuration settings available to runtime application */
 export interface IDeploymentRuntimeConfig {
+  /** version of open-app-builder used to compile */
+  _core_version: string;
+  /** tag of content version provided by content git repo*/
+  _content_version: string;
+
   api: {
     /** Name of target db for api operations. Default `plh` */
     db_name?: string;
@@ -46,6 +51,8 @@ export interface IDeploymentRuntimeConfig {
       enabled: boolean;
     };
   };
+  /** Friendly name used to identify the deployment name */
+  name: string;
   /** 3rd party integration for remote asset storage and sync */
   supabase: {
     enabled: boolean;
@@ -56,8 +63,6 @@ export interface IDeploymentRuntimeConfig {
 
 /** Deployment settings not available at runtime  */
 interface IDeploymentCoreConfig {
-  /** Friendly name used to identify the deployment name */
-  name: string;
   google_drive: {
     /** @deprecated Use `sheets_folder_ids` array instead */
     sheets_folder_id?: string;
@@ -146,8 +151,29 @@ export interface IDeploymentConfigJson extends IDeploymentConfig {
   _config_version: number;
 }
 
+export const DEPLOYMENT_RUNTIME_CONFIG_DEFAULTS: IDeploymentRuntimeConfig = {
+  _content_version: "",
+  _core_version: "",
+  name: "",
+  api: {
+    db_name: "plh",
+    endpoint: "https://apps-server.idems.international/api",
+  },
+  app_config: {} as any, // populated by `getDefaultAppConstants()`,
+
+  firebase: {
+    config: null,
+    auth: { enabled: false },
+    crashlytics: { enabled: true },
+  },
+  supabase: {
+    enabled: false,
+  },
+};
+
 /** Full example of just all config once merged with defaults */
 export const DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS: IDeploymentConfig = {
+  ...DEPLOYMENT_RUNTIME_CONFIG_DEFAULTS,
   name: "Full Config Example",
   google_drive: {
     assets_folder_id: "",
@@ -157,11 +183,6 @@ export const DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS: IDeploymentConfig = {
     assets_filter_function: (gdriveEntry) => true,
   },
   android: {},
-  api: {
-    db_name: "plh",
-    endpoint: "https://apps-server.idems.international/api",
-  },
-  app_config: {} as any, // populated by `getDefaultAppConstants()`,
   local_drive: {
     assets_path: "./assets",
     sheets_path: "./sheets",
@@ -171,15 +192,7 @@ export const DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS: IDeploymentConfig = {
     sheets_filter_function: (flow) => true,
     assets_filter_function: (fileEntry) => true,
   },
-  firebase: {
-    config: null,
-    auth: { enabled: false },
-    crashlytics: { enabled: true },
-  },
   ios: {},
-  supabase: {
-    enabled: false,
-  },
   translations: {
     filter_language_codes: null,
     source_strings_path: "./app_data/translations_source/source_strings",

--- a/packages/scripts/src/tasks/providers/appData.ts
+++ b/packages/scripts/src/tasks/providers/appData.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "fs-extra";
 import path from "path";
+import packageJSON from "../../../../../package.json";
 import { parseCommand } from "../../commands";
 import { WorkflowRunner } from "../../commands/workflow/run";
 import { SRC_ASSETS_PATH } from "../../paths";
@@ -59,8 +60,18 @@ const copyDeploymentDataToApp = () => {
 };
 
 function generateRuntimeConfig(deploymentConfig: IDeploymentConfigJson): IDeploymentRuntimeConfig {
-  const { api, app_config, firebase, supabase, error_logging } = deploymentConfig;
-  return { api, app_config, firebase, supabase, error_logging };
+  const { api, app_config, firebase, supabase, error_logging, git, name } = deploymentConfig;
+
+  return {
+    api,
+    app_config,
+    firebase,
+    supabase,
+    error_logging,
+    _core_version: packageJSON.version,
+    _content_version: git.content_tag_latest || "",
+    name,
+  };
 }
 
 export default { postProcessAssets, postProcessSheets, copyDeploymentDataToApp };

--- a/packages/scripts/src/tasks/providers/appData.ts
+++ b/packages/scripts/src/tasks/providers/appData.ts
@@ -34,7 +34,7 @@ const copyDeploymentDataToApp = () => {
   const { app_data } = WorkflowRunner.config;
 
   // copy filtered subset of app_data
-  const copiedFolders = ["assets", "sheets", "translations", "config.json"];
+  const copiedFolders = ["assets", "sheets", "translations"];
   const filter_fn = (entry: IContentsEntry) => {
     const [baseDir] = entry.relativePath.split("/");
     return copiedFolders.includes(baseDir);

--- a/packages/scripts/src/tasks/providers/appData.ts
+++ b/packages/scripts/src/tasks/providers/appData.ts
@@ -4,6 +4,7 @@ import { parseCommand } from "../../commands";
 import { WorkflowRunner } from "../../commands/workflow/run";
 import { SRC_ASSETS_PATH } from "../../paths";
 import { IContentsEntry, replicateDir } from "../../utils";
+import { IDeploymentConfigJson, IDeploymentRuntimeConfig } from "data-models";
 
 /** Prepare sourcely cached assets for population to app */
 const postProcessAssets = async (options: { sourceAssetsFolders: string[] }) => {
@@ -30,24 +31,36 @@ const postProcessSheets = async (options: {
  */
 const copyDeploymentDataToApp = () => {
   const { app_data } = WorkflowRunner.config;
-  const copiedFolders = ["assets", "sheets", "translations"];
-  // omit index files
+
+  // copy filtered subset of app_data
+  const copiedFolders = ["assets", "sheets", "translations", "config.json"];
   const filter_fn = (entry: IContentsEntry) => {
     const [baseDir] = entry.relativePath.split("/");
     return copiedFolders.includes(baseDir);
   };
-  const source = app_data.output_path;
-  const target = path.resolve(SRC_ASSETS_PATH, "app_data");
-  replicateDir(source, target, { filter_fn });
+  // copy folders
+  const sourceFolder = app_data.output_path;
+  const targetFolder = path.resolve(SRC_ASSETS_PATH, "app_data");
+  replicateDir(sourceFolder, targetFolder, { filter_fn });
 
   // HACK - Angular webpack won't always live-reload when changes only made to asset files
   // so write an arbitrary variable that can be imported into the app and will trigger reload
   // https://github.com/angular/angular-cli/issues/22751
   // https://github.com/webpack/webpack-dev-server/issues/3794
   writeFileSync(
-    path.resolve(target, "index.ts"),
+    path.resolve(targetFolder, "index.ts"),
     `export const DEV_COMPILE_TIME = ${new Date().getTime()}`
   );
+
+  // write runtime deployment config
+  const configTarget = path.resolve(targetFolder, "deployment.json");
+  const runtimeConfig = generateRuntimeConfig(WorkflowRunner.config);
+  writeFileSync(configTarget, JSON.stringify(runtimeConfig, null, 2));
 };
+
+function generateRuntimeConfig(deploymentConfig: IDeploymentConfigJson): IDeploymentRuntimeConfig {
+  const { api, app_config, firebase, supabase, error_logging } = deploymentConfig;
+  return { api, app_config, firebase, supabase, error_logging };
+}
 
 export default { postProcessAssets, postProcessSheets, copyDeploymentDataToApp };

--- a/packages/scripts/src/tasks/providers/appData.ts
+++ b/packages/scripts/src/tasks/providers/appData.ts
@@ -68,7 +68,7 @@ function generateRuntimeConfig(deploymentConfig: IDeploymentConfigJson): IDeploy
     firebase,
     supabase,
     error_logging,
-    _core_version: packageJSON.version,
+    _app_builder_version: packageJSON.version,
     _content_version: git.content_tag_latest || "",
     name,
   };

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "moduleResolution": "node",
     "module": "CommonJS",
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     // Global type definitions.
     "typeRoots": ["./node_modules/@types"],

--- a/packages/shared/src/utils/file-utils.ts
+++ b/packages/shared/src/utils/file-utils.ts
@@ -497,8 +497,6 @@ export function replicateFile(src: string, target: string) {
       return;
     }
   }
-  // copy from src to target
-  fs.ensureDir(path.dirname(target));
   fs.ensureDirSync(path.dirname(target));
   fs.copyFileSync(src, target);
   const mtime = new Date(srcStats.modifiedTime);

--- a/packages/shared/src/utils/file-utils.ts
+++ b/packages/shared/src/utils/file-utils.ts
@@ -2,7 +2,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import * as os from "os";
 import { createHash, randomUUID } from "crypto";
-import { logWarning } from "./logging.utils";
+import { Logger, logWarning } from "./logging.utils";
 import { tmpdir } from "os";
 
 /**
@@ -149,12 +149,7 @@ export function generateFolderFlatMap(
     const relativePath = path.relative(folderPath, filePath).split(path.sep).join("/");
     const shouldInclude = options.filterFn ? options.filterFn(relativePath) : true;
     if (shouldInclude) {
-      // generate size and md5 checksum stats
-      const { size, mtime } = fs.statSync(filePath);
-      const modifiedTime = mtime.toISOString();
-      // write size in kb to 1 dpclear
-      const size_kb = Math.round(size / 102.4) / 10;
-      const md5Checksum = getFileMD5Checksum(filePath);
+      const { md5Checksum, modifiedTime, size_kb } = getFileStats(filePath);
       const entry: IContentsEntry = { relativePath, size_kb, md5Checksum, modifiedTime };
       if (options.includeLocalPath) {
         entry.localPath = filePath;
@@ -163,6 +158,16 @@ export function generateFolderFlatMap(
     }
   }
   return flatMap;
+}
+
+function getFileStats(filePath: string) {
+  // generate size and md5 checksum stats
+  const { size, mtime } = fs.statSync(filePath);
+  const modifiedTime = mtime.toISOString();
+  // write size in kb to 1 dpclear
+  const size_kb = Math.round(size / 102.4) / 10;
+  const md5Checksum = getFileMD5Checksum(filePath);
+  return { size_kb, md5Checksum, modifiedTime };
 }
 
 export interface IContentsEntry {
@@ -478,6 +483,26 @@ export function replicateDir(
     cleanupEmptyFolders(target);
   }
   return ops;
+}
+
+/** Copy a file from src to target, only replacing if unchanged */
+export function replicateFile(src: string, target: string) {
+  const srcExists = fs.pathExistsSync(src);
+  if (!srcExists) return Logger.error({ msg1: "File not found", msg2: src });
+  const srcStats = getFileStats(src);
+  // skip if target file same contents as src
+  if (fs.pathExistsSync(target)) {
+    const targetStats = getFileStats(target);
+    if (srcStats.md5Checksum === targetStats.md5Checksum) {
+      return;
+    }
+  }
+  // copy from src to target
+  fs.ensureDir(path.dirname(target));
+  fs.ensureDirSync(path.dirname(target));
+  fs.copyFileSync(src, target);
+  const mtime = new Date(srcStats.modifiedTime);
+  fs.utimesSync(target, mtime, mtime);
 }
 
 /**

--- a/src/app/shared/services/deployment/deployment.service.spec.ts
+++ b/src/app/shared/services/deployment/deployment.service.spec.ts
@@ -1,0 +1,43 @@
+import { DeploymentService } from "./deployment.service";
+import { HttpClient, HttpErrorResponse } from "@angular/common/http";
+import { DEPLOYMENT_RUNTIME_CONFIG_DEFAULTS, IDeploymentRuntimeConfig } from "packages/data-models";
+import { asyncData, asyncError } from "src/test/utils";
+
+const mockConfig: IDeploymentRuntimeConfig = {
+  ...DEPLOYMENT_RUNTIME_CONFIG_DEFAULTS,
+  name: "test",
+};
+
+/**
+ * Call standalone tests via:
+ * yarn ng test --include src/app/shared/services/deployment/deployment.service.spec.ts
+ */
+describe("Deployment Service", () => {
+  let service: DeploymentService;
+  let httpClientSpy: jasmine.SpyObj<HttpClient>;
+
+  beforeEach(async () => {
+    // NOTE - prefer use of spy to `HttpTestingController` as allows to specify responses
+    // in advance of request (controller must be called after start of init but before complete)
+    httpClientSpy = jasmine.createSpyObj("HttpClient", ["get"]);
+    service = new DeploymentService(httpClientSpy);
+  });
+
+  it("Loads deployment from assets json", async () => {
+    httpClientSpy.get.and.returnValue(asyncData(mockConfig));
+    await service.ready();
+    expect(service.config().name).toEqual(mockConfig.name);
+  });
+
+  it("Handles handles missing deployment json", async () => {
+    const errorResponse = new HttpErrorResponse({
+      error: "test 404 error",
+      status: 404,
+      statusText: "Not Found",
+    });
+    httpClientSpy.get.and.returnValue(asyncError(errorResponse));
+    await service.ready();
+    expect(service.config().name).toEqual(DEPLOYMENT_RUNTIME_CONFIG_DEFAULTS.name);
+    // TODO - could also consider check that logger gets called
+  });
+});

--- a/src/app/shared/services/deployment/deployment.service.spec.ts
+++ b/src/app/shared/services/deployment/deployment.service.spec.ts
@@ -29,7 +29,7 @@ describe("Deployment Service", () => {
     expect(service.config().name).toEqual(mockConfig.name);
   });
 
-  it("Handles handles missing deployment json", async () => {
+  it("Handles missing deployment json", async () => {
     const errorResponse = new HttpErrorResponse({
       error: "test 404 error",
       status: 404,

--- a/src/app/shared/services/deployment/deployment.service.ts
+++ b/src/app/shared/services/deployment/deployment.service.ts
@@ -37,7 +37,6 @@ export class DeploymentService extends AsyncServiceBase {
         console.warn("No deployment config available");
         return of(null);
       }),
-      // HACK - json config converts functions to strings, not strongly typed
       map((v) => v as IDeploymentRuntimeConfig)
     );
   }

--- a/src/app/shared/services/deployment/deployment.service.ts
+++ b/src/app/shared/services/deployment/deployment.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, signal } from "@angular/core";
+import { AsyncServiceBase } from "../asyncService.base";
+import { HttpClient } from "@angular/common/http";
+import { catchError, map, of, firstValueFrom } from "rxjs";
+import { DEPLOYMENT_RUNTIME_CONFIG_DEFAULTS, IDeploymentRuntimeConfig } from "packages/data-models";
+
+@Injectable({ providedIn: "root" })
+/**
+ * Deployment runtime config settings
+ *
+ * NOTE - this is populated as a blocking service during init,
+ * so no need to await service initialisation before access
+ */
+export class DeploymentService extends AsyncServiceBase {
+  constructor(private http: HttpClient) {
+    super("Deployment Service");
+    this.registerInitFunction(this.initialise);
+  }
+
+  /** Private writeable config to allow population from JSON */
+  private _config = signal(DEPLOYMENT_RUNTIME_CONFIG_DEFAULTS);
+
+  /** Read-only access to deployment runtime config */
+  public config = this._config.asReadonly();
+
+  /** Load active deployment configuration from JSON file */
+  private async initialise() {
+    const deployment = await firstValueFrom(this.loadDeployment());
+    if (deployment) {
+      this._config.set(deployment);
+    }
+  }
+
+  private loadDeployment() {
+    return this.http.get("assets/deployment.json").pipe(
+      catchError(() => {
+        console.warn("No deployment config available");
+        return of(null);
+      }),
+      // HACK - json config converts functions to strings, not strongly typed
+      map((v) => v as IDeploymentRuntimeConfig)
+    );
+  }
+}

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,0 +1,20 @@
+import { defer } from "rxjs";
+
+// Utils referenced in v17 angular docs, copied from
+// https://stackblitz.com/edit/spec-has-no-expectations?file=src%2Ftesting%2Fasync-observable-helpers.ts
+
+/**
+ * Create async observable that emits-once and completes
+ * after a JS engine turn
+ */
+export function asyncData<T>(data: T) {
+  return defer(() => Promise.resolve(data));
+}
+
+/**
+ * Create async observable error that errors
+ * after a JS engine turn
+ */
+export function asyncError<T>(errorObject: any) {
+  return defer(() => Promise.reject(errorObject));
+}


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
Currently full deployment configuration is made available to the app at build time by directly importing the `activeDeployment.json` file into the angular `environment.ts` file. A few issues with this include:

- Large amount of developer-specific code exposed (e.g. local workspace directories)
- Deployment config changes require full app rebuild to run (actively running angular compiler)
- Potentially sensitive data exposed (e.g. config tokens)

This PR is the first of two designed to dynamically import minimally required deployment config during runtime.

**Main Changes**
- Create separate type definitions for deployment config variables used at runtime
- Update scripts to populate runtime config to file and 
- Create service and tests to enable access to runtime config

## Review Notes
Can see the config file populated to `src\assets\app_data\deployment.json`. This will be populated as part of `populate_src_assets` workflow which is called during `yarn start`

Most variables have just been cut-pasted from the main deployment config to the runtime, with the exception of `_app_builder_version` and `_content_version` which are populated from the `package.json` version and git config `content_tag_latest` respectively

This shouldn't have any immediate impact on current apps as the configuration is not yet read from the asset folder (will be follow-up pr)

## Dev Notes



**Next Steps (follow-up PR)**
- Refactor all existing code to access runtime config through service instead of environment
- Tidy up environment variables (review which are still required or not)

Once both merged this will open pathways to better separate app build from runtime, and enable things such as importing pre-built core app bundles and just populating assets to run (no angular compiler required).

**Further Steps (to discuss/organise)**
- Consider splitting out `app_config` variables to separate json/file (e.g. separate app and feature/service config files)
- Consider removing config function stringification (only runtime config needs load from json and doesn't include any properties with functions)
- Review work from #2086 and try to revive as useful 
- Attempt to rewrite config as ts/js export that can access named utils. Enable to be fully compiled in advance or evaluated at runtime (e.g. import js string and use eval with util variable contexts).
- Update config to export as generator functions (module.exports)
- Refactor to allow creation of full config from partial at runtime (just save config diffs)
- Config validation through zod or similar
- Create local and gh action workflows that allow serve/build deployments without angular dev server (i.e. use pre-built app core and load deployment config, sheets and assets as app_data only)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
