### PR TITLE
chore: make legend scales horizontal; move legend to under map

### DIFF
--- a/src/app/shared/components/template/components/map/map.component.scss
+++ b/src/app/shared/components/template/components/map/map.component.scss
@@ -6,40 +6,42 @@ $map-height: 400px;
 
 .map-and-legend-container {
   display: flex;
+  flex-direction: column;
   width: 100%;
+  min-height: $map-height;
 }
 
 .map {
-  flex: 1;
   height: $map-height;
   min-width: 0;
 }
 
 .legend {
   display: flex;
+  flex-direction: column;
   width: auto;
-  height: $map-height;
   padding: 0 12px;
 
   .legend-item {
     display: flex;
     flex-direction: column;
+    padding: 8px 0;
     .title {
-      max-width: 100px;
-      margin-bottom: 12px;
+      width: 100%;
+      margin-bottom: 8px;
     }
 
     .scale-container {
       height: 100%;
       display: flex;
-      flex-direction: row-reverse;
+      flex-direction: column-reverse;
       align-items: flex-start;
       justify-content: flex-end;
 
       .scale-labels {
-        height: 100%;
+        width: 100%;
         display: flex;
-        flex-direction: column;
+        flex-direction: row-reverse;
         justify-content: space-between;
         .scale-label {
           font-size: var(--font-size-text-tiny);
@@ -49,9 +51,9 @@ $map-height: 400px;
     }
 
     .colour-scale {
-      width: 12px;
-      margin-right: 12px;
-      height: 100%;
+      width: 100%;
+      height: 12px;
+      margin-bottom: 8px;
     }
   }
 }

--- a/src/app/shared/components/template/components/map/map.component.ts
+++ b/src/app/shared/components/template/components/map/map.component.ts
@@ -346,7 +346,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements OnInit {
       setCustomLayerProperties;
 
     const cssGradientFill = scaleColours
-      ? `linear-gradient(0deg, ${scaleColours.join(", ")})`
+      ? `linear-gradient(90deg, ${scaleColours.join(", ")})`
       : undefined;
     layer.setVisible(visible === undefined || !!visible);
     if (opacity || opacity === 0) layer.setOpacity(opacity);


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Moves the legend to display under the map (previously it displayed on right hand side)
- Makes the legend scale bars be displayed horizontally (previously vertically)

## Git Issues

Closes https://github.com/IDEMSInternational/conflict-forecast-content/issues/9

## Screenshots/Videos

[comp_map](https://docs.google.com/spreadsheets/d/1KgLTrFhqZdGhcSk6Zt0KQoy2mYf7NCqhCJz_zS0KEYw/edit?gid=569531329#gid=569531329) template:

<img width="800" alt="Screenshot 2024-10-30 at 15 30 03" src="https://github.com/user-attachments/assets/c0cb957f-b769-41f4-ac12-e8517b657026">

