### PR TITLE
feat: screen_orientation action

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation project(':capacitor-filesystem')
     implementation project(':capacitor-local-notifications')
     implementation project(':capacitor-push-notifications')
+    implementation project(':capacitor-screen-orientation')
     implementation project(':capacitor-share')
     implementation project(':capacitor-splash-screen')
     implementation project(':capawesome-capacitor-app-update')

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -40,6 +40,10 @@
 		"classpath": "com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin"
 	},
 	{
+		"pkg": "@capacitor/screen-orientation",
+		"classpath": "com.capacitorjs.plugins.screenorientation.ScreenOrientationPlugin"
+	},
+	{
 		"pkg": "@capacitor/share",
 		"classpath": "com.capacitorjs.plugins.share.SharePlugin"
 	},

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -32,6 +32,9 @@ project(':capacitor-local-notifications').projectDir = new File('../node_modules
 include ':capacitor-push-notifications'
 project(':capacitor-push-notifications').projectDir = new File('../node_modules/@capacitor/push-notifications/android')
 
+include ':capacitor-screen-orientation'
+project(':capacitor-screen-orientation').projectDir = new File('../node_modules/@capacitor/screen-orientation/android')
+
 include ':capacitor-share'
 project(':capacitor-share').projectDir = new File('../node_modules/@capacitor/share/android')
 

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -21,6 +21,7 @@ def capacitor_pods
   pod 'CapacitorFilesystem', :path => '../../node_modules/@capacitor/filesystem'
   pod 'CapacitorLocalNotifications', :path => '../../node_modules/@capacitor/local-notifications'
   pod 'CapacitorPushNotifications', :path => '../../node_modules/@capacitor/push-notifications'
+  pod 'CapacitorScreenOrientation', :path => '../../node_modules/@capacitor/screen-orientation'
   pod 'CapacitorShare', :path => '../../node_modules/@capacitor/share'
   pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'
   pod 'CapawesomeCapacitorAppUpdate', :path => '../../node_modules/@capawesome/capacitor-app-update'

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -32,6 +32,8 @@ PODS:
     - Capacitor
   - CapacitorPushNotifications (6.0.2):
     - Capacitor
+  - CapacitorScreenOrientation (6.0.2):
+    - Capacitor
   - CapacitorShare (6.0.2):
     - Capacitor
   - CapacitorSplashScreen (6.0.2):
@@ -162,6 +164,7 @@ DEPENDENCIES:
   - "CapacitorFirebasePerformance (from `../../node_modules/@capacitor-firebase/performance`)"
   - "CapacitorLocalNotifications (from `../../node_modules/@capacitor/local-notifications`)"
   - "CapacitorPushNotifications (from `../../node_modules/@capacitor/push-notifications`)"
+  - "CapacitorScreenOrientation (from `../../node_modules/@capacitor/screen-orientation`)"
   - "CapacitorShare (from `../../node_modules/@capacitor/share`)"
   - "CapacitorSplashScreen (from `../../node_modules/@capacitor/splash-screen`)"
   - "CapawesomeCapacitorAppUpdate (from `../../node_modules/@capawesome/capacitor-app-update`)"
@@ -218,6 +221,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/local-notifications"
   CapacitorPushNotifications:
     :path: "../../node_modules/@capacitor/push-notifications"
+  CapacitorScreenOrientation:
+    :path: "../../node_modules/@capacitor/screen-orientation"
   CapacitorShare:
     :path: "../../node_modules/@capacitor/share"
   CapacitorSplashScreen:
@@ -239,6 +244,7 @@ SPEC CHECKSUMS:
   CapacitorFirebasePerformance: c806ce7f8270295465c050210d8e8a4ae2dc282e
   CapacitorLocalNotifications: 6bac9e948b2b8852506c6d74abb2cde140250f86
   CapacitorPushNotifications: ccd797926c030acad3d5498ef452c735c90a2c89
+  CapacitorScreenOrientation: 6039dc2ea4a8596b79316709d5727e8bb7e32845
   CapacitorShare: 591ae4693d85686ceb590db8e8b44aa014ec6490
   CapacitorSplashScreen: 250df9ef8014fac5c7c1fd231f0f8b1d8f0b5624
   CapawesomeCapacitorAppUpdate: 3c05b5c8e42f9c6a88d666093406e9336d9bfdb1
@@ -264,6 +270,6 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
 
-PODFILE CHECKSUM: a6362e50008bd5aea904cdd9ec858da94a7f155c
+PODFILE CHECKSUM: 131ec70809fe3dec63113a003a42e6009560dcef
 
 COCOAPODS: 1.15.2

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@capacitor/ios": "^6.0.0",
     "@capacitor/local-notifications": "^6.0.0",
     "@capacitor/push-notifications": "^6.0.0",
+    "@capacitor/screen-orientation": "^6.0.2",
     "@capacitor/share": "^6.0.0",
     "@capacitor/splash-screen": "^6.0.0",
     "@capawesome/capacitor-app-update": "^6.0.0",

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -414,6 +414,7 @@ export namespace FlowTypes {
     "process_template",
     "reset_app",
     "save_to_device",
+    "screen_orientation",
     "set_field",
     "set_item",
     "set_items",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -42,6 +42,7 @@ import { FeedbackService } from "./feature/feedback/feedback.service";
 import { ShareService } from "./shared/services/share/share.service";
 import { LocalStorageService } from "./shared/services/local-storage/local-storage.service";
 import { DeploymentService } from "./shared/services/deployment/deployment.service";
+import { ScreenOrientationService } from "./shared/services/screen-orientation/screen-orientation.service";
 
 @Component({
   selector: "app-root",
@@ -111,7 +112,8 @@ export class AppComponent {
     private appUpdateService: AppUpdateService,
     private remoteAssetService: RemoteAssetService,
     private shareService: ShareService,
-    private fileManagerService: FileManagerService
+    private fileManagerService: FileManagerService,
+    private screenOrientationService: ScreenOrientationService
   ) {
     this.initializeApp();
   }
@@ -249,6 +251,7 @@ export class AppComponent {
         this.feedbackService,
         this.shareService,
         this.fileManagerService,
+        this.screenOrientationService,
       ],
       deferred: [this.analyticsService],
       implicit: [

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.spec.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { ScreenOrientationService } from "./screen-orientation.service";
+
+describe("ScreenOrientationService", () => {
+  let service: ScreenOrientationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ScreenOrientationService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from "@angular/core";
+import { SyncServiceBase } from "../syncService.base";
+import {
+  ScreenOrientation,
+  OrientationLockType,
+  OrientationLockOptions,
+} from "@capacitor/screen-orientation";
+import { TemplateActionRegistry } from "../../components/template/services/instance/template-action.registry";
+
+const ORIENTATION_TYPES: OrientationLockType[] = ["portrait", "landscape"];
+
+@Injectable({
+  providedIn: "root",
+})
+export class ScreenOrientationService extends SyncServiceBase {
+  constructor(private templateActionRegistry: TemplateActionRegistry) {
+    super("Screen Orientation Service");
+    this.initialise();
+  }
+
+  initialise() {
+    this.registerTemplateActionHandlers();
+  }
+
+  private registerTemplateActionHandlers() {
+    this.templateActionRegistry.register({
+      screen_orientation: async ({ args }) => {
+        const [targetOrientation] = args;
+        if (ORIENTATION_TYPES.includes(targetOrientation)) {
+          this.setOrientation(targetOrientation);
+        } else {
+          console.error(`[SCREEN ORIENTATION] - Invalid orientation: ${targetOrientation}`);
+        }
+      },
+    });
+  }
+
+  private async setPortrait() {
+    return await this.setOrientation("portrait");
+  }
+
+  private async setLandscape() {
+    return await this.setOrientation("landscape");
+  }
+
+  private async getOrientation() {
+    return await ScreenOrientation.orientation();
+  }
+
+  private async setOrientation(orientation: OrientationLockType) {
+    return await ScreenOrientation.lock({ orientation });
+  }
+
+  private async unlockOrientation() {
+    return await ScreenOrientation.unlock();
+  }
+}

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -1,10 +1,6 @@
 import { Injectable } from "@angular/core";
 import { SyncServiceBase } from "../syncService.base";
-import {
-  ScreenOrientation,
-  OrientationLockType,
-  OrientationLockOptions,
-} from "@capacitor/screen-orientation";
+import { ScreenOrientation, OrientationLockType } from "@capacitor/screen-orientation";
 import { TemplateActionRegistry } from "../../components/template/services/instance/template-action.registry";
 
 const ORIENTATION_TYPES: OrientationLockType[] = ["portrait", "landscape"];
@@ -35,6 +31,10 @@ export class ScreenOrientationService extends SyncServiceBase {
     });
   }
 
+  private async setOrientation(orientation: OrientationLockType) {
+    return await ScreenOrientation.lock({ orientation });
+  }
+
   private async setPortrait() {
     return await this.setOrientation("portrait");
   }
@@ -45,10 +45,6 @@ export class ScreenOrientationService extends SyncServiceBase {
 
   private async getOrientation() {
     return await ScreenOrientation.orientation();
-  }
-
-  private async setOrientation(orientation: OrientationLockType) {
-    return await ScreenOrientation.lock({ orientation });
   }
 
   private async unlockOrientation() {

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -34,20 +34,4 @@ export class ScreenOrientationService extends SyncServiceBase {
   private async setOrientation(orientation: OrientationLockType) {
     return await ScreenOrientation.lock({ orientation });
   }
-
-  private async setPortrait() {
-    return await this.setOrientation("portrait");
-  }
-
-  private async setLandscape() {
-    return await this.setOrientation("landscape");
-  }
-
-  private async getOrientation() {
-    return await ScreenOrientation.orientation();
-  }
-
-  private async unlockOrientation() {
-    return await ScreenOrientation.unlock();
-  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,6 +2196,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@capacitor/screen-orientation@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@capacitor/screen-orientation@npm:6.0.2"
+  peerDependencies:
+    "@capacitor/core": ^6.0.0
+  checksum: d7e431f9c42373d71d2d6b062ba3fc2fc1e4b034b02166b13c7ba4366e932e61c7558ae6e0429a84a7273f246ea42b23d3ae673ca8a8e7e60517f85d9bd41b22
+  languageName: node
+  linkType: hard
+
 "@capacitor/share@npm:^6.0.0":
   version: 6.0.2
   resolution: "@capacitor/share@npm:6.0.2"
@@ -14955,6 +14964,7 @@ __metadata:
     "@capacitor/ios": ^6.0.0
     "@capacitor/local-notifications": ^6.0.0
     "@capacitor/push-notifications": ^6.0.0
+    "@capacitor/screen-orientation": ^6.0.2
     "@capacitor/share": ^6.0.0
     "@capacitor/splash-screen": ^6.0.0
     "@capawesome/capacitor-app-update": ^6.0.0


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new template action to lock screen orientation to either portrait or landscape.
- Action ID: `screen_orientation`
- Possible arguments: `portrait` | `landscape`
- Example: `click | screen_orientation: portrait;`

This is a step towards resolving #2114. As mentioned in [a comment on that issue](https://github.com/IDEMSInternational/open-app-builder/issues/2114#issuecomment-1791018473), we would like to be able to set the screen orientation of a given template at the level of metadata on templates, and have the orientation set automatically upon navigation. However, it made sense to me to break this down into steps: this PR adds the base functionality to lock the screen orientation, exposed to an action, and a follow-up will handle setting the orientation automatically on route changes based on template metadata.

## Testing

This feature is only available on mobile devices – tere is no screen orientation API on web, and so attempting to run this action on desktop browsers will throw an error:

<img width="360" alt="Screenshot 2024-10-30 at 15 03 03" src="https://github.com/user-attachments/assets/fb9b435f-1842-47c3-9bb0-248320cb680e">

For testing, the android test build action doesn't appear to be working at the moment (first identified [here](https://github.com/IDEMSInternational/open-app-builder/pull/2492#pullrequestreview-2403053785)), but I've manually uploaded builds to appetize: see [iOS](https://appetize.io/apps/ios/international.idems.debug-app) and [Android](https://appetize.io/apps/android/international.idems.debug_app) versions. And I've included screen recordings below.


## Git Issues

Closes #

## Screenshots/Videos

### Demos of [feature_screen_orientation](https://docs.google.com/spreadsheets/d/13KnDdmBicPDZaWFNnlIck7WNMLlM02HjD0-_UiqZ4z8/edit?gid=569531329#gid=569531329) template:

#### Android (appetize)

https://github.com/user-attachments/assets/a69de701-6e56-4204-a532-ef632753667e

#### ios

https://github.com/user-attachments/assets/773022c1-e457-4f7a-b23c-e06e6847fb48

