### PR TITLE
fix(map): scale colour no longer overrides stroke value for vector layers

### DIFF
--- a/src/app/shared/components/template/components/map/map.component.ts
+++ b/src/app/shared/components/template/components/map/map.component.ts
@@ -241,7 +241,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements OnInit {
               color: fill && fill !== "none" ? fill : "transparent",
             }),
             stroke: new Stroke({
-              color: stroke || "black",
+              color: stroke && stroke !== "none" ? stroke : "transparent",
               width: 1,
             }),
           });
@@ -282,7 +282,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements OnInit {
             color: this.getColourForValue(colourScale, value),
           }),
           stroke: new Stroke({
-            color: "black",
+            color: stroke && stroke !== "none" ? stroke : "transparent",
             width: 1,
           }),
         });


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the stroke colour of vector layers would override authored values when a scale fill was applied

## Git Issues

Closes #

