### PR TITLE
Set custom domain for documentation site

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -4,14 +4,13 @@ on:
     branches:
       - master
   workflow_dispatch:
-    
 jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # Only pull lfs files for documentation folder
         # https://github.com/git-lfs/git-lfs/issues/1351
       - name: Checkout git lfs partial files
@@ -20,13 +19,9 @@ jobs:
         # Github pages fails when expecting LFS, so remove hook
         run: rm .git/hooks/pre-push
       - name: Deploy docs
-        # TODO - check if working on latest or pin to version (rather than commit)
         uses: mhausenblas/mkdocs-deploy-gh-pages@e55ecab6718b449a90ebd4313f1320f9327f1386
-        # Or use mhausenblas/mkdocs-deploy-gh-pages@nomaterial to build without the mkdocs-material theme
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # CUSTOM_DOMAIN: optionaldomain.com
+          CUSTOM_DOMAIN: open-app-builder.com
           CONFIG_FILE: documentation/mkdocs.yml
-          # EXTRA_PACKAGES: build-base
-          # GITHUB_DOMAIN: github.myenterprise.com
           REQUIREMENTS: documentation/requirements.txt


### PR DESCRIPTION
Should prevent the open-app-builder.com site from going down every time there is a commit to the master branch.

The 'documentation-deploy' flow overwrites everything in the 'gh-pages' branch every time there is a push to the master branch - that is why files like CNAME go missing, which causes downtime. There is a setting on the action that generates the site that should set a custom domain name, and this has been set appropriately.

Upgraded the checkout action. Removed commented code and todo.
