### PR TITLE
ci: fix test-appetize action trigger

### DIFF
--- a/.github/workflows/reusable-appetize.yml
+++ b/.github/workflows/reusable-appetize.yml
@@ -22,7 +22,9 @@ env:
 
 
 on:
- workflow_call:
+  pull_request:
+    types: [labeled, synchronize]
+  workflow_call:
 
 jobs:
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow-up to #2200, this PR reinstates the PR label trigger such that the `test-appetize` action will be run if the `test - appetize` label is added to a PR.

As noted in #2200, an `APPETIZE_APP_KEY` secret must be added to the targeted content repo. This is the "Build Identifier", i.e. the last section of the URL path, `https://appetize.io/app/{buildId}`, see [official appetize docs](https://docs.appetize.io/platform/sharing-apps#build-identifier). This can only be obtained after an initial build has been uploaded manually to appetize. I have update the debug content repo accordingly.

## Git Issues

Closes #

## Screenshots/Videos
