### PR TITLE
fix: app-data evaluator

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -4,7 +4,7 @@ import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
-const cacheVersion = 20241001.2;
+const cacheVersion = 20241024.0;
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {

--- a/packages/shared/src/models/appDataEvaluator/appDataEvaluator.spec.ts
+++ b/packages/shared/src/models/appDataEvaluator/appDataEvaluator.spec.ts
@@ -1,6 +1,6 @@
 import { AppDataEvaluator } from "./appDataEvaluator";
 
-describe("App String Evaluator - String Replacement", () => {
+describe("AppDataEvaluator - String Replacement", () => {
   const evaluator = new AppDataEvaluator();
 
   evaluator.setExecutionContext({
@@ -15,17 +15,28 @@ describe("App String Evaluator - String Replacement", () => {
   it("{nested:[@row.first_name]}", () => {
     expect(evaluator.evaluate({ nested: ["@row.first_name"] })).toEqual({ nested: ["Ada"] });
   });
+
+  it("prefix_{@row.first_name}_suffix", () => {
+    expect(evaluator.evaluate("prefix_{@row.first_name}_suffix")).toEqual("prefix_Ada_suffix");
+  });
 });
 
-describe("App String Evaluator - JS Evaluate", () => {
+describe("AppDataEvaluator - JS Evaluate", () => {
   const evaluator = new AppDataEvaluator();
 
-  evaluator.setExecutionContext({
-    row: { first_name: "Ada", last_name: "Lovelace", number_1: 1, number_2: 2 },
+  beforeEach(() => {
+    evaluator.setExecutionContext({
+      row: { first_name: "Ada", last_name: "Lovelace", number_1: 1, number_2: 2 },
+    });
   });
 
   it("@row.number_1 > @row.number_2", () => {
     expect(evaluator.evaluate("@row.number_1 > @row.number_2")).toEqual(false);
+  });
+
+  it("@row.number_1 > @local.number", () => {
+    evaluator.updateExecutionContext({ local: { number: 2 } });
+    expect(evaluator.evaluate("@row.number_1 > @local.number")).toEqual(false);
   });
 
   it("@row.first_name === 'Ada'", () => {

--- a/packages/shared/src/models/appDataEvaluator/appDataEvaluator.ts
+++ b/packages/shared/src/models/appDataEvaluator/appDataEvaluator.ts
@@ -1,7 +1,7 @@
 import { JSEvaluator } from "../jsEvaluator/jsEvaluator";
 import { TemplatedData } from "../templatedData/templatedData";
 import { isObjectLiteral } from "../../utils/object-utils";
-import { addJSDelimeters } from "../../utils/delimiters";
+import { addJSDelimiters } from "../../utils/delimiters";
 
 /** Variable context is stored in namespaces, e.g. `{item:{key:'value'},field:{key:'value'}}` */
 type IContext = { [nameSpace: string]: { [field: string]: any } };
@@ -37,7 +37,12 @@ export class AppDataEvaluator {
     this.templatedData.updateContext(context);
   }
   public updateExecutionContext(update: IContext) {
-    this.setExecutionContext({ ...this.context, update });
+    this.setExecutionContext({ ...this.context, ...update });
+  }
+
+  /** Wrapper around templatedData method to list all variables within data **/
+  public listContextVariables(data: any, prefixes: string[]) {
+    return this.templatedData.listContextVariables(data, prefixes);
   }
 
   /**
@@ -97,13 +102,30 @@ export class AppDataEvaluator {
    * "Hello Ada"
    */
   private evaluateExpression(expression: string) {
-    try {
-      const jsDelimited = addJSDelimeters(expression, Object.keys(this.context));
-      const evaluated = this.jsEvaluator.evaluate(jsDelimited, this.context);
-      return evaluated;
-    } catch (error) {
-      const parsed = this.templatedData.parse(expression);
-      return parsed;
+    if (this.shouldEvaluateJS(expression)) {
+      try {
+        const jsDelimited = addJSDelimiters(expression, Object.keys(this.context));
+        const evaluated = this.jsEvaluator.evaluate(jsDelimited, this.context);
+        return evaluated;
+      } catch (error) {
+        // Ignore errors as may be intended as templated data (will attempt next)
+      }
     }
+    // If error or if not evaluated in JS continue as templated data replacement
+    const parsed = this.templatedData.parse(expression);
+    return parsed;
+  }
+
+  private shouldEvaluateJS(expression: string) {
+    // HACK - assume any expressions that have been manually delimited are likely
+    // intended as string replacements, I.E.
+    // JS:       `{@row.name}_suffix` -> this.Ada_suffix -> undefined
+    // Template: `{@row.name}_suffix` -> "Ada_suffix"
+    for (const prefix of Object.keys(this.context)) {
+      if (expression.includes(`{@${prefix}.`)) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/packages/shared/src/utils/delimiters.spec.ts
+++ b/packages/shared/src/utils/delimiters.spec.ts
@@ -6,7 +6,7 @@ interface IDelimitedTestData {
   delimited: string;
 }
 
-const prefixes = ["row"];
+const prefixes = ["row", "local"];
 const stringDelimiterTests: IDelimitedTestData[] = [
   // basic
   {
@@ -17,6 +17,11 @@ const stringDelimiterTests: IDelimitedTestData[] = [
   {
     input: "@row.first_name @row.last_name",
     delimited: "{@row.first_name} {@row.last_name}",
+  },
+  // mixed contexts
+  {
+    input: "@row.first_name @local.name",
+    delimited: "{@row.first_name} {@local.name}",
   },
   // nested
   {
@@ -40,6 +45,9 @@ interface IParseTestData {
   extracted: ITemplatedStringVariable;
 }
 
+/**
+ * yarn workspace shared test --filter "addStringDelimiters"
+ */
 describe("addStringDelimiters", () => {
   // Test individual string parsing
   for (const testData of stringDelimiterTests) {
@@ -60,21 +68,27 @@ describe("addStringDelimiters", () => {
 });
 
 const jsDelimterTests: IDelimitedTestData[] = [
-  // nested
-  {
-    input: "@row.@row.first_name",
-    delimited: "this.row[this.row.first_name]",
-  },
-
   // basic
   {
     input: "@row.first_name",
     delimited: "this.row.first_name",
   },
+
   // expression
   {
     input: "@row.first_name === 'Ada'",
     delimited: "this.row.first_name === 'Ada'",
+  },
+  // mixed context expressions
+  {
+    input: "@row.number_1 > @local.number_2",
+    delimited: "this.row.number_1 > this.local.number_2",
+  },
+
+  // nested
+  {
+    input: "@row.@row.first_name",
+    delimited: "this.row[this.row.first_name]",
   },
 
   // nested with braces
@@ -105,7 +119,7 @@ describe("addJSDelimiters", () => {
     const { input, delimited } = testData;
 
     it(JSON.stringify(input), () => {
-      const parsedValue = Delimiters.addJSDelimeters(input, prefixes);
+      const parsedValue = Delimiters.addJSDelimiters(input, prefixes);
       expect(parsedValue).toEqual(delimited);
       process.nextTick(() => console.log(`      ${JSON.stringify(parsedValue)}\n`));
       // NOTE - in case of errors additional tests can be carried out just on intermediate

--- a/packages/shared/src/utils/delimiters.ts
+++ b/packages/shared/src/utils/delimiters.ts
@@ -33,9 +33,9 @@ export function addStringDelimiters(value: string, contextPrefixes: string[], fi
         replaceCount++;
       }
     }
-    if (firstPass) {
-      return addStringDelimiters(value, contextPrefixes, false);
-    }
+  }
+  if (firstPass) {
+    return addStringDelimiters(value, contextPrefixes, false);
   }
   return value;
 }
@@ -48,17 +48,18 @@ export function addStringDelimiters(value: string, contextPrefixes: string[], fi
  * // output
  * "this.row[this.row.lookup_variable]"
  */
-export function addJSDelimeters(value: string, contextPrefixes: string[]) {
+export function addJSDelimiters(value: string, contextPrefixes: string[]) {
   const delimited = addStringDelimiters(value, contextPrefixes);
   let replaced = delimited;
   // inner variables, e.g. `@row.@row.inner_variable`
-  // E.g. Regex /\.{@(row.[a-z0-9_.]*)}/gi
-  const innerRegex = new RegExp(`\\.{@(${contextPrefixes.join("|")}.[a-z0-9_.]*)}`, "gi");
-  replaced = replaced.replace(innerRegex, "[this.$1]");
+  // E.g. Regex /\.{@(row|local).([a-z0-9_.]*)}/gi
+  const innerRegex = new RegExp(`\\.{@(${contextPrefixes.join("|")}).([a-z0-9_.]*)}`, "gi");
+  replaced = replaced.replace(innerRegex, "[this.$1.$2]");
+
   // outer variables, e.g. `@row[this.inner_variable]` or `@row.outer_variable`
-  // E.g. Regex /{@(row.[a-z0-9_.\[\]]*)}/gi
-  const outerRegex = new RegExp(`{@(${contextPrefixes.join("|")}.[a-z0-9_.\\[\\]]*)}`, "gi");
-  replaced = replaced.replace(outerRegex, "this.$1");
+  // E.g. Regex /{@(row|local)([a-z0-9_.\[\]]*)}/gi
+  const outerRegex = new RegExp(`{@(${contextPrefixes.join("|")})([a-z0-9_.\\[\\]]*)}`, "gi");
+  replaced = replaced.replace(outerRegex, "this.$1$2");
   return replaced;
 }
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

- Fix regression from #2461 where expressions like `{@row.id}_suffix` would be evaluated as JS (-> `undefined`) instead of templated data (-> `some_id_suffix`) for `data_pipe` append operator
- Fix issue where evaluation would break when using multiple different variable types, e.g. `@row.number > @local.number`
- Update tests to capture new cases

## Review Notes
Should confirm if fixes issue originally outlined in [mattermost thread](https://chat.idems.international/all/pl/krgfwnfdi7yfi8xrd7o53bwhoh)

Should be able to confirm tests passed from github action. 

As for possible knock-ons, it's only the `appendColumns` operator that uses the code, so changes should show up in parser for any given deployment repo that has example content.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
