### PR TITLE
Chore: update action artifact versions

### DIFF
--- a/.github/workflows/deprecated/deployment-hosting.yml
+++ b/.github/workflows/deprecated/deployment-hosting.yml
@@ -34,7 +34,7 @@ jobs:
           echo "DEPLOYMENT_NAME=${{needs.build.outputs.DEPLOYMENT_NAME}}" >> $GITHUB_ENV
           echo "GIT_SHA=${{needs.build.outputs.GIT_SHA}}" >> $GITHUB_ENV
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: www
       - name: Extract Build folder
@@ -52,7 +52,7 @@ jobs:
           SENTRY_PROJECT: ${{env.DEPLOYMENT_NAME}}
         continue-on-error: true
       - name: Store sourcemaps artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sourcemaps-$GIT_SHA
           path: www/*.map
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: www
       - name: Extract Build folder

--- a/.github/workflows/deprecated/sourcemaps-upload.yml
+++ b/.github/workflows/deprecated/sourcemaps-upload.yml
@@ -60,7 +60,7 @@ jobs:
           SENTRY_PROJECT: ${{env.DEPLOYMENT_NAME}}
         continue-on-error: true
       - name: Store sourcemaps artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sourcemaps-$SHA_SHORT
           path: www/*.map

--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -104,7 +104,7 @@ jobs:
           run: yarn workflow android
              
         - name: Download Build Artifact
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
             name: www
 
@@ -134,7 +134,7 @@ jobs:
           run: ./gradlew :app:assembleDebug
   
         - name: Upload debug apk
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: debug_apk
             path: android/app/build/outputs/apk/debug/app-debug.apk
@@ -155,7 +155,7 @@ jobs:
             keyPassword: ${{ env.KEY_PASSWORD }}
             
         - name: Upload release bundle
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: release_bundle
             path: ${{steps.sign_aab.outputs.signedReleaseFile}}

--- a/.github/workflows/reusable-android-release.yml
+++ b/.github/workflows/reusable-android-release.yml
@@ -33,7 +33,7 @@ jobs:
 
         - name: Download Build Artifact
           id: download
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
             name: release_bundle
             path: ./

--- a/.github/workflows/reusable-appetize.yml
+++ b/.github/workflows/reusable-appetize.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: debug_apk
           path: ./

--- a/.github/workflows/reusable-deploy-pr-preview.yml
+++ b/.github/workflows/reusable-deploy-pr-preview.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: www
           

--- a/.github/workflows/reusable-deploy-web-preview.yml
+++ b/.github/workflows/reusable-deploy-web-preview.yml
@@ -40,11 +40,14 @@ on:
       FIREBASE_SERVICE_ACCOUNT:
         required: true
 
+# TODO - tidy up, bump versions, settup testing, rename, use templates
+
 jobs:
   build_action:
     uses: ./.github/workflows/reusable-app-build.yml
     secrets: inherit
 
+    # TODO - split post_build and deploy
   deploy:
     needs: build_action
     runs-on: ubuntu-latest
@@ -55,7 +58,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        # TODO - get id from build step ?
         with:
           name: www
 

--- a/.github/workflows/reusable-deploy-web-preview.yml
+++ b/.github/workflows/reusable-deploy-web-preview.yml
@@ -40,8 +40,6 @@ on:
       FIREBASE_SERVICE_ACCOUNT:
         required: true
 
-# TODO - tidy up, bump versions, settup testing, rename, use templates
-
 jobs:
   build_action:
     uses: ./.github/workflows/reusable-app-build.yml
@@ -59,7 +57,6 @@ jobs:
 
       - name: Download Build Artifact
         uses: actions/download-artifact@v4
-        # TODO - get id from build step ?
         with:
           name: www
 
@@ -68,6 +65,7 @@ jobs:
           mkdir www
           tar -xf artifact.tar --directory www
 
+      # TODO - use templated files
       # Create a .firebaserc file mapping any firebase deployment host targets (required if multi-host projects)
       # e.g. {"projects": {"default": "my_app"},"targets": {"my_app": {"hosting": {"my_app_dev":["my_app_dev"]} } }
       - name: Populate Firebase Targets

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: www
       - name: Extract Build folder

--- a/.github/workflows/test-visual.yml
+++ b/.github/workflows/test-visual.yml
@@ -55,7 +55,7 @@ jobs:
       #         Download build
       #############################################################################
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: www
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload screenshots
         if: ${{inputs.generate}}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: screenshots-artifact # NOTE - must match SCREENSHOT_ARTIFACT_NAME in code
           path: packages/test-visual/output/screenshots
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload artifact
         if: ${{inputs.compare}}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-visual-diffs-artifact
           path: packages/test-visual/output/diffs
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload Text Outputs
         if: ${{inputs.compare}}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: text_output
           path: packages/test-visual/output/*.txt

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -175,7 +175,7 @@ jobs:
         # Use github pages upload artifact action to compress and upload
       - name: Upload artifact
         if: ${{!inputs.skip-upload}}
-        uses: actions/upload-pages-artifact@v1.0.8
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "www/"
           name: www

--- a/packages/actions/templates/app-build/template.yml
+++ b/packages/actions/templates/app-build/template.yml
@@ -69,7 +69,7 @@ jobs:
 
         # Use github pages upload artifact action to compress and upload
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1.0.8
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "www/"
           name: ${{inputs.artifact-name}}

--- a/packages/actions/templates/deploy-firebase/template.yml
+++ b/packages/actions/templates/deploy-firebase/template.yml
@@ -49,7 +49,7 @@ jobs:
       # Extract build artifact
       - uses: actions/checkout@v3
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: www
       - name: Extract Build folder

--- a/packages/actions/templates/pr-preview-firebase/template.yml
+++ b/packages/actions/templates/pr-preview-firebase/template.yml
@@ -50,7 +50,7 @@ jobs:
       # Extract build artifact
       - uses: actions/checkout@v3
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: www
       - name: Extract Build folder

--- a/src/app/shared/components/template/components/data-items/data-items.component.spec.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.spec.ts
@@ -236,4 +236,16 @@ describe("DataItemsComponent", () => {
     ).args[0];
     expect(setItemContext.currentItemId).toBe(rowItemId);
   });
+  // TODO
+  // it("sets an item correctly for a given _index", async () => {
+  //   await actions.set_item({
+  //     context: SET_ITEM_CONTEXT,
+  //     _index: 1,
+  //     writeableProps: { string: "sets an item correctly for a given _index" },
+  //   });
+  //   const obs = await service.query$<any>("data_list", "test_flow");
+  //   const data = await firstValueFrom(obs);
+  //   expect(data[0].string).toEqual("hello");
+  //   expect(data[1].string).toEqual("sets an item correctly for a given _index");
+  // });
 });

--- a/src/app/shared/components/template/components/data-items/data-items.component.spec.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.spec.ts
@@ -236,16 +236,4 @@ describe("DataItemsComponent", () => {
     ).args[0];
     expect(setItemContext.currentItemId).toBe(rowItemId);
   });
-  // TODO
-  // it("sets an item correctly for a given _index", async () => {
-  //   await actions.set_item({
-  //     context: SET_ITEM_CONTEXT,
-  //     _index: 1,
-  //     writeableProps: { string: "sets an item correctly for a given _index" },
-  //   });
-  //   const obs = await service.query$<any>("data_list", "test_flow");
-  //   const data = await firstValueFrom(obs);
-  //   expect(data[0].string).toEqual("hello");
-  //   expect(data[1].string).toEqual("sets an item correctly for a given _index");
-  // });
 });


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

- Make consistent the version of upload/download artifacts across all actions

## Review Notes
Testing done by triggering actions from Temp content repo PR https://github.com/IDEMSInternational/app-debug-content/pull/82 

**Before**
Example [Failed Action](https://github.com/IDEMSInternational/app-debug-content/actions/runs/10820932897/job/30022078872?pr=82) when targeting `master` branch from debug deployment content repo

**After**
Example [Passing Action](https://github.com/IDEMSInternational/app-debug-content/actions/runs/10820985652/job/30022481832) when targeting this branch


## Dev Notes
There is some confusion as various actions use both `upload-artifact` and `upload-pages-artifact`. The `upload-pages-artifact` is simply a lightweight wrapper around `upload-artifact` (some minor modifications to folder structures, if I remember I think the upload-artifact nests everything in a subfolder while the upload-pages-artifact doesn't have nesting... although may have changed with recent versions) - although the upload-pages `v3` action targets the upload-artifact `v4` branch (and so should be used with `download-artifact` v4 also 

It might be possible to completely remove the `upload-pages-artifact` calls (to be investigated)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
