### PR TITLE
Fix: generator chained flows

### DIFF
--- a/.idems_app/deployments/local/.gitignore
+++ b/.idems_app/deployments/local/.gitignore
@@ -4,3 +4,4 @@ tasks
 config.json
 sheets/
 !sheets/demo.xlsx
+reports

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -66,8 +66,6 @@ export namespace FlowTypes {
     rows: any[];
     /** Datalists populate rows as a hashmap instead to allow easier access to nested structures */
     rowsHashmap?: { [id: string]: any };
-    /** Additional flows generated during parsing, such as data pipe or generator flow outputs */
-    _generated?: { [flow_type in FlowType]?: { [flow_name: string]: FlowTypeWithData } };
   }
 
   /*********************************************************************************************

--- a/packages/scripts/src/commands/app-data/convert/cacheStrategy/jsonFile.mock.ts
+++ b/packages/scripts/src/commands/app-data/convert/cacheStrategy/jsonFile.mock.ts
@@ -1,0 +1,46 @@
+import { TimeLike } from "fs";
+import { JsonFileCache } from "./jsonFile";
+import { IContentsEntry } from "shared";
+
+interface IContentsEntryWithValue extends IContentsEntry {
+  value?: any;
+}
+
+/**
+ * Mock implementation of JsonFileCache that only uses in-memory caching
+ * instead of persisting files to disk
+ */
+export class MockJsonFileCache extends JsonFileCache {
+  private mockContents: Record<string, IContentsEntryWithValue> = {};
+
+  constructor() {
+    super("", 0);
+  }
+
+  public add(data: any, entryName?: string, stats?: { mtime: TimeLike }) {
+    if (data) {
+      if (!entryName) {
+        entryName = this.generateCacheEntryName(data);
+      }
+      if (!this.mockContents[entryName]) {
+        this.mockContents[entryName] = {} as any;
+      }
+      this.mockContents[entryName].value = data;
+      return { filePath: entryName, entryName, data };
+    }
+  }
+
+  public clear() {
+    this.mockContents = {};
+  }
+
+  public remove(entryName: string) {
+    if (this.mockContents.hasOwnProperty(entryName)) {
+      delete this.mockContents[entryName];
+    }
+  }
+
+  public get<T = any>(entryName: string) {
+    return this.mockContents[entryName] as T;
+  }
+}

--- a/packages/scripts/src/commands/app-data/convert/cacheStrategy/jsonFile.mock.ts
+++ b/packages/scripts/src/commands/app-data/convert/cacheStrategy/jsonFile.mock.ts
@@ -1,6 +1,6 @@
 import { TimeLike } from "fs";
 import { JsonFileCache } from "./jsonFile";
