### PR TITLE
fix: text bubble component handles markdown

### DIFF
--- a/src/app/shared/components/template/components/text-bubble/text-bubble.component.html
+++ b/src/app/shared/components/template/components/text-bubble/text-bubble.component.html
@@ -5,9 +5,9 @@
 >
   <div class="text-bubble" [attr.data-position]="params.speakerPosition">
     @if (_row.value) {
-      <p class="text">
-        {{ _row.value }}
-      </p>
+      <plh-tmpl-text
+        [row]="{ _nested_name: '', name: '', type: 'text', value: value() }"
+      ></plh-tmpl-text>
     }
     @for (childRow of _row.rows | filterDisplayComponent; track trackByRow($index, childRow)) {
       <plh-template-component

--- a/src/app/shared/components/template/components/text-bubble/text-bubble.component.scss
+++ b/src/app/shared/components/template/components/text-bubble/text-bubble.component.scss
@@ -48,12 +48,17 @@ $imageSize: 64px;
 }
 
 .text-bubble {
-  padding: var(--large-padding);
-  p {
-    line-height: inherit;
-    margin: 0;
-    font-size: var(--font-size-text-large);
-    color: var(--ion-color-primary);
+  padding: var(--small-padding) var(--large-padding);
+
+  // HACK: The `text` component already includes a substantial margin, but when the `text-bubble`
+  // component contains child rows rather than a `value` string, apply a margin around these rows.
+  plh-template-component {
+    &:first-child {
+      margin-top: var(--regular-padding);
+    }
+    &:last-child {
+      margin-bottom: var(--regular-padding);
+    }
   }
 }
 

--- a/src/app/shared/components/template/components/text-bubble/text-bubble.component.scss
+++ b/src/app/shared/components/template/components/text-bubble/text-bubble.component.scss
@@ -48,17 +48,12 @@ $imageSize: 64px;
 }
 
 .text-bubble {
-  padding: var(--small-padding) var(--large-padding);
+  padding: var(--large-padding) var(--large-padding);
 
-  // HACK: The `text` component already includes a substantial margin, but when the `text-bubble`
-  // component contains child rows rather than a `value` string, apply a margin around these rows.
-  plh-template-component {
-    &:first-child {
-      margin-top: var(--regular-padding);
-    }
-    &:last-child {
-      margin-bottom: var(--regular-padding);
-    }
+  // Override default margins of child text component:
+  // handle with padding on this parent element instead
+  plh-tmpl-text {
+    --margin-text: 0;
   }
 }
 

--- a/src/app/shared/components/template/components/text-bubble/text-bubble.component.scss
+++ b/src/app/shared/components/template/components/text-bubble/text-bubble.component.scss
@@ -48,7 +48,7 @@ $imageSize: 64px;
 }
 
 .text-bubble {
-  padding: var(--large-padding) var(--large-padding);
+  padding: var(--large-padding);
 
   // Override default margins of child text component:
   // handle with padding on this parent element instead

--- a/src/app/shared/components/template/components/text/text.component.html
+++ b/src/app/shared/components/template/components/text/text.component.html
@@ -1,6 +1,6 @@
 @if (this._row.value) {
   <div
-    class="large standard normal margin-t-large"
+    class="large standard normal"
     [class]="params.style"
     [ngStyle]="!hasTextValue ? { display: 'none' } : { display: 'block' }"
     [innerHTML]="

--- a/src/app/shared/components/template/components/text/text.component.scss
+++ b/src/app/shared/components/template/components/text/text.component.scss
@@ -1,0 +1,5 @@
+:host {
+  // Default value for top and bottom margins. Can be overridden in parent component
+  // styles if calling the text component as a child of another component
+  --margin-text: 0.75em;
+}

--- a/src/app/shared/components/template/components/text/text.component.ts
+++ b/src/app/shared/components/template/components/text/text.component.ts
@@ -11,7 +11,7 @@ interface ITextParams {
 @Component({
   selector: "plh-tmpl-text",
   templateUrl: "./text.component.html",
-  styleUrls: ["../tmpl-components-common.scss"],
+  styleUrls: ["../tmpl-components-common.scss", "./text.component.scss"],
 })
 export class TmplTextComponent extends TemplateBaseComponent implements OnInit {
   params: Partial<ITextParams> = {};

--- a/src/theme/_typography.scss
+++ b/src/theme/_typography.scss
@@ -8,8 +8,7 @@ h3 {
 }
 
 p {
-  margin-top: var(--margin-text);
-  margin-bottom: var(--margin-text);
+  margin: var(--margin-text, 0.75em) 0;
 }
 
 .standard {

--- a/src/theme/_typography.scss
+++ b/src/theme/_typography.scss
@@ -8,7 +8,8 @@ h3 {
 }
 
 p {
-  margin: 0.75em 0;
+  margin-top: var(--margin-text);
+  margin-bottom: var(--margin-text);
 }
 
 .standard {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Text passed to as the `value` to the `text-bubble` component is now parsed as markdown, in line with other components like `text`.

## Dev notes

It makes sense to me that when we're rendering text as a standard paragraph, we should be calling an instance of the `text` component itself rather than replicating its logic. This PR implements a pattern, previously used in #2460, of
instantiating the text component and passing in an ad-hoc template row.

One issue with this is that we can't directly modify the styles of the child `text` component from the parent component (without using `ViewEncapsulation.none`, `::ng-deep` etc.), making it tricky to apply a minor styling change to the text as it appears in context. Some styling changes can be achieved through the `text` component's existing API, for example we could pass in `text_align: center` to the parameter list of the inline row in the parent component template. 

In the case of the `text-bubble` component, the issue is that the `text` component includes its own substantial top and bottom margins. When combined with the margin applied directly on the text-bubble container, the spacing was too large. But as we want to support the text bubble containing multiple child rows (which could instantiate arbitrary components), removing the default padding would not be sensible. So I've included a hack that consists of reducing the default padding of the text-bubble container, but applying additional padding in the case that it contains child rows. This leaves the styling unchanged for all the examples in the [component demo template](https://docs.google.com/spreadsheets/d/1Yo8X4TrTW2lzEgusDplAQ-y-JJvQOIqXGNLVON1uvRo/edit?gid=569531329#gid=569531329).

## Git Issues

Closes #2435

## Screenshots/Videos

[comp_text_bubble](https://docs.google.com/spreadsheets/d/1Yo8X4TrTW2lzEgusDplAQ-y-JJvQOIqXGNLVON1uvRo/edit?gid=569531329#gid=569531329)

<img width="800" alt="Screenshot 2024-10-31 at 12 12 33" src="https://github.com/user-attachments/assets/49288f43-a246-41d6-909c-37aa86a5ff85">

<img width="360" alt="Screenshot 2024-10-31 at 12 13 02" src="https://github.com/user-attachments/assets/2c7074bb-3718-4157-a8f3-bba7bb7ea743">
