### PR TITLE
feat: display group variant box white

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -52,7 +52,8 @@
     border-radius: var(--ion-border-radius-secondary);
     flex: 1;
     background-color: var(--background-color, transparent);
-    border: 2px solid var(--border-color, transparent);
+    border: var(--border-standard);
+    border-color: var(--border-color);
   }
 
   &[data-variant~="box_gray"] {
@@ -72,6 +73,6 @@
 
   &[data-variant~="box_white"] {
     --background-color: white;
-    --border-color: var(--ion-color-gray-200);
+    --border-color: var(--border-color-default, var(--ion-color-primary));
   }
 }

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -45,7 +45,8 @@
 .display-group-wrapper {
   &[data-variant~="box_gray"],
   &[data-variant~="box_primary"],
-  &[data-variant~="box_secondary"] {
+  &[data-variant~="box_secondary"],
+  &[data-variant~="box_white"] {
     margin-top: var(--regular-margin);
     padding: var(--regular-padding);
     border-radius: var(--ion-border-radius-secondary);
@@ -67,5 +68,10 @@
   &[data-variant~="box_secondary"] {
     --background-color: var(--ion-color-secondary-200);
     --border-color: var(--ion-color-secondary-500);
+  }
+
+  &[data-variant~="box_white"] {
+    --background-color: white;
+    --border-color: var(--ion-color-gray-300);
   }
 }

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -72,6 +72,6 @@
 
   &[data-variant~="box_white"] {
     --background-color: white;
-    --border-color: var(--ion-color-gray-300);
+    --border-color: var(--ion-color-gray-200);
   }
 }

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
@@ -4,7 +4,7 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
 
 interface IDisplayGroupParams {
   /** TEMPLATE PARAMETER: "variant" */
-  variant: "box_gray" | "box_primary" | "box_secondary" | "dashed_box";
+  variant: "box_gray" | "box_primary" | "box_secondary" | "box_white" | "dashed_box";
   /** TEMPLATE PARAMETER: "style". TODO: Various additional legacy styles, review and convert some to variants */
   style: "form" | "default" | string | null;
   /** TEMPLATE PARAMETER: "offset". Add a custom bottom margin */


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new variant for the display group: `box_white`. The border colour and weight are determined by the new theme variables introduced in #2503, so currently the border colour is "primary" for the `default` theme and light grey for the `professional` theme. One knock-on is that the border weight of the other `box_*` variants is also now thinner for the professional theme, in line with the theme-level styling introduced in #2503.

## Git Issues

Closes #2437 

## Screenshots/Videos

| Theme: default | Theme: professional |
|------|------|
| <img width="280" alt="Screenshot 2024-11-07 at 12 54 08" src="https://github.com/user-attachments/assets/ae612aa7-2c4a-4601-80d4-9ce0cf2f9108"> | <img width="280" alt="Screenshot 2024-11-07 at 12 58 22" src="https://github.com/user-attachments/assets/a6ab1167-e155-4669-a69b-26202feed3ea"> |




