### PR TITLE
chore: move arrayToHashmap function

### DIFF
--- a/packages/shared/src/utils/file-utils.ts
+++ b/packages/shared/src/utils/file-utils.ts
@@ -247,30 +247,6 @@ export function groupJsonByMultipleKeys<T>(json: T[], keys: string[], joinCharac
   return byKey;
 }
 
-/**
- * Convert an object array into a json object, with keys corresponding to array entries
- * @param keyfield any unique field which all array objects contain to use as hash keys (e.g. 'id')
- * @param handleDuplicateKey optional function to trigger when duplicate hash key entry detected.
- * Should return replacement key to populate instead
- */
-export function arrayToHashmap<T extends object>(
-  arr: T[],
-  keyfield: keyof T,
-  handleDuplicateKey = (k: string) => k
-): { [key: string]: T } {
-  const hashmap: { [key: string]: T } = {};
-  for (const el of arr) {
-    if (el.hasOwnProperty(keyfield)) {
-      let hashKey = el[keyfield] as string;
-      if (hashKey in hashmap) {
-        hashKey = handleDuplicateKey(hashKey);
-      }
-      hashmap[hashKey] = el;
-    }
-  }
-  return hashmap;
-}
-
 export function listFolderNames(folderPath: string) {
   if (!fs.existsSync(folderPath)) {
     return [];

--- a/packages/shared/src/utils/object-utils.spec.ts
+++ b/packages/shared/src/utils/object-utils.spec.ts
@@ -5,6 +5,7 @@ import {
   isObjectLiteral,
   sortJsonKeys,
   toEmptyObject,
+  arrayToHashmap,
 } from "./object-utils";
 
 const MOCK_NESTED_OBJECT = {
@@ -117,5 +118,30 @@ describe("Object Utils", () => {
         }
       )
     ).toEqual(false);
+  });
+  it("arrayToHashmap", () => {
+    const arr = [
+      { id: "id_1", number: 1 },
+      { id: "id_2", number: 2 },
+    ];
+    const res = arrayToHashmap(arr, "id");
+    expect(res).toEqual({
+      id_1: { id: "id_1", number: 1 },
+      id_2: { id: "id_2", number: 2 },
+    });
+  });
+
+  it("arrayToHashmap duplicate key", () => {
+    const arr = [
+      { id: "id_1", number: 1 },
+      { id: "id_2", number: 2 },
+      { id: "id_2", number: 2.1 },
+    ];
+    const res = arrayToHashmap(arr, "id", (k) => `${k}_duplicate`);
+    expect(res).toEqual({
+      id_1: { id: "id_1", number: 1 },
+      id_2: { id: "id_2", number: 2 },
+      id_2_duplicate: { id: "id_2", number: 2.1 },
+    });
   });
 });

--- a/packages/shared/src/utils/object-utils.ts
+++ b/packages/shared/src/utils/object-utils.ts
@@ -104,3 +104,27 @@ export function isEqual(a: any, b: any) {
   console.warn(`[isEqual] could not compare`, a, b);
   return false;
 }
+
+/**
+ * Convert an object array into a json object, with keys corresponding to array entries
+ * @param keyfield any unique field which all array objects contain to use as hash keys (e.g. 'id')
+ * @param handleDuplicateKey optional function to trigger when duplicate hash key entry detected.
+ * Should return replacement key to populate instead
+ */
+export function arrayToHashmap<T extends object>(
+  arr: T[],
+  keyfield: keyof T,
+  handleDuplicateKey = (k: string) => k
+): { [key: string]: T } {
+  const hashmap: { [key: string]: T } = {};
+  for (const el of arr) {
+    if (el.hasOwnProperty(keyfield)) {
+      let hashKey = el[keyfield] as string;
+      if (hashKey in hashmap) {
+        hashKey = handleDuplicateKey(hashKey);
+      }
+      hashmap[hashKey] = el;
+    }
+  }
+  return hashmap;
+}


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Move the `arrayToHashmap` shared util from `file-utils` to `object-utils`. This is required as the `file-utils` contain node-specific logic, and so can't import from the file in web (issues with webpack polyfills for `os`). 
The `object-utils` doesn't contain any node-specific code and makes more sense as the location for this method. 

Also adds basic tests.

## Review notes
I've checked for any files that import the method from `file-utils` however all import from the top-level `shared` so shouldn't have any issues with the moved method.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
