### PR TITLE
feat: add slider/filter fucntionality, toggled on for a given layer via the scale_slider property

### DIFF
--- a/src/app/shared/components/template/components/map/map.component.html
+++ b/src/app/shared/components/template/components/map/map.component.html
@@ -9,6 +9,19 @@
               {{ mapLayer.get("scaleTitle") }}
             </div>
             <div class="scale-container">
+              @if (mapLayer.get("scaleSlider")) {
+                <ion-range
+                  [dualKnobs]="true"
+                  [value]="{ lower: 0, upper: 100 }"
+                  [ngStyle]="{ '--bar-background': mapLayer.get('gradientFill') }"
+                  (ionChange)="handleSliderChange($event, mapLayer)"
+                ></ion-range>
+              } @else {
+                <div
+                  class="colour-scale"
+                  [ngStyle]="{ 'background-image': mapLayer.get('gradientFill') }"
+                ></div>
+              }
               <div class="scale-labels">
                 <div class="scale-label max">
                   {{ mapLayer.get("scaleMax") }}
@@ -17,10 +30,6 @@
                   {{ mapLayer.get("scaleMin") }}
                 </div>
               </div>
-              <div
-                class="colour-scale"
-                [ngStyle]="{ 'background-image': mapLayer.get('gradientFill') }"
-              ></div>
             </div>
           </div>
         }

--- a/src/app/shared/components/template/components/map/map.component.scss
+++ b/src/app/shared/components/template/components/map/map.component.scss
@@ -34,7 +34,7 @@ $map-height: 400px;
     .scale-container {
       height: 100%;
       display: flex;
-      flex-direction: column-reverse;
+      flex-direction: column;
       align-items: flex-start;
       justify-content: flex-end;
 
@@ -54,6 +54,17 @@ $map-height: 400px;
       width: 100%;
       height: 12px;
       margin-bottom: 8px;
+    }
+
+    ion-range {
+      width: 100%;
+      // position: absolute;
+      bottom: 0px;
+      --bar-background: none;
+      --bar-background-active: none;
+      --bar-height: 12px;
+      --knob-background: var(--ion-color-primary);
+      --knob-size: 28px;
     }
   }
 }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Adds a new map layer property, `scale_slider`, which takes a boolean value (default `false`). When true, the scale in the legend gets two slidable handles added, which can be used to set a range to filter which features are visible on the map. See demo below

## Git Issues

Closes #

## Screenshots/Videos
Updated [comp_map_layer_data](https://docs.google.com/spreadsheets/d/1KgLTrFhqZdGhcSk6Zt0KQoy2mYf7NCqhCJz_zS0KEYw/edit?gid=1695224840#gid=1695224840):

<img width="1200" alt="Screenshot 2024-11-01 at 09 24 08" src="https://github.com/user-attachments/assets/4d889b8d-77cc-4b53-b295-564787f9ad18">


https://github.com/user-attachments/assets/09e30683-141d-4c9e-a26b-4b3e7a54f8d5



