### PR TITLE
Feat: landscape mode

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -43,6 +43,7 @@ import { ShareService } from "./shared/services/share/share.service";
 import { LocalStorageService } from "./shared/services/local-storage/local-storage.service";
 import { DeploymentService } from "./shared/services/deployment/deployment.service";
 import { ScreenOrientationService } from "./shared/services/screen-orientation/screen-orientation.service";
+import { TemplateMetadataService } from "./shared/components/template/services/template-metadata.service";
 
 @Component({
   selector: "app-root",
@@ -90,6 +91,7 @@ export class AppComponent {
     private tourService: TourService,
     private templateService: TemplateService,
     private templateFieldService: TemplateFieldService,
+    private templateMetadataService: TemplateMetadataService,
     private templateProcessService: TemplateProcessService,
     private appEventService: AppEventService,
     private campaignService: CampaignService,
@@ -251,8 +253,10 @@ export class AppComponent {
         this.feedbackService,
         this.shareService,
         this.fileManagerService,
+        this.templateMetadataService,
+        this.screenOrientationService,
       ],
-      deferred: [this.analyticsService, this.screenOrientationService],
+      deferred: [this.analyticsService],
       implicit: [
         this.dbService,
         this.templateTranslateService,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -251,9 +251,8 @@ export class AppComponent {
         this.feedbackService,
         this.shareService,
         this.fileManagerService,
-        this.screenOrientationService,
       ],
-      deferred: [this.analyticsService],
+      deferred: [this.analyticsService, this.screenOrientationService],
       implicit: [
         this.dbService,
         this.templateTranslateService,

--- a/src/app/feature/template/template.page.html
+++ b/src/app/feature/template/template.page.html
@@ -1,17 +1,15 @@
 <ion-content [scrollEvents]="shouldEmitScrollEvents">
-  <plh-template-container
-    *ngIf="templateName"
-    [templatename]="templateName"
-  ></plh-template-container>
-  <div *ngIf="!templateName" class="ion-padding">
+  @if (templateName) {
+  <plh-template-container [templatename]="templateName"></plh-template-container>
+  } @else {
+  <div class="ion-padding">
     <h3>Select a Template</h3>
     <ion-searchbar [(ngModel)]="filterTerm" (ionInput)="search()"></ion-searchbar>
     <ion-list>
-      <ion-item
-        *ngFor="let template of filteredTemplates; trackBy: trackByFn"
-        [routerLink]="template.flow_name"
-        >{{template.flow_name}}</ion-item
-      >
+      @for(template of filteredTemplates; track trackByFn) {
+      <ion-item [routerLink]="template.flow_name">{{template.flow_name}}</ion-item>
+      }
     </ion-list>
   </div>
+  }
 </ion-content>

--- a/src/app/feature/template/template.page.ts
+++ b/src/app/feature/template/template.page.ts
@@ -26,14 +26,15 @@ export class TemplatePage implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.templateName = this.route.snapshot.params.templateName;
-    const allTemplates = this.appDataService.listSheetsByType("template");
-    this.allTemplates = allTemplates.sort((a, b) => (a.flow_name > b.flow_name ? 1 : -1));
-    this.filteredTemplates = allTemplates;
+    if (!this.templateName) {
+      const allTemplates = this.appDataService.listSheetsByType("template");
+      this.allTemplates = allTemplates.sort((a, b) => (a.flow_name > b.flow_name ? 1 : -1));
+      this.filteredTemplates = allTemplates;
+    }
     this.subscribeToAppConfigChanges();
   }
 
   search() {
-    this.allTemplates = this.allTemplates;
     this.filteredTemplates = this.allTemplates.filter(
       (i) => i.flow_name.toLocaleLowerCase().indexOf(this.filterTerm.toLowerCase()) > -1
     );

--- a/src/app/feature/template/template.page.ts
+++ b/src/app/feature/template/template.page.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute } from "@angular/router";
 import { Capacitor } from "@capacitor/core";
 import { FlowTypes, IAppConfig } from "data-models";
 import { Subscription } from "rxjs";
-import { TemplateNavService } from "src/app/shared/components/template/services/template-nav.service";
+import { TemplateMetadataService } from "src/app/shared/components/template/services/template-metadata.service";
 import { AppConfigService } from "src/app/shared/services/app-config/app-config.service";
 import { AppDataService } from "src/app/shared/services/data/app-data.service";
 
@@ -24,13 +24,13 @@ export class TemplatePage implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private appDataService: AppDataService,
     private appConfigService: AppConfigService,
-    private templateNavService: TemplateNavService
+    private templateMetadataService: TemplateMetadataService
   ) {}
 
   async ngOnInit() {
     this.templateName = this.route.snapshot.params.templateName;
     if (this.templateName) {
-      this.templateNavService.applyQueryParamsForTemplate(this.templateName);
+      this.templateMetadataService.applyQueryParamsForTemplate(this.templateName);
     } else {
       const allTemplates = this.appDataService.listSheetsByType("template");
       this.allTemplates = allTemplates.sort((a, b) => (a.flow_name > b.flow_name ? 1 : -1));

--- a/src/app/feature/template/template.page.ts
+++ b/src/app/feature/template/template.page.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute } from "@angular/router";
 import { Capacitor } from "@capacitor/core";
 import { FlowTypes, IAppConfig } from "data-models";
 import { Subscription } from "rxjs";
-import { TemplateMetadataService } from "src/app/shared/components/template/services/template-metadata.service";
 import { AppConfigService } from "src/app/shared/services/app-config/app-config.service";
 import { AppDataService } from "src/app/shared/services/data/app-data.service";
 
@@ -23,15 +22,12 @@ export class TemplatePage implements OnInit, OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private appDataService: AppDataService,
-    private appConfigService: AppConfigService,
-    private templateMetadataService: TemplateMetadataService
+    private appConfigService: AppConfigService
   ) {}
 
-  async ngOnInit() {
+  ngOnInit() {
     this.templateName = this.route.snapshot.params.templateName;
-    if (this.templateName) {
-      this.templateMetadataService.applyQueryParamsForTemplate(this.templateName);
-    } else {
+    if (!this.templateName) {
       const allTemplates = this.appDataService.listSheetsByType("template");
       this.allTemplates = allTemplates.sort((a, b) => (a.flow_name > b.flow_name ? 1 : -1));
       this.filteredTemplates = allTemplates;

--- a/src/app/feature/template/template.page.ts
+++ b/src/app/feature/template/template.page.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from "@angular/router";
 import { Capacitor } from "@capacitor/core";
 import { FlowTypes, IAppConfig } from "data-models";
 import { Subscription } from "rxjs";
+import { TemplateNavService } from "src/app/shared/components/template/services/template-nav.service";
 import { AppConfigService } from "src/app/shared/services/app-config/app-config.service";
 import { AppDataService } from "src/app/shared/services/data/app-data.service";
 
@@ -18,15 +19,19 @@ export class TemplatePage implements OnInit, OnDestroy {
   filteredTemplates: FlowTypes.FlowTypeBase[] = [];
   appConfigChanges$: Subscription;
   shouldEmitScrollEvents: boolean = false;
+
   constructor(
     private route: ActivatedRoute,
     private appDataService: AppDataService,
-    private appConfigService: AppConfigService
+    private appConfigService: AppConfigService,
+    private templateNavService: TemplateNavService
   ) {}
 
-  ngOnInit() {
+  async ngOnInit() {
     this.templateName = this.route.snapshot.params.templateName;
-    if (!this.templateName) {
+    if (this.templateName) {
+      this.templateNavService.applyQueryParamsForTemplate(this.templateName);
+    } else {
       const allTemplates = this.appDataService.listSheetsByType("template");
       this.allTemplates = allTemplates.sort((a, b) => (a.flow_name > b.flow_name ? 1 : -1));
       this.filteredTemplates = allTemplates;
@@ -34,13 +39,13 @@ export class TemplatePage implements OnInit, OnDestroy {
     this.subscribeToAppConfigChanges();
   }
 
-  search() {
+  public search() {
     this.filteredTemplates = this.allTemplates.filter(
       (i) => i.flow_name.toLocaleLowerCase().indexOf(this.filterTerm.toLowerCase()) > -1
     );
   }
 
-  trackByFn(index) {
+  public trackByFn(index) {
     return index;
   }
 

--- a/src/app/shared/components/template/services/instance/template-process.service.ts
+++ b/src/app/shared/components/template/services/instance/template-process.service.ts
@@ -7,6 +7,7 @@ import { TemplateContainerComponent } from "../../template-container.component";
 import { TemplateNavService } from "../template-nav.service";
 import { TemplateService } from "../template.service";
 import { CampaignService } from "src/app/feature/campaign/campaign.service";
+import { TemplateMetadataService } from "../template-metadata.service";
 
 /**
  * The template process service is a slightly hacky wrapper around the template container component so that
@@ -29,6 +30,9 @@ export class TemplateProcessService extends SyncServiceBase {
 
   private get templateService() {
     return getGlobalService(this.injector, TemplateService);
+  }
+  private get templateMetadataService() {
+    return getGlobalService(this.injector, TemplateMetadataService);
   }
   private get templateNavService() {
     return getGlobalService(this.injector, TemplateNavService);
@@ -56,6 +60,7 @@ export class TemplateProcessService extends SyncServiceBase {
     // Create mock template container component
     this.container = new TemplateContainerComponent(
       this.templateService,
+      this.templateMetadataService,
       this.templateNavService,
       this.injector
     );

--- a/src/app/shared/components/template/services/instance/template-process.service.ts
+++ b/src/app/shared/components/template/services/instance/template-process.service.ts
@@ -7,7 +7,6 @@ import { TemplateContainerComponent } from "../../template-container.component";
 import { TemplateNavService } from "../template-nav.service";
 import { TemplateService } from "../template.service";
 import { CampaignService } from "src/app/feature/campaign/campaign.service";
-import { TemplateMetadataService } from "../template-metadata.service";
 
 /**
  * The template process service is a slightly hacky wrapper around the template container component so that
@@ -30,9 +29,6 @@ export class TemplateProcessService extends SyncServiceBase {
 
   private get templateService() {
     return getGlobalService(this.injector, TemplateService);
-  }
-  private get templateMetadataService() {
-    return getGlobalService(this.injector, TemplateMetadataService);
   }
   private get templateNavService() {
     return getGlobalService(this.injector, TemplateNavService);
@@ -60,7 +56,6 @@ export class TemplateProcessService extends SyncServiceBase {
     // Create mock template container component
     this.container = new TemplateContainerComponent(
       this.templateService,
-      this.templateMetadataService,
       this.templateNavService,
       this.injector
     );

--- a/src/app/shared/components/template/services/template-metadata.service.spec.ts
+++ b/src/app/shared/components/template/services/template-metadata.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { TemplateMetadataService } from "./template-metadata.service";
+
+describe("TemplateMetadataService", () => {
+  let service: TemplateMetadataService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TemplateMetadataService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/template/services/template-metadata.service.ts
+++ b/src/app/shared/components/template/services/template-metadata.service.ts
@@ -1,22 +1,22 @@
-import { Injectable, signal, WritableSignal } from "@angular/core";
+import { Injectable, OnDestroy, signal } from "@angular/core";
 import { SyncServiceBase } from "src/app/shared/services/syncService.base";
 import { TemplateService } from "./template.service";
 import { FlowTypes } from "src/app/shared/model";
 import { ActivatedRoute, NavigationEnd, Router } from "@angular/router";
-import { distinctUntilChanged, filter, map } from "rxjs";
+import { distinctUntilChanged, filter, map, Subject, takeUntil } from "rxjs";
 import { Capacitor } from "@capacitor/core";
 
-/** Some authored template metadata values should be stored in the url via query params */
-export interface ITemplateMetadataQueryParams {
-  landscape?: boolean;
-}
-
+/**
+ * Service responsible for handling metadata of the current top-level template,
+ * i.e. parameters authored through the template's parameter_list in a contents list
+ */
 @Injectable({
   providedIn: "root",
 })
-export class TemplateMetadataService extends SyncServiceBase {
-  public parameterList: WritableSignal<FlowTypes.Template["parameter_list"]> = signal({});
+export class TemplateMetadataService extends SyncServiceBase implements OnDestroy {
+  public parameterList = signal<FlowTypes.Template["parameter_list"]>({});
   private enabled: boolean;
+  private destroy$ = new Subject();
 
   constructor(
     private templateService: TemplateService,
@@ -26,8 +26,7 @@ export class TemplateMetadataService extends SyncServiceBase {
 
     // Currently the only watched parameter is for screen orientation,
     // which is only supported on native platforms
-    this.enabled = Capacitor.isNativePlatform();
-
+    this.enabled = !Capacitor.isNativePlatform();
     this.initialise();
   }
 
@@ -40,28 +39,38 @@ export class TemplateMetadataService extends SyncServiceBase {
   private watchRouteForTopLevelTemplate() {
     this.router.events
       .pipe(
-        filter((event) => event instanceof NavigationEnd), // Listen for route changes
+        filter((event) => event instanceof NavigationEnd),
         map(() => this.router.routerState.root),
-        map((root) => {
-          let active = root;
-          while (active.firstChild) {
-            active = active.firstChild;
-          }
-          return active.snapshot.params["templateName"]; // Access the parameter here
-        }),
-        distinctUntilChanged()
+        map((root) => this.extractTemplateNameFromRoute(root)),
+        distinctUntilChanged(),
+        takeUntil(this.destroy$)
       )
       .subscribe(async (templateName: string | undefined) => {
-        console.log("*****templateName*****", templateName);
-        if (!templateName) return this.parameterList.set({});
-        try {
-          const parameterList = await this.templateService.getTemplateMetadata(templateName);
-          this.parameterList.set(parameterList || {});
-          console.log("this.parameterList", this.parameterList());
-        } catch (error) {
-          console.error("[TEMPLATE METADATA] Failed to fetch template parameter_list", error);
-          this.parameterList.set({});
-        }
+        await this.updateParameterList(templateName);
       });
+  }
+
+  private extractTemplateNameFromRoute(root: ActivatedRoute): string | undefined {
+    let active = root;
+    while (active.firstChild) {
+      active = active.firstChild;
+    }
+    return active.snapshot.params["templateName"];
+  }
+
+  private async updateParameterList(templateName: string | undefined) {
+    if (!templateName) return this.parameterList.set({});
+    try {
+      const parameterList = await this.templateService.getTemplateMetadata(templateName);
+      this.parameterList.set(parameterList || {});
+    } catch (error) {
+      console.error("[TEMPLATE METADATA] Failed to fetch template parameter_list", error);
+      this.parameterList.set({});
+    }
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next(true);
+    this.destroy$.complete();
   }
 }

--- a/src/app/shared/components/template/services/template-metadata.service.ts
+++ b/src/app/shared/components/template/services/template-metadata.service.ts
@@ -1,8 +1,10 @@
-import { Injectable } from "@angular/core";
+import { Injectable, signal, WritableSignal } from "@angular/core";
 import { SyncServiceBase } from "src/app/shared/services/syncService.base";
 import { TemplateService } from "./template.service";
 import { FlowTypes } from "src/app/shared/model";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, NavigationEnd, Router } from "@angular/router";
+import { distinctUntilChanged, filter, map } from "rxjs";
+import { Capacitor } from "@capacitor/core";
 
 /** Some authored template metadata values should be stored in the url via query params */
 export interface ITemplateMetadataQueryParams {
@@ -13,29 +15,53 @@ export interface ITemplateMetadataQueryParams {
   providedIn: "root",
 })
 export class TemplateMetadataService extends SyncServiceBase {
-  route: ActivatedRoute;
+  public parameterList: WritableSignal<FlowTypes.Template["parameter_list"]> = signal({});
+  private enabled: boolean;
 
   constructor(
     private templateService: TemplateService,
     private router: Router
   ) {
     super("TemplateMetadata");
+
+    // Currently the only watched parameter is for screen orientation,
+    // which is only supported on native platforms
+    this.enabled = Capacitor.isNativePlatform();
+
+    this.initialise();
   }
 
-  public async applyQueryParamsForTemplate(templateName: string) {
-    const templateMetadata = await this.templateService.getTemplateMetadata(templateName);
-    await this.updateQueryParamsFromTemplateMetadata(templateMetadata);
+  private initialise() {
+    if (this.enabled) {
+      this.watchRouteForTopLevelTemplate();
+    }
   }
-  public async updateQueryParamsFromTemplateMetadata(
-    templateMetadata: FlowTypes.Template["parameter_list"]
-  ) {
-    const templateMetadataQueryParams: ITemplateMetadataQueryParams = {};
-    templateMetadataQueryParams.landscape = templateMetadata?.landscape || null;
-    this.router.navigate([], {
-      relativeTo: this.route,
-      queryParams: templateMetadataQueryParams,
-      queryParamsHandling: "merge",
-      replaceUrl: true,
-    });
+
+  private watchRouteForTopLevelTemplate() {
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd), // Listen for route changes
+        map(() => this.router.routerState.root),
+        map((root) => {
+          let active = root;
+          while (active.firstChild) {
+            active = active.firstChild;
+          }
+          return active.snapshot.params["templateName"]; // Access the parameter here
+        }),
+        distinctUntilChanged()
+      )
+      .subscribe(async (templateName: string | undefined) => {
+        console.log("*****templateName*****", templateName);
+        if (!templateName) return this.parameterList.set({});
+        try {
+          const parameterList = await this.templateService.getTemplateMetadata(templateName);
+          this.parameterList.set(parameterList || {});
+          console.log("this.parameterList", this.parameterList());
+        } catch (error) {
+          console.error("[TEMPLATE METADATA] Failed to fetch template parameter_list", error);
+          this.parameterList.set({});
+        }
+      });
   }
 }

--- a/src/app/shared/components/template/services/template-metadata.service.ts
+++ b/src/app/shared/components/template/services/template-metadata.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from "@angular/core";
+import { SyncServiceBase } from "src/app/shared/services/syncService.base";
+import { TemplateService } from "./template.service";
+import { FlowTypes } from "src/app/shared/model";
+import { ActivatedRoute, Router } from "@angular/router";
+
+/** Some authored template metadata values should be stored in the url via query params */
+export interface ITemplateMetadataQueryParams {
+  landscape?: boolean;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class TemplateMetadataService extends SyncServiceBase {
+  route: ActivatedRoute;
+
+  constructor(
+    private templateService: TemplateService,
+    private router: Router
+  ) {
+    super("TemplateMetadata");
+  }
+
+  public async applyQueryParamsForTemplate(templateName: string) {
+    const templateMetadata = await this.templateService.getTemplateMetadata(templateName);
+    await this.updateQueryParamsFromTemplateMetadata(templateMetadata);
+  }
+  public async updateQueryParamsFromTemplateMetadata(
+    templateMetadata: FlowTypes.Template["parameter_list"]
+  ) {
+    const templateMetadataQueryParams: ITemplateMetadataQueryParams = {};
+    templateMetadataQueryParams.landscape = templateMetadata?.landscape || null;
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: templateMetadataQueryParams,
+      queryParamsHandling: "merge",
+      replaceUrl: true,
+    });
+  }
+}

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -12,7 +12,7 @@ import {
 } from "../components/layout/popup/popup.component";
 import { ITemplateContainerProps } from "../models";
 import { TemplateContainerComponent } from "../template-container.component";
-import { TemplateService } from "./template.service";
+import { TemplateMetadataService } from "./template-metadata.service";
 
 // Toggle logs used across full service for debugging purposes (there's quite a few and tedious to comment)
 const SHOW_DEBUG_LOGS = false;
@@ -31,7 +31,7 @@ export class TemplateNavService extends SyncServiceBase {
     private location: Location,
     private router: Router,
     private route: ActivatedRoute,
-    private templateService: TemplateService
+    private templateMetadataService: TemplateMetadataService
   ) {
     super("TemplateNav");
   }
@@ -44,23 +44,6 @@ export class TemplateNavService extends SyncServiceBase {
   private openPopupsByName: {
     [templatename: string]: { modal: HTMLIonModalElement; props: ITemplateContainerProps };
   } = {};
-
-  public async applyQueryParamsForTemplate(templateName: string) {
-    const templateMetadata = await this.templateService.getTemplateMetadata(templateName);
-    await this.updateQueryParamsFromTemplateMetadata(templateMetadata);
-  }
-  public async updateQueryParamsFromTemplateMetadata(
-    templateMetadata: FlowTypes.Template["parameter_list"]
-  ) {
-    const templateMetadataQueryParams: ITemplateMetadataQueryParams = {};
-    templateMetadataQueryParams.landscape = templateMetadata?.landscape || null;
-    this.router.navigate([], {
-      relativeTo: this.route,
-      queryParams: templateMetadataQueryParams,
-      queryParamsHandling: "merge",
-      replaceUrl: true,
-    });
-  }
 
   public async handleQueryParamChange(
     params: INavQueryParams,
@@ -134,7 +117,7 @@ export class TemplateNavService extends SyncServiceBase {
     // handle template navigation
     else {
       navTarget = ["template", templatename];
-      this.applyQueryParamsForTemplate(templatename);
+      this.templateMetadataService.applyQueryParamsForTemplate(templatename);
     }
     return this.router.navigate(navTarget, {
       queryParams,
@@ -389,9 +372,4 @@ export interface INavQueryParams {
   popup_child?: string; //
   popup_parent?: string;
   popup_parent_triggered_by?: string; //
-}
-
-/** Templates can add additional query params to the url based on authored metadata */
-export interface ITemplateMetadataQueryParams {
-  landscape?: boolean;
 }

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -12,7 +12,6 @@ import {
 } from "../components/layout/popup/popup.component";
 import { ITemplateContainerProps } from "../models";
 import { TemplateContainerComponent } from "../template-container.component";
-import { TemplateMetadataService } from "./template-metadata.service";
 
 // Toggle logs used across full service for debugging purposes (there's quite a few and tedious to comment)
 const SHOW_DEBUG_LOGS = false;
@@ -30,8 +29,7 @@ export class TemplateNavService extends SyncServiceBase {
     private modalCtrl: ModalController,
     private location: Location,
     private router: Router,
-    private route: ActivatedRoute,
-    private templateMetadataService: TemplateMetadataService
+    private route: ActivatedRoute
   ) {
     super("TemplateNav");
   }
@@ -87,6 +85,8 @@ export class TemplateNavService extends SyncServiceBase {
     const [templatename, key, value] = action.args;
     const nav_parent_triggered_by = action._triggeredBy?.name;
     const queryParams: INavQueryParams = { nav_parent: parentName, nav_parent_triggered_by };
+    // handle direct page or template navigation
+    const navTarget = templatename.startsWith("/") ? [templatename] : ["template", templatename];
 
     // If "dismiss_pop_up" is set to true for the go_to action, dismiss the current popup before navigating away
     if (key === "dismiss_pop_up" && parseBoolean(value)) {
@@ -107,17 +107,6 @@ export class TemplateNavService extends SyncServiceBase {
         // Dismiss open popup (without await to allow rest of nav to proceed await)
         this.dismissPopup(popup_child);
       }
-    }
-
-    let navTarget: any[];
-    // handle direct page navigation
-    if (templatename.startsWith("/")) {
-      navTarget = [templatename];
-    }
-    // handle template navigation
-    else {
-      navTarget = ["template", templatename];
-      this.templateMetadataService.applyQueryParamsForTemplate(templatename);
     }
     return this.router.navigate(navTarget, {
       queryParams,

--- a/src/app/shared/components/template/services/template.service.ts
+++ b/src/app/shared/components/template/services/template.service.ts
@@ -165,6 +165,14 @@ export class TemplateService extends SyncServiceBase {
     }
   }
 
+  public async getTemplateMetadata(templateName: string) {
+    const template = (await this.appDataService.getSheet<FlowTypes.Template>(
+      "template",
+      templateName
+    )) as FlowTypes.Template;
+    return template?.parameter_list;
+  }
+
   /**
    * Check if target template contains any conditional overrides. Evaluate condition and override if satisfied.
    * @param isOverrideTarget indicate if self-referencing override target from override (prevent infinite loop)

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -128,6 +128,11 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
    * ```
    */
   public async forceRerender(full = false, shouldProcess = false) {
+    // ensure query params are applied on rerender, only for top-level templates
+    if (!this.parent) {
+      this.templateNavService.updateQueryParamsFromTemplateMetadata(this.template.parameter_list);
+    }
+
     if (shouldProcess) {
       if (full) {
         console.log("[Force Reload]", this.name);

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -19,7 +19,6 @@ import { TemplateNavService } from "./services/template-nav.service";
 import { TemplateRowService } from "./services/instance/template-row.service";
 import { TemplateService } from "./services/template.service";
 import { getIonContentScrollTop, setElStyleAnimated, setIonContentScrollTop } from "./utils";
-import { TemplateMetadataService } from "./services/template-metadata.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -68,7 +67,6 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
 
   constructor(
     private templateService: TemplateService,
-    private templateMetadataService: TemplateMetadataService,
     private templateNavService: TemplateNavService,
     private injector: Injector,
     // Containers created in headless context may not have specific injectors
@@ -130,13 +128,6 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
    * ```
    */
   public async forceRerender(full = false, shouldProcess = false) {
-    // ensure query params are applied on rerender, only for top-level templates
-    if (!this.parent) {
-      this.templateMetadataService.updateQueryParamsFromTemplateMetadata(
-        this.template.parameter_list
-      );
-    }
-
     if (shouldProcess) {
       if (full) {
         console.log("[Force Reload]", this.name);

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -19,6 +19,7 @@ import { TemplateNavService } from "./services/template-nav.service";
 import { TemplateRowService } from "./services/instance/template-row.service";
 import { TemplateService } from "./services/template.service";
 import { getIonContentScrollTop, setElStyleAnimated, setIonContentScrollTop } from "./utils";
+import { TemplateMetadataService } from "./services/template-metadata.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -67,6 +68,7 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
 
   constructor(
     private templateService: TemplateService,
+    private templateMetadataService: TemplateMetadataService,
     private templateNavService: TemplateNavService,
     private injector: Injector,
     // Containers created in headless context may not have specific injectors
@@ -130,7 +132,9 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   public async forceRerender(full = false, shouldProcess = false) {
     // ensure query params are applied on rerender, only for top-level templates
     if (!this.parent) {
-      this.templateNavService.updateQueryParamsFromTemplateMetadata(this.template.parameter_list);
+      this.templateMetadataService.updateQueryParamsFromTemplateMetadata(
+        this.template.parameter_list
+      );
     }
 
     if (shouldProcess) {

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -1,39 +1,45 @@
-import { effect, Injectable, signal } from "@angular/core";
+import { effect, Injectable } from "@angular/core";
 import { ScreenOrientation, OrientationLockType } from "@capacitor/screen-orientation";
 import { TemplateActionRegistry } from "../../components/template/services/instance/template-action.registry";
-import { ActivatedRoute } from "@angular/router";
 import { Capacitor } from "@capacitor/core";
-import { distinctUntilChanged, filter, map } from "rxjs";
-import { AsyncServiceBase } from "../asyncService.base";
+import { TemplateMetadataService } from "../../components/template/services/template-metadata.service";
+import { SyncServiceBase } from "../syncService.base";
 
 // Supported orientation types
-const ORIENTATION_TYPES: OrientationLockType[] = ["portrait", "landscape"];
+const ORIENTATION_TYPES = ["portrait", "landscape"] as const;
 
 type IOrientationType = (typeof ORIENTATION_TYPES)[number];
 
 @Injectable({
   providedIn: "root",
 })
-export class ScreenOrientationService extends AsyncServiceBase {
-  private orientation = signal<IOrientationType>("portrait");
+export class ScreenOrientationService extends SyncServiceBase {
+  private enabled: boolean;
+
   constructor(
     private templateActionRegistry: TemplateActionRegistry,
-    private route: ActivatedRoute
+    private templateMetadataService: TemplateMetadataService
   ) {
     super("Screen Orientation Service");
-    effect(() => {
-      this.setOrientation(this.orientation());
-    });
-    this.registerInitFunction(this.initialise);
+
+    // TODO: expose a property at deployment config level to enable "landscape_mode" to avoid unnecessary checks
+    // AND/OR: check on init if any templates actually use screen orientation metadata?
+    this.enabled = Capacitor.isNativePlatform();
+
+    if (this.enabled) {
+      effect(() => {
+        const targetOrientation =
+          this.templateMetadataService.parameterList().orientation || "portrait";
+        if (targetOrientation && ORIENTATION_TYPES.includes(targetOrientation)) {
+          this.setOrientation(targetOrientation);
+        }
+      });
+    }
+    this.initialise();
   }
 
   async initialise() {
-    // TODO: expose a property at deployment config level to enable "landscape_mode" to avoid unnecessary checks
-    // AND/OR: check on init if any templates actually use screen orientation metadata?
-    if (Capacitor.isNativePlatform()) {
-      const currentOrientation = await this.getOrientation();
-      this.orientation.set(currentOrientation);
-      this.watchOrientationParam();
+    if (this.enabled) {
       this.registerTemplateActionHandlers();
     }
   }
@@ -51,25 +57,12 @@ export class ScreenOrientationService extends AsyncServiceBase {
     });
   }
 
-  private async setOrientation(orientation: OrientationLockType) {
-    return await ScreenOrientation.lock({ orientation });
+  public async setOrientation(orientation: IOrientationType) {
+    console.log(`[SCREEN ORIENTATION] - Setting to ${orientation}`);
+    return await ScreenOrientation.lock({ orientation: orientation as OrientationLockType });
   }
 
   private async getOrientation() {
     return (await ScreenOrientation.orientation()).type;
-  }
-
-  private watchOrientationParam() {
-    this.route.queryParamMap
-      .pipe(
-        map((params) =>
-          params.get("landscape") === "true" ? "landscape" : ("portrait" as IOrientationType)
-        ),
-        distinctUntilChanged(),
-        filter((targetOrientation) => targetOrientation !== this.orientation())
-      )
-      .subscribe((targetOrientation: OrientationType) => {
-        this.orientation.set(targetOrientation);
-      });
   }
 }

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -7,7 +7,7 @@ import { SyncServiceBase } from "../syncService.base";
 import { environment } from "src/environments/environment";
 
 /** List of possible orientations provided by authors */
-const SCREEN_ORIENTATIONS = ["portrait", "landscape"] as const;
+const SCREEN_ORIENTATIONS = ["portrait", "landscape", "unlock"] as const;
 
 type IScreenOrientation = (typeof SCREEN_ORIENTATIONS)[number];
 
@@ -54,7 +54,7 @@ export class ScreenOrientationService extends SyncServiceBase {
 
     this.lockedOrientation = orientation;
 
-    if (orientation) {
+    if (orientation && orientation !== "unlock") {
       if (SCREEN_ORIENTATIONS.includes(orientation)) {
         console.log(`[SCREEN ORIENTATION] - Lock ${orientation}`);
         return ScreenOrientation.lock({ orientation });

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -1,10 +1,6 @@
 import { Injectable } from "@angular/core";
 import { SyncServiceBase } from "../syncService.base";
-import {
-  ScreenOrientation,
-  OrientationLockType,
-  OrientationLockOptions,
-} from "@capacitor/screen-orientation";
+import { ScreenOrientation, OrientationLockType } from "@capacitor/screen-orientation";
 import { TemplateActionRegistry } from "../../components/template/services/instance/template-action.registry";
 
 const ORIENTATION_TYPES: OrientationLockType[] = ["portrait", "landscape"];
@@ -35,6 +31,10 @@ export class ScreenOrientationService extends SyncServiceBase {
     });
   }
 
+  private async setOrientation(orientation: OrientationLockType) {
+    return await ScreenOrientation.lock({ orientation });
+  }
+
   private async setPortrait() {
     return await this.setOrientation("portrait");
   }
@@ -45,10 +45,6 @@ export class ScreenOrientationService extends SyncServiceBase {
 
   private async getOrientation() {
     return await ScreenOrientation.orientation();
-  }
-
-  private async setOrientation(orientation: OrientationLockType) {
-    return await ScreenOrientation.lock({ orientation });
   }
 
   private async unlockOrientation() {

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -1,20 +1,41 @@
-import { Injectable } from "@angular/core";
+import { effect, Injectable, WritableSignal } from "@angular/core";
 import { SyncServiceBase } from "../syncService.base";
 import { ScreenOrientation, OrientationLockType } from "@capacitor/screen-orientation";
 import { TemplateActionRegistry } from "../../components/template/services/instance/template-action.registry";
+import { ActivatedRoute } from "@angular/router";
+import { Capacitor } from "@capacitor/core";
+import { distinctUntilChanged, filter, map } from "rxjs";
 
+// Supported orientation types
 const ORIENTATION_TYPES: OrientationLockType[] = ["portrait", "landscape"];
+
+type IOrientationType = (typeof ORIENTATION_TYPES)[number];
 
 @Injectable({
   providedIn: "root",
 })
 export class ScreenOrientationService extends SyncServiceBase {
-  constructor(private templateActionRegistry: TemplateActionRegistry) {
+  private orientation: WritableSignal<IOrientationType>;
+  constructor(
+    private templateActionRegistry: TemplateActionRegistry,
+    private route: ActivatedRoute
+  ) {
     super("Screen Orientation Service");
+    effect(() => {
+      console.log(`[SCREEN ORIENTATION] - Orientation: ${this.orientation()}`);
+      this.setOrientation(this.orientation());
+    });
     this.initialise();
   }
 
-  initialise() {
+  async initialise() {
+    // TODO: also check if any templates actually use screen orientation metadata?
+    // Or maybe have a toggle to enable "landscape_mode" at deployment config level
+    if (Capacitor.isNativePlatform()) {
+      const currentOrientation = await this.getOrientation();
+      this.orientation.set(currentOrientation);
+      this.watchOrientationParam();
+    }
     this.registerTemplateActionHandlers();
   }
 
@@ -33,5 +54,23 @@ export class ScreenOrientationService extends SyncServiceBase {
 
   private async setOrientation(orientation: OrientationLockType) {
     return await ScreenOrientation.lock({ orientation });
+  }
+
+  private async getOrientation() {
+    return (await ScreenOrientation.orientation()).type;
+  }
+
+  private watchOrientationParam() {
+    this.route.queryParamMap
+      .pipe(
+        map((params) =>
+          params.get("landscape") === "true" ? "landscape" : ("portrait" as IOrientationType)
+        ),
+        distinctUntilChanged(),
+        filter((targetOrientation) => targetOrientation !== this.orientation())
+      )
+      .subscribe((targetOrientation: OrientationType) => {
+        this.orientation.set(targetOrientation);
+      });
   }
 }

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -34,20 +34,4 @@ export class ScreenOrientationService extends SyncServiceBase {
   private async setOrientation(orientation: OrientationLockType) {
     return await ScreenOrientation.lock({ orientation });
   }
-
-  private async setPortrait() {
-    return await this.setOrientation("portrait");
-  }
-
-  private async setLandscape() {
-    return await this.setOrientation("landscape");
-  }
-
-  private async getOrientation() {
-    return await ScreenOrientation.orientation();
-  }
-
-  private async unlockOrientation() {
-    return await ScreenOrientation.unlock();
-  }
 }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Introduces a new template metadata parameter, `orientation`, which can be set on a particular template through the `parameter_list` on within the content list. Setting `orientation: landscape` for a given template forces the screen orientation to be set to landscape when that template is being displayed. Setting `orientation: portrait` for a given template forces the screen orientation to be set to portrait when that template is being displayed. For all other templates, the screen orientation is unlocked, meaning that it should match the user's native screen orientation settings.

## Testing

As there is no screen orientation API on web, this feature can only be tested on native devices.

See appetize builds:
- [Android](https://appetize.io/apps/android/international.idems.debug_app)
- [ios](https://appetize.io/apps/ios/international.idems.debug-app)

## Git Issues

Closes #2114 

## Screenshots/Videos

See [feature_screen_orientation](https://docs.google.com/spreadsheets/d/1trodkUN5eM0xFnrHfNbfB8lhv25PwvQw3RukuLFKpfY/edit?gid=3937162#gid=3937162):
<img width="640" alt="Screenshot 2024-11-07 at 11 31 29" src="https://github.com/user-attachments/assets/7893f4ad-15ad-47d3-87ba-a300eaf72bfa">

[feature_screen_orientation](https://docs.google.com/spreadsheets/d/1trodkUN5eM0xFnrHfNbfB8lhv25PwvQw3RukuLFKpfY/edit?gid=569531329#gid=569531329):
<img width="640" alt="Screenshot 2024-11-07 at 11 32 04" src="https://github.com/user-attachments/assets/f3a5f7ad-c801-46c1-ba7e-fd9727eab9ef">

Android:


https://github.com/user-attachments/assets/4b134df5-7913-499c-8233-96c4f9a232b9




iOS:
Note that on iOS, the user may need to physically rotate their device in order for the "unlocked" screen orientation to take effect, for example when navigating away from a template that enforces a landscape orientation. 

Appetize:


https://github.com/user-attachments/assets/dcaffa57-df17-49c4-ad1a-76a7d4e920d4



Simluator:


https://github.com/user-attachments/assets/083c32d4-f440-4a91-8050-e40198b13ccd



