### PR TITLE
fix: encrypted deployment set

### DIFF
--- a/packages/scripts/src/commands/deployment/set.ts
+++ b/packages/scripts/src/commands/deployment/set.ts
@@ -68,7 +68,7 @@ export class DeploymentSet {
     }
   }
 
-  private async promptDeploymentSelect() {
+  public async promptDeploymentSelect() {
     const deploymentNames = fs
       .readdirSync(DEPLOYMENTS_PATH, { withFileTypes: true })
       .filter((d) => d.isDirectory())

--- a/packages/scripts/src/commands/deployment/utils.ts
+++ b/packages/scripts/src/commands/deployment/utils.ts
@@ -63,6 +63,7 @@ function parseConfigJson(json: IDeploymentConfigJson) {
 /**
  * Decide if a config needs recompiling by checking if modified timestamps
  * on the .ts and .json files are the same (applied during compilation)
+ * TODO - also consider files from encrypted or other imports (e.g. skins)
  */
 function isConfigUpToDate(tsPath: string, jsonPath: string) {
   const json = fs.readJSONSync(jsonPath) as IDeploymentConfigJson;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fix issue where setting config for first time (e.g CI actions) fails to include encrypted deployment values.

## Review Notes
Should be able to confirm if supabase config loaded in test-preview action

## Dev Notes
The reason deployment config would be loaded before decrypt was to handle the case where the name of the deployment isn't known (in which case the deployment set action prompts name input). I've updated the workflow to add a standalone step to handle ensuring a name is provided (either as a command arg or through prompt), and using that can force deployment to be decrypted before compiling the full deployment json.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
