### PR TITLE
fix: scripts app_config

### DIFF
--- a/packages/scripts/src/commands/app-data/postProcess/assets.ts
+++ b/packages/scripts/src/commands/app-data/postProcess/assets.ts
@@ -170,7 +170,8 @@ export class AssetsPostProcessor {
     const filtered: typeof sourceAssets = {};
     const { assets_filter_function } = this.activeDeployment.app_data;
     const { filter_language_codes } = this.activeDeployment.translations;
-    const filter_theme_names = this.activeDeployment.app_config.APP_THEMES.available;
+    // themes are defined in runtime app config which may not be available during scripts
+    const filter_theme_names = this.activeDeployment.app_config.APP_THEMES?.available || [];
 
     // remove contents file from gdrive download
     delete sourceAssets["_contents.json"];


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Fix regression introduced by #2423 

Default app_config variables are no longer loaded until runtime, however there appears to be an instance where scripts that post-process assets expect to access the app_config theme variables. This would results in any deployments without themes defined being unable to compile

This fix simply adds fallback empty array for cases where deployment doesn't specify themes. An more robust solution should probably include improving type-definitions to asset config is only partial during script processing, and to move the theme config to the top-level deployment config - however likely not worth the time involved right now. 

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