-import { IContentsEntry } from "shared";
+import type { IContentsEntry } from "shared";
 
 interface IContentsEntryWithValue extends IContentsEntry {
   value?: any;

--- a/packages/scripts/src/commands/app-data/convert/cacheStrategy/jsonFile.ts
+++ b/packages/scripts/src/commands/app-data/convert/cacheStrategy/jsonFile.ts
@@ -34,7 +34,10 @@ export class JsonFileCache {
 
   constructor(folderPath: string, version: number) {
     this.version = version;
-    this.setup(folderPath);
+    // HACK - support tests by avoiding setup if folderPath not provided
+    if (folderPath) {
+      this.setup(folderPath);
+    }
   }
 
   /**

--- a/packages/scripts/src/commands/app-data/convert/convert.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/convert.spec.ts
@@ -64,7 +64,7 @@ describe("App Data Converter", () => {
   it("Populates output to folder by data type", async () => {
     await converter.run();
     const outputFolders = readdirSync(paths.outputFolder);
-    expect(outputFolders).toEqual(["data_list", "data_pipe", "template"]);
+    expect(outputFolders).toEqual(["data_list", "template"]);
   });
   it("Supports input from multiple source folders", async () => {
     const multipleSourceConverter = new AppDataConverter({

--- a/packages/scripts/src/commands/app-data/convert/convert.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/convert.spec.ts
@@ -41,6 +41,8 @@ describe("App Data Converter", () => {
     ensureDirSync(paths.cacheFolder);
     emptyDirSync(paths.cacheFolder);
     converter = new AppDataConverter(paths);
+    // HACK - Tests failing on CI due to logs persisting between runs
+    clearLogs(true);
   });
 
   it("Uses child caches", async () => {

--- a/packages/scripts/src/commands/app-data/convert/convert.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/convert.spec.ts
@@ -34,13 +34,12 @@ jest.spyOn(ActiveDeployment, "get").mockReturnValue(mockDeployment as IDeploymen
 /** yarn workspace scripts test -t convert.spec.ts */
 describe("App Data Converter", () => {
   let converter: AppDataConverter;
-  beforeAll(() => {
+
+  beforeEach(() => {
     ensureDirSync(paths.outputFolder);
     emptyDirSync(paths.outputFolder);
     ensureDirSync(paths.cacheFolder);
     emptyDirSync(paths.cacheFolder);
-  });
-  beforeEach(() => {
     converter = new AppDataConverter(paths);
   });
 

--- a/packages/scripts/src/commands/app-data/convert/processors/base.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/base.ts
@@ -26,7 +26,10 @@ class BaseProcessor<T = any, V = any> {
   constructor(public context: { namespace: string; paths: IConverterPaths; cacheVersion: number }) {
     const { namespace } = context;
     this.logger = createChildFileLogger({ source: namespace });
-    this.setupCache();
+    // HACK - support tests by avoiding setup if folderPath not provided
+    if (context.paths) {
+      this.setupCache();
+    }
   }
   /**
    * Create a namespaced cache folder and populate a list of all files currently cached,

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.spec.ts
@@ -80,7 +80,8 @@ describe("FlowParser Processor", () => {
   });
   it("Outputs flows by type", async () => {
     const output = await processor.process(testInputs);
-    expect(Object.keys(output)).toEqual(["data_list", "template", "data_pipe"]);
+    // NOTE - data_pipe and generator flows will not populate self but instead generated outputs
+    expect(Object.keys(output)).toEqual(["data_list", "template"]);
     const errorLogs = getLogs("error");
     if (errorLogs.length > 0) {
       console.log("Unexpected Errors:\n", errorLogs);

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -4,7 +4,7 @@ import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
-const cacheVersion = 20240502.0;
+const cacheVersion = 20240924.4;
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {
@@ -93,47 +93,13 @@ export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithDat
         return k;
       });
     }
-    // populate any generated flows to main list
-    const flowTypesWithGenerated = this.populateGeneratedFlows(flowHashmapByType);
 
     // convert back from hashmap to hashArrays for final output
     const outputData: IParsedWorkbookData = {};
-    for (const [type, typeHashmap] of Object.entries(flowTypesWithGenerated)) {
+    for (const [type, typeHashmap] of Object.entries(flowHashmapByType)) {
       outputData[type] = Object.values(typeHashmap);
     }
     return outputData;
-  }
-
-  /**
-   * Iterate over all flows to check for any that populate additional _generated flows
-   * that should be extracted to top-level
-   */
-  private populateGeneratedFlows(flowsByType: IFlowHashmapByType) {
-    // handle any additional methods that operate on full list of processed flows,
-    // e.g. populating additional generated flows
-    for (const typeFlows of Object.values(flowsByType)) {
-      for (const { _generated, ...flow } of Object.values(typeFlows)) {
-        if (_generated) {
-          // remove _generated field from flow
-          flowsByType[flow.flow_type][flow.flow_name] = flow;
-          // populate generated to main list, ensure generated flows are also fully processed
-          for (const generatedFlows of Object.values(_generated)) {
-            for (const generatedFlow of Object.values(generatedFlows)) {
-              flowsByType[generatedFlow.flow_type] ??= {};
-              if (flowsByType[generatedFlow.flow_type][generatedFlow.flow_name]) {
-                this.logger.error({
-                  message: "Generated flow will override existing flow",
-                  details: [generatedFlow.flow_type, generatedFlow.flow_name],
-                });
-              }
-              const processed = this.processInput(JSON.parse(JSON.stringify(generatedFlow)));
-              flowsByType[generatedFlow.flow_type][generatedFlow.flow_name] = processed;
-            }
-          }
-        }
-      }
-    }
-    return flowsByType;
   }
 
   public shouldUseCachedEntry(

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -64,10 +64,8 @@ export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithDat
 
   public updateProcessedFlowHashmap(flow: FlowTypes.FlowTypeWithData) {
     const { flow_name, flow_type, _xlsxPath } = flow;
-    if (!this.processedFlowHashmap[flow_type]) {
-      this.processedFlowHashmap[flow_type] = {};
-      this.processedFlowHashmapWithMeta[flow_type] = {};
-    }
+    this.processedFlowHashmap[flow_type] ??= {};
+    this.processedFlowHashmapWithMeta[flow_type] ??= {};
     // NOTE - duplicate flows are identified up during main converter
     this.processedFlowHashmap[flow_type][flow_name] = flow.rows;
     this.processedFlowHashmapWithMeta[flow_type][flow_name] = flow;

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.spec.ts
@@ -4,9 +4,9 @@ import { DataPipeParser } from "./data_pipe.parser";
 import { FlowParserProcessor } from "../flowParser";
 import { MockJsonFileCache } from "../../../cacheStrategy/jsonFile.mock";
 
-const testInputSources = {
+const getTestData = () => ({
   data_list: { test_data_list: [{ id: 1 }, { id: 2 }, { id: 3 }] },
-};
+});
 
 /** yarn workspace scripts test -t data_pipe.parser.spec.ts */
 describe("data_pipe Parser", () => {
@@ -15,9 +15,9 @@ describe("data_pipe Parser", () => {
     // HACK - setup parser with in-memory cache to avoid writing to disk
     parser = new DataPipeParser(new FlowParserProcessor(null as any));
     parser.flowProcessor.cache = new MockJsonFileCache();
+    parser.flowProcessor.processedFlowHashmap = getTestData();
   });
   it("Populates generated data lists", async () => {
-    parser.flowProcessor.processedFlowHashmap = testInputSources;
     parser.run({
       flow_name: "test_pipe_parse",
       flow_type: "data_pipe",
@@ -41,14 +41,13 @@ describe("data_pipe Parser", () => {
     await parser.flowProcessor.queue.onIdle();
 
     expect(parser.flowProcessor.processedFlowHashmap.data_list).toEqual({
-      ...testInputSources.data_list,
+      ...getTestData().data_list,
       test_output_1: [{ id: 2 }, { id: 3 }],
       test_output_2: [{ id: 3 }],
     });
   });
 
   it("Allows outputs from one pipe to be used in another", async () => {
-    parser.flowProcessor.processedFlowHashmap = testInputSources;
     const ops1: IDataPipeOperation[] = [
       {
         input_source: "test_data_list",

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.ts
@@ -3,6 +3,9 @@ import { DataPipe } from "shared/src/models/dataPipe";
 import { DefaultParser } from "./default.parser";
 
 export class DataPipeParser extends DefaultParser<FlowTypes.DataPipeFlow> {
+  /** local hashmap of generated outputs. Used for tests  */
+  private outputHashmap: { [flow_name: string]: { [output_name: string]: any } } = {};
+
   /** If extending the class add additional postprocess pipeline here */
 
   public postProcessFlow(flow: FlowTypes.DataPipeFlow): FlowTypes.DataPipeFlow {
@@ -18,6 +21,9 @@ export class DataPipeParser extends DefaultParser<FlowTypes.DataPipeFlow> {
     }
     try {
       const outputs = pipe.run();
+      // HACK - populate to output hashmap for use in tests. Clone output due to deep nest issues
+      this.outputHashmap[flow.flow_name] = JSON.parse(JSON.stringify(outputs));
+
       this.populateGeneratedFlows(outputs);
       // As the populated flows will be passed directly to the processor queue
       // can just return undefined so that the data pipe will not be stored in outputs

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.ts
@@ -29,8 +29,6 @@ export class DataPipeParser extends DefaultParser<FlowTypes.DataPipeFlow> {
   }
 
   private populateGeneratedFlows(outputs: { [output_name: string]: any[] }) {
-    this.flowProcessor.processedFlowHashmap.data_list ??= {};
-
     for (const [flow_name, rows] of Object.entries(outputs)) {
       const flow: FlowTypes.FlowTypeWithData = {
         flow_name,

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
@@ -268,7 +268,7 @@ class RowProcessor {
     if (this.parent.flow.flow_type === "data_pipe") return this.row;
     // Handle replacements
     const context = { row: this.row };
-    return new TemplatedData({ context, initialValue: this.row }).parse();
+    return new TemplatedData({ context }).parse(this.row);
   }
 
   private removeMetaFields() {

--- a/packages/scripts/src/commands/app-data/postProcess/sheets.ts
+++ b/packages/scripts/src/commands/app-data/postProcess/sheets.ts
@@ -95,7 +95,7 @@ class SheetsPostProcessor {
 
   private extractContentsData(flow: FlowTypes.FlowTypeWithData): FlowTypes.FlowTypeBase {
     // remove rows property (if exists)
-    const { rows, status, _generated, ...keptFields } = flow;
+    const { rows, status, ...keptFields } = flow;
     return keptFields as FlowTypes.FlowTypeBase;
   }
   private sheetsWriteContents(baseFolder: string, contents: ISheetContents) {

--- a/packages/shared/src/models/templatedData/templatedData.spec.ts
+++ b/packages/shared/src/models/templatedData/templatedData.spec.ts
@@ -118,8 +118,8 @@ describe("Templated Data Parsing", () => {
   function execTest(testData: ITestData) {
     const { input, output } = testData;
     it(JSON.stringify(input), () => {
-      const parser = new TemplatedData({ context: context.input, initialValue: input });
-      const parsedValue = parser.parse();
+      const parser = new TemplatedData({ context: context.input });
+      const parsedValue = parser.parse(input);
       expect(parsedValue).toEqual(output);
       // process.nextTick(() => console.log(`      ${JSON.stringify(parsedValue)}\n`));
     });

--- a/packages/shared/src/models/templatedData/templatedData.ts
+++ b/packages/shared/src/models/templatedData/templatedData.ts
@@ -1,6 +1,6 @@
 import { ITemplatedStringVariable } from "../../types";
 import { addStringDelimiters, extractDelimitedTemplateString } from "../../utils/delimiters";
-import { isObjectLiteral } from "../../utils";
+import { isObjectLiteral } from "../../utils/object-utils";
 
 type ITemplatedDataContext = { [prefix: string]: any };
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fix issue where outputs generated from data_pipe or generator operations aren't processed (if output as data_pipe or generator operators)

## Review Notes
As the changes impact the main parser, should ideally test updates against a content repo that has recently been synced to see if there is any content diffs. The only expected change is that `data_pipe` flows should no longer be stored within the generated content (these have already been used to generate the populated data_lists, so aren't useful to the app runtime)

I create a content sync for the latest sheets from master branch on the debug repo at:
https://github.com/IDEMSInternational/app-debug-content/pull/88

Then, using this branch see updated content sync at:
https://github.com/IDEMSInternational/app-debug-content/pull/89

Should also confirm it fixes the issues seen in #2434

## Author Notes
Now that `data_pipe` and `generator` flows are no longer included in final output or git content repo, I'm wondering if we may still want to try and keep some reference to them - maybe just keeping a `_generated_from` property on the list itself as a references to the data_pipe or generator flow that created it? 

We could also consider whether we want to keep generated outputs from data_pipe operations the `generated` data_list subfolder (not sure if the purpose it serves could be better-handled by the proposed `_generated_from` property)

## Dev Notes
The core of the issue is the way that `_generated` flows would be saved to the local flow and then re-populated to the main list at the end of processing. This would fail to trigger any subsequent processing if the generated flow was itself a generator or data_pipe type.

Now, instead of storing lists of `_generated` flows the child data_pipe and generator processor take the outputs and send them back to the main flow processor to process as if they were part of the original list.

The largest part of the code change is actually just with the testing to enable checking the main parent FlowProcessor output from within an individual processor (e.g. data_pipe). This wasn't set up very well for testing as the parent FlowProcessor is tightly coupled with a caching system that writes files to disk - so a new Mock Class was created to substitute in for the jsonFile cache system (to just use an in-memory cache instead). In the future it would be best to try and decouple as much as possible processing logic from disk I/O to make it easier to test and separate concerns a bit more.

## Git Issues

Closes #2434

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
