### PR TITLE
style: make border default gray for professional and plh_kids_kw themes

### DIFF
--- a/src/app/shared/components/template/components/accordion/accordion.component.scss
+++ b/src/app/shared/components/template/components/accordion/accordion.component.scss
@@ -1,7 +1,7 @@
 // Create overlapping effect
 ion-accordion {
   background: white;
-  border: 1px solid var(--ion-color-primary);
+  border: var(--ion-border-standard);
   border-radius: 10px;
   margin-top: -12px;
   padding-top: 8px;

--- a/src/app/shared/components/template/components/accordion/accordion.component.scss
+++ b/src/app/shared/components/template/components/accordion/accordion.component.scss
@@ -1,7 +1,7 @@
 // Create overlapping effect
 ion-accordion {
   background: white;
-  border: var(--ion-border-standard);
+  border: var(--border-standard);
   border-radius: 10px;
   margin-top: -12px;
   padding-top: 8px;

--- a/src/app/shared/components/template/components/audio/audio.component.scss
+++ b/src/app/shared/components/template/components/audio/audio.component.scss
@@ -4,7 +4,7 @@ $control-background: var(--audio-control-background, var(--ion-color-primary-500
 
 .container-player[data-variant~="compact"] {
   background: white;
-  border: var(--ion-border-standard);
+  border: var(--border-standard);
   box-sizing: border-box;
   box-shadow: var(--ion-default-box-shadow);
   border-radius: var(--ion-border-radius-standard);
@@ -87,7 +87,7 @@ $control-background: var(--audio-control-background, var(--ion-color-primary-500
 
 .container-player[data-variant~="large"] {
   background: var(--ion-color-primary-contrast);
-  border: var(--ion-border-standard);
+  border: var(--border-standard);
   box-sizing: border-box;
   box-shadow: var(--ion-default-box-shadow);
   border-radius: var(--ion-border-radius-standard);
@@ -134,7 +134,7 @@ $control-background: var(--audio-control-background, var(--ion-color-primary-500
       }
 
       ion-range::part(bar) {
-        border: var(--ion-border-thin-standard);
+        border: var(--border-thin-standard);
         height: var(--audio-bar-height);
       }
 

--- a/src/app/shared/components/template/components/combo-box/combo-box-modal/combo-box-modal.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box-modal/combo-box-modal.component.scss
@@ -13,7 +13,7 @@ $background-with-value: var(
   padding: 0;
   .text-box-input {
     background: var(--ion-color-primary-contrast);
-    border: var(--ion-border-standard);
+    border: var(--border-standard);
     border-radius: var(--ion-border-radius-secondary);
     width: 100%;
     min-height: 55px;
@@ -55,7 +55,7 @@ $background-with-value: var(
       min-height: 55px;
       width: 100%;
       background: var(--ion-color-primary-contrast);
-      border: var(--ion-border-standard);
+      border: var(--border-standard);
       border-radius: var(--ion-border-radius-secondary);
       box-shadow: var(--ion-default-box-shadow);
       @include mixins.flex-centered;

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.scss
@@ -8,7 +8,7 @@ $background-with-value: var(
 .open-combobox {
   outline: none;
   width: 100%;
-  border: var(--ion-border-standard);
+  border: var(--border-standard);
   box-sizing: border-box;
   filter: drop-shadow(var(--ion-default-box-shadow));
   border-radius: var(--ion-border-radius-secondary);

--- a/src/app/shared/components/template/components/layout/accordion-section/accordion-section.component.scss
+++ b/src/app/shared/components/template/components/layout/accordion-section/accordion-section.component.scss
@@ -14,7 +14,7 @@ $background-highlight: var(
   .accordion-status {
     @include mixins.medium-square;
     border-radius: var(--ion-border-radius-rounded);
-    border: var(--ion-border-thin-standard);
+    border: var(--border-thin-standard);
     padding: var(--tiny-padding);
     background: var(--ion-color-primary-contrast);
     display: flex;
@@ -43,7 +43,7 @@ $background-highlight: var(
     border-radius: var(--ion-border-radius-standard);
     overflow: hidden;
     padding: var(--small-padding);
-    border: var(--ion-border-thin-standard);
+    border: var(--border-thin-standard);
     transition: max-height 0.4s;
     overflow-y: hidden;
     &.completed {

--- a/src/app/shared/components/template/components/layout/display-grid/display-grid.component.scss
+++ b/src/app/shared/components/template/components/layout/display-grid/display-grid.component.scss
@@ -1,4 +1,4 @@
-$border: var(-border-standard);
+$border: var(--border-standard);
 $border-radius: var(--ion-border-radius-standard, 15px);
 
 .display-grid {

--- a/src/app/shared/components/template/components/layout/display-grid/display-grid.component.scss
+++ b/src/app/shared/components/template/components/layout/display-grid/display-grid.component.scss
@@ -1,4 +1,4 @@
-$border: var(--ion-border-standard);
+$border: var(-border-standard);
 $border-radius: var(--ion-border-radius-standard, 15px);
 
 .display-grid {

--- a/src/app/shared/components/template/components/number-selector/number-selector.component.scss
+++ b/src/app/shared/components/template/components/number-selector/number-selector.component.scss
@@ -2,7 +2,7 @@
 .container {
   width: calc(100% - 10px);
   background: var(--ion-color-primary-contrast);
-  border: var(--ion-border-standard);
+  border: var(--border-standard);
   box-shadow: var(--ion-default-box-shadow);
   border-radius: var(--ion-border-radius-secondary);
   @include mixins.flex-space-between;
@@ -24,7 +24,7 @@
     --background: transparent;
     --box-shadow: none;
     border-radius: var(--ion-border-radius-rounded);
-    border: var(--ion-border-standard);
+    border: var(--border-standard);
     @include mixins.tiny-square;
     @include mixins.flex-centered;
     .line {

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.scss
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.scss
@@ -4,7 +4,7 @@ $background-selected: var(
   --radio-group-background-selected,
   var(--gradient-primary-light-vertical)
 );
-$border: var(--ion-border-standard);
+$border: var(--border-standard);
 $border-radius: var(--ion-border-radius-standard);
 $text-size: var(--radio-button-font-size, 1.25rem);
 $text-color: var(--radio-button-font-color, var(--ion-color-primary));

--- a/src/app/shared/components/template/components/radio-group/radio-group.component.scss
+++ b/src/app/shared/components/template/components/radio-group/radio-group.component.scss
@@ -96,7 +96,7 @@ img {
         }
         .checked {
           transition: 0.3s linear;
-          border: var(--ion-border-standard);
+          border: var(--border-standard);
           box-shadow: var(--ion-default-box-shadow);
         }
       }
@@ -110,7 +110,7 @@ img {
   max-width: fit-content;
   min-width: 100%;
   box-shadow: var(--ion-default-box-shadow);
-  border: var(--ion-border-standard);
+  border: var(--border-standard);
   color: var(--ion-color-primary);
   background: var(--ion-color-primary-contrast);
 }

--- a/src/app/shared/components/template/components/slider/slider.component.scss
+++ b/src/app/shared/components/template/components/slider/slider.component.scss
@@ -6,7 +6,7 @@ $ui-color: var(--slider-ui-color, var(--ion-color-primary-700));
   min-width: 100%;
   padding: var(--regular-padding) 0 var(--regular-padding) var(--regular-padding);
   background: var(--ion-color-primary-contrast);
-  border: var(--ion-border-standard);
+  border: var(--border-standard);
   box-sizing: border-box;
   box-shadow: var(--ion-default-box-shadow);
   border-radius: var(--ion-border-radius-secondary);

--- a/src/app/shared/components/template/components/text-area/text-area.component.scss
+++ b/src/app/shared/components/template/components/text-area/text-area.component.scss
@@ -1,7 +1,7 @@
 .wrapper {
   .text_area {
     background: var(--ion-color-primary-contrast);
-    border: var(--ion-border-standard);
+    border: var(--border-standard);
     font-size: var(--text-box-font-size);
     color: var(--ion-color-primary);
     font-weight: var(--font-weight-bold);

--- a/src/app/shared/components/template/components/text-box/text-box.component.scss
+++ b/src/app/shared/components/template/components/text-box/text-box.component.scss
@@ -1,7 +1,7 @@
 .wrapper {
   .text-box-input {
     background: var(--ion-color-primary-contrast);
-    border: var(--ion-border-standard);
+    border: var(--border-standard);
     width: 100%;
     height: var(--text-box-height);
     font-size: var(--text-box-font-size);

--- a/src/app/shared/components/template/components/tile-component/tile-component.component.scss
+++ b/src/app/shared/components/template/components/tile-component/tile-component.component.scss
@@ -50,7 +50,7 @@ $background-secondary-light: var(
     // Note - CC 2021-12-21 - Currently not in use in any templates, but keeping in case we want
     // to expose as a parameter option in the future
     .circle-border {
-      border: var(--ion-border-light-thicker);
+      border: var(--ion-border-standard);
       --border-radius: var(--ion-border-radius-rounded);
       border-radius: var(--ion-border-radius-rounded);
     }

--- a/src/app/shared/components/template/components/tile-component/tile-component.component.scss
+++ b/src/app/shared/components/template/components/tile-component/tile-component.component.scss
@@ -50,7 +50,7 @@ $background-secondary-light: var(
     // Note - CC 2021-12-21 - Currently not in use in any templates, but keeping in case we want
     // to expose as a parameter option in the future
     .circle-border {
-      border: var(--ion-border-standard);
+      border: var(--border-standard);
       --border-radius: var(--ion-border-radius-rounded);
       border-radius: var(--ion-border-radius-rounded);
     }
@@ -75,7 +75,7 @@ $background-secondary-light: var(
   width: 8rem;
   min-height: 7rem;
   border-radius: var(--ion-border-radius-standard);
-  border: var(--ion-border-thin-standard);
+  border: var(--border-thin-standard);
   background: var(--ion-color-primary-contrast);
   text-align: center;
   padding: var(--tiny-padding);

--- a/src/app/shared/components/template/components/timer/timer.component.scss
+++ b/src/app/shared/components/template/components/timer/timer.component.scss
@@ -62,7 +62,7 @@ $button-background: var(--timer-button-background, var(--ion-color-primary-500))
   width: 100%;
   background-color: var(--ion-color-primary-contrast);
   box-sizing: border-box;
-  border: var(--ion-border-standard);
+  border: var(--border-standard);
   box-shadow: var(--ion-default-box-shadow);
   border-radius: var(--ion-border-radius-secondary);
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -160,7 +160,7 @@ $tour-next-button-background: var(
     transform: translate(-50%, -5%);
   }
   .introjs-bullets ul li a {
-    border: var(--ion-border-thin-standard);
+    border: var(--border-thin-standard);
     background: var(--ion-color-primary-contrast);
   }
   .introjs-bullets ul li a.active {
@@ -169,7 +169,7 @@ $tour-next-button-background: var(
   }
 }
 .buttonClass {
-  border: var(--ion-border-thin-standard);
+  border: var(--border-thin-standard);
   padding: 10px 15px;
   border-radius: var(--ion-border-radius-small);
   box-shadow: var(--ion-default-box-shadow);

--- a/src/theme/deployment/components/_display-group.scss
+++ b/src/theme/deployment/components/_display-group.scss
@@ -224,5 +224,5 @@ plh-tmpl-display-group .display-group-wrapper[data-param-style~="parent_point"] 
 .display-group-wrapper[data-param-style~="white_box"] {
   @include essential-tool;
   background: var(--ion-color-primary-contrast);
-  border: var(--ion-border-standard);
+  border: var(--border-standard);
 }

--- a/src/theme/deployment/components/_modal.scss
+++ b/src/theme/deployment/components/_modal.scss
@@ -1,7 +1,7 @@
 ion-modal.combo-box-modal {
   --height: auto;
   --max-height: 90vh;
-  --border-color: var(--ion-border-standard);
+  --border-color: var(--border-color-default);
   --border-radius: var(--ion-border-radius-secondary);
   --border-style: solid;
   --border-width: 2px;

--- a/src/theme/deployment/components/_modal.scss
+++ b/src/theme/deployment/components/_modal.scss
@@ -4,7 +4,7 @@ ion-modal.combo-box-modal {
   --border-color: var(--border-color-default);
   --border-radius: var(--ion-border-radius-secondary);
   --border-style: solid;
-  --border-width: 2px;
+  --border-width: var(--border-width-default);
   --background: var(--ion-color-primary-contrast);
   --max-width: 90vw;
 }

--- a/src/theme/themes/default.scss
+++ b/src/theme/themes/default.scss
@@ -15,7 +15,8 @@
 
       // BORDERS
       border-color-default: var(--ion-color-primary),
-      border-standard: 2px solid var(--border-color-default),
+      border-width-default: 2px,
+      border-standard: var(--border-width-default) solid var(--border-color-default),
       border-thin-standard: 1px solid var(--border-color-default),
       gradient-yellow-vertical:
         linear-gradient(175deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),

--- a/src/theme/themes/default.scss
+++ b/src/theme/themes/default.scss
@@ -14,8 +14,9 @@
       demo-variable: red,
 
       // BORDERS
-      // ion-border-standard: 2px solid var(--ion-color-primary),
-      // ion-border-thin-standard: 1px solid var(--ion-color-primary),
+      border-color-default: var(--ion-color-primary),
+      ion-border-standard: 2px solid var(--border-color-default),
+      ion-border-thin-standard: 1px solid var(--border-color-default),
       gradient-yellow-vertical:
         linear-gradient(175deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),
       gradient-yellow-horizontal:

--- a/src/theme/themes/default.scss
+++ b/src/theme/themes/default.scss
@@ -8,10 +8,14 @@
     $color-secondary: hsl(31, 100%, 57%); // #fa9529
     $page-background: null;
 
-    /** Authoring component overrides **/
+    /** Global and component variables **/
     $variable-overrides: (
-      demo-variable: red,
       // an example variable for illustration purposes
+      demo-variable: red,
+
+      // BORDERS
+      // ion-border-standard: 2px solid var(--ion-color-primary),
+      // ion-border-thin-standard: 1px solid var(--ion-color-primary),
       gradient-yellow-vertical:
         linear-gradient(175deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),
       gradient-yellow-horizontal:

--- a/src/theme/themes/default.scss
+++ b/src/theme/themes/default.scss
@@ -15,8 +15,8 @@
 
       // BORDERS
       border-color-default: var(--ion-color-primary),
-      ion-border-standard: 2px solid var(--border-color-default),
-      ion-border-thin-standard: 1px solid var(--border-color-default),
+      border-standard: 2px solid var(--border-color-default),
+      border-thin-standard: 1px solid var(--border-color-default),
       gradient-yellow-vertical:
         linear-gradient(175deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),
       gradient-yellow-horizontal:

--- a/src/theme/themes/early_family_math.scss
+++ b/src/theme/themes/early_family_math.scss
@@ -8,8 +8,11 @@
     $color-secondary: #b53f94;
     $page-background: white;
 
-    /** Authoring component overrides **/
+    /** Global and component variables **/
     $variable-overrides: (
+      // BORDERS
+      // ion-border-standard: 2px solid var(--ion-color-primary),
+      // ion-border-thin-standard: 1px solid var(--ion-color-primary),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/early_family_math.scss
+++ b/src/theme/themes/early_family_math.scss
@@ -12,7 +12,8 @@
     $variable-overrides: (
       // BORDERS
       // border-color-default: var(--ion-color-primary),
-      // border-standard: 2px solid var(--border-color-default),
+      border-width-default: 2px,
+      // border-standard: var(--border-width-default) solid var(--border-color-default),
       // border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),

--- a/src/theme/themes/early_family_math.scss
+++ b/src/theme/themes/early_family_math.scss
@@ -11,8 +11,9 @@
     /** Global and component variables **/
     $variable-overrides: (
       // BORDERS
-      // ion-border-standard: 2px solid var(--ion-color-primary),
-      // ion-border-thin-standard: 1px solid var(--ion-color-primary),
+      // border-color-default: var(--ion-color-primary),
+      // ion-border-standard: 2px solid var(--border-color-default),
+      // ion-border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/early_family_math.scss
+++ b/src/theme/themes/early_family_math.scss
@@ -12,8 +12,8 @@
     $variable-overrides: (
       // BORDERS
       // border-color-default: var(--ion-color-primary),
-      // ion-border-standard: 2px solid var(--border-color-default),
-      // ion-border-thin-standard: 1px solid var(--border-color-default),
+      // border-standard: 2px solid var(--border-color-default),
+      // border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/pfr.scss
+++ b/src/theme/themes/pfr.scss
@@ -13,8 +13,8 @@
     $variable-overrides: (
       // BORDERS
       // border-color-default: var(--ion-color-primary),
-      // ion-border-standard: 2px solid var(--border-color-default),
-      // ion-border-thin-standard: 1px solid var(--border-color-default),
+      // border-standard: 2px solid var(--border-color-default),
+      // border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/pfr.scss
+++ b/src/theme/themes/pfr.scss
@@ -9,8 +9,11 @@
     $page-background: white;
     $green: #289b4c;
 
-    /** Authoring component overrides **/
+    /** Global and component variables **/
     $variable-overrides: (
+      // BORDERS
+      // ion-border-standard: 2px solid var(--ion-color-primary),
+      // ion-border-thin-standard: 1px solid var(--ion-color-primary),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/pfr.scss
+++ b/src/theme/themes/pfr.scss
@@ -12,8 +12,9 @@
     /** Global and component variables **/
     $variable-overrides: (
       // BORDERS
-      // ion-border-standard: 2px solid var(--ion-color-primary),
-      // ion-border-thin-standard: 1px solid var(--ion-color-primary),
+      // border-color-default: var(--ion-color-primary),
+      // ion-border-standard: 2px solid var(--border-color-default),
+      // ion-border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/pfr.scss
+++ b/src/theme/themes/pfr.scss
@@ -13,7 +13,8 @@
     $variable-overrides: (
       // BORDERS
       // border-color-default: var(--ion-color-primary),
-      // border-standard: 2px solid var(--border-color-default),
+      border-width-default: 2px,
+      // border-standard: var(--border-width-default) solid var(--border-color-default),
       // border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),

--- a/src/theme/themes/plh_facilitator_mx.scss
+++ b/src/theme/themes/plh_facilitator_mx.scss
@@ -8,8 +8,11 @@
     $color-secondary: #ff5e00;
     $page-background: white;
 
-    /** Authoring component overrides **/
+    /** Global and component variables **/
     $variable-overrides: (
+      // BORDERS
+      // ion-border-standard: 2px solid var(--ion-color-primary),
+      // ion-border-thin-standard: 1px solid var(--ion-color-primary),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/plh_facilitator_mx.scss
+++ b/src/theme/themes/plh_facilitator_mx.scss
@@ -12,7 +12,8 @@
     $variable-overrides: (
       // BORDERS
       // border-color-default: var(--ion-color-primary),
-      // border-standard: 2px solid var(--border-color-default),
+      border-width-default: 2px,
+      // border-standard: var(--border-width-default) solid var(--border-color-default),
       // border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),

--- a/src/theme/themes/plh_facilitator_mx.scss
+++ b/src/theme/themes/plh_facilitator_mx.scss
@@ -11,8 +11,9 @@
     /** Global and component variables **/
     $variable-overrides: (
       // BORDERS
-      // ion-border-standard: 2px solid var(--ion-color-primary),
-      // ion-border-thin-standard: 1px solid var(--ion-color-primary),
+      // border-color-default: var(--ion-color-primary),
+      // ion-border-standard: 2px solid var(--border-color-default),
+      // ion-border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/plh_facilitator_mx.scss
+++ b/src/theme/themes/plh_facilitator_mx.scss
@@ -12,8 +12,8 @@
     $variable-overrides: (
       // BORDERS
       // border-color-default: var(--ion-color-primary),
-      // ion-border-standard: 2px solid var(--border-color-default),
-      // ion-border-thin-standard: 1px solid var(--border-color-default),
+      // border-standard: 2px solid var(--border-color-default),
+      // border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/plh_kids_kw/_index.scss
+++ b/src/theme/themes/plh_kids_kw/_index.scss
@@ -50,7 +50,8 @@
 
       // BORDERS
       border-color-default: var(--ion-color-gray-200),
-      border-standard: 2px solid var(--border-color-default),
+      border-width-default: 1px,
+      border-standard: var(--border-width-default) solid var(--border-color-default),
       border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),

--- a/src/theme/themes/plh_kids_kw/_index.scss
+++ b/src/theme/themes/plh_kids_kw/_index.scss
@@ -10,7 +10,7 @@
     $color-secondary: hsl(199 100% 41.6%); // #0092D4
     $page-background: white;
 
-    /** Authoring component overrides **/
+    /** Global and component variables **/
     $variable-overrides: (
       ion-font-family: "Nunito",
       font-weight-standard: 500,
@@ -48,6 +48,9 @@
       buttons-full-width: 100%,
       buttons-full-height: 100%,
 
+      // BORDERS
+      ion-border-standard: 2px solid var(--ion-color-gray-200),
+      ion-border-thin-standard: 1px solid var(--ion-color-gray-200),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/plh_kids_kw/_index.scss
+++ b/src/theme/themes/plh_kids_kw/_index.scss
@@ -50,8 +50,8 @@
 
       // BORDERS
       border-color-default: var(--ion-color-gray-200),
-      ion-border-standard: 2px solid var(--border-color-default),
-      ion-border-thin-standard: 1px solid var(--border-color-default),
+      border-standard: 2px solid var(--border-color-default),
+      border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/plh_kids_kw/_index.scss
+++ b/src/theme/themes/plh_kids_kw/_index.scss
@@ -49,8 +49,9 @@
       buttons-full-height: 100%,
 
       // BORDERS
-      ion-border-standard: 2px solid var(--ion-color-gray-200),
-      ion-border-thin-standard: 1px solid var(--ion-color-gray-200),
+      border-color-default: var(--ion-color-gray-200),
+      ion-border-standard: 2px solid var(--border-color-default),
+      ion-border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/professional.scss
+++ b/src/theme/themes/professional.scss
@@ -12,7 +12,8 @@
     $variable-overrides: (
       // BORDERS
       border-color-default: var(--ion-color-gray-200),
-      border-standard: 2px solid var(--border-color-default),
+      border-width-default: 1px,
+      border-standard: var(--border-width-default) solid var(--border-color-default),
       border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),

--- a/src/theme/themes/professional.scss
+++ b/src/theme/themes/professional.scss
@@ -8,8 +8,11 @@
     $color-secondary: hsl(31, 100%, 57%); // #fa9529
     $page-background: white;
 
-    /** Authoring component overrides **/
+    /** Global and component variables **/
     $variable-overrides: (
+      // BORDERS
+      ion-border-standard: 2px solid var(--ion-color-gray-200),
+      ion-border-thin-standard: 1px solid var(--ion-color-gray-200),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),
@@ -48,7 +51,7 @@
       ion-item-background: var(--ion-color-gray-light),
       task-progress-bar-color: var(--ion-color-green),
       // checkbox-background-color: white,
-      progress-path-line-background: var(--ion-color-gray-100),
+      progress-path-line-background: var(--ion-color-gray-100)
     );
     @include utils.generateTheme($color-primary, $color-secondary, $page-background);
     @each $name, $value in $variable-overrides {

--- a/src/theme/themes/professional.scss
+++ b/src/theme/themes/professional.scss
@@ -11,8 +11,9 @@
     /** Global and component variables **/
     $variable-overrides: (
       // BORDERS
-      ion-border-standard: 2px solid var(--ion-color-gray-200),
-      ion-border-thin-standard: 1px solid var(--ion-color-gray-200),
+      border-color-default: var(--ion-color-gray-200),
+      ion-border-standard: 2px solid var(--border-color-default),
+      ion-border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/professional.scss
+++ b/src/theme/themes/professional.scss
@@ -12,8 +12,8 @@
     $variable-overrides: (
       // BORDERS
       border-color-default: var(--ion-color-gray-200),
-      ion-border-standard: 2px solid var(--border-color-default),
-      ion-border-thin-standard: 1px solid var(--border-color-default),
+      border-standard: 2px solid var(--border-color-default),
+      border-thin-standard: 1px solid var(--border-color-default),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/utils/generate-theme.scss
+++ b/src/theme/themes/utils/generate-theme.scss
@@ -129,10 +129,6 @@
   // BORDERS
   --ion-border-standard: 2px solid #{map.get($colorPalette, "color-primary")};
   --ion-border-thin-standard: 1px solid #{map.get($colorPalette, "color-primary")};
-  --ion-border-color-secondary: 2px solid #{map.get($colorPalette, "color-secondary")};
-  --ion-border-light: 1px solid #{map.get($colorPalette, "light")};
-  --ion-border-light-thicker: 2px solid #{map.get($colorPalette, "light")};
-  --border-dashed: 2px dashed #{map.get($colorPalette, "color-primary")};
 
   //  GRADIENTS
   //Gradient direction

--- a/src/theme/themes/utils/generate-theme.scss
+++ b/src/theme/themes/utils/generate-theme.scss
@@ -127,8 +127,8 @@
   --ion-item-background: #{map.get($colorPalette, "color-primary-100")};
 
   // BORDERS
-  --ion-border-standard: 2px solid #{map.get($colorPalette, "color-primary")};
-  --ion-border-thin-standard: 1px solid #{map.get($colorPalette, "color-primary")};
+  --border-standard: 2px solid #{map.get($colorPalette, "color-primary")};
+  --border-thin-standard: 1px solid #{map.get($colorPalette, "color-primary")};
 
   //  GRADIENTS
   //Gradient direction


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- `professional` theme: Makes the default border colour grey/gray
- `plh_kids_kw` theme: Makes the default border colour grey/gray
- Minor refactor to default border styles: remove unused global style variables

## Review notes

There should be no changes to component styles for the `default` theme. Below is a comprehensive list of all the components that make use of the variable that has been updated by this PR. If you come across any components that you would expect to be changed in accordance with #2426 but are not affected by this PR, then they do not use the default variable and can be refactored as part of this PR or as a follow-up.

@FaithDaka I've applied these changes to the `plh_kids_kw` theme (see #2426 for justification). I imagine that any custom styling you've been applying as part of that theme or otherwise will override the changes I've made as part of this PR. But it's worth being aware of these changes and identifying whether you'll need to make any updates to your custom styles.

## Git Issues

Closes #2426

## Screenshots/Videos

Below is a comprehensive list of all affected components

| Component Name    | Before | After |
|-------------------|--------|-------|
| audio             | <img width="300" alt="Screenshot 2024-11-04 at 16 58 30" src="https://github.com/user-attachments/assets/8d531376-8f67-40a6-9cb7-b527605edebc">      | <img width="300" alt="Screenshot 2024-11-05 at 12 19 18" src="https://github.com/user-attachments/assets/a5d22559-5fa9-44a5-a252-871c0ab8224f">    |
| accordion         |  <img width="300" alt="Screenshot 2024-11-04 at 16 59 17" src="https://github.com/user-attachments/assets/740b0b35-8d07-42d1-ac3e-2c22e678beba">     | <img width="300" alt="Screenshot 2024-11-05 at 12 20 21" src="https://github.com/user-attachments/assets/a2c5665f-c998-4045-b99b-dbb3463dc2c8">    |
| combo_box         | <img width="300" alt="Screenshot 2024-11-04 at 16 59 44" src="https://github.com/user-attachments/assets/c69006f9-7262-4b09-8dd9-43e723858e70">      | <img width="300" alt="Screenshot 2024-11-05 at 12 35 27" src="https://github.com/user-attachments/assets/9d3d635e-cc6a-4745-b139-a378565cf735">   |
| combo_box_modal   | <img width="300" alt="Screenshot 2024-11-04 at 17 00 06" src="https://github.com/user-attachments/assets/9ad33e06-e3f0-4f91-8a29-c955b0ef0c6a">      | <img width="300" alt="Screenshot 2024-11-05 at 12 35 53" src="https://github.com/user-attachments/assets/017b9400-b501-46db-a020-a7f022a99ac8">    |
| display_grid      | <img width="300" alt="Screenshot 2024-11-04 at 17 00 31" src="https://github.com/user-attachments/assets/a45abd54-da6b-448d-9531-f10b768b9e02">      | <img width="300" alt="Screenshot 2024-11-05 at 12 36 48" src="https://github.com/user-attachments/assets/c90ad828-2862-4a71-b1d8-a9c7f35641a4">    |
| number_selector   | <img width="300" alt="Screenshot 2024-11-04 at 17 00 49" src="https://github.com/user-attachments/assets/e5f8317d-e7fe-464a-8af4-886bbb840257">      | <img width="300" alt="Screenshot 2024-11-05 at 12 37 25" src="https://github.com/user-attachments/assets/6215fa3e-7bcb-4670-9010-7a65c2c58cdf">   |
| radio_button_grid | <img width="300" alt="Screenshot 2024-11-04 at 17 01 08" src="https://github.com/user-attachments/assets/bd2df6d5-87bf-4a05-a306-b8c602ebf616">      | <img width="300" alt="Screenshot 2024-11-05 at 12 38 01" src="https://github.com/user-attachments/assets/f9503636-1a18-46e4-b0ef-0950a68ad87f">   |
| radio_group       | <img width="300" alt="Screenshot 2024-11-04 at 17 01 32" src="https://github.com/user-attachments/assets/8c8beae3-55f9-471d-bd29-310a96243749">      | <img width="300" alt="Screenshot 2024-11-05 at 12 38 29" src="https://github.com/user-attachments/assets/1cbb9ffc-2459-4eca-933c-6b6d8818ec77">    |
| slider            | <img width="300" alt="Screenshot 2024-11-04 at 17 01 48" src="https://github.com/user-attachments/assets/55220db7-1e87-4ce9-a4b2-a03ee5b594c9">      | <img width="300" alt="Screenshot 2024-11-05 at 12 39 02" src="https://github.com/user-attachments/assets/6f10fb5e-f9c4-4430-bcee-3c297c4e1a51">    |
| text_area         | <img width="300" alt="Screenshot 2024-11-04 at 17 02 09" src="https://github.com/user-attachments/assets/d136c865-d3b2-4da4-9053-a68f72057f22">      |  <img width="300" alt="Screenshot 2024-11-05 at 12 39 33" src="https://github.com/user-attachments/assets/10018eae-9dae-462c-b8bd-c3828ffd26cc">    |
| text_box          | <img width="300" alt="Screenshot 2024-11-04 at 17 02 27" src="https://github.com/user-attachments/assets/b6983d00-6cc7-49fe-93b2-043e71b7f88c">      | <img width="300" alt="Screenshot 2024-11-05 at 12 40 05" src="https://github.com/user-attachments/assets/fab9897f-eed9-4bb2-913d-3dc26a9df75c">     |
| timer             | <img width="300" alt="Screenshot 2024-11-04 at 17 02 46" src="https://github.com/user-attachments/assets/1b6c69eb-9030-442e-a069-0dd9ce3736dd">      | <img width="300" alt="Screenshot 2024-11-05 at 12 40 32" src="https://github.com/user-attachments/assets/d0cb6e79-c7b4-496f-b7ee-0321c17617fd">   |
