### PR TITLE
feat: deployment clone progress

### DIFF
--- a/packages/scripts/src/tasks/providers/git.ts
+++ b/packages/scripts/src/tasks/providers/git.ts
@@ -2,12 +2,14 @@ import chalk from "chalk";
 import fs from "fs-extra";
 import path from "path";
 import semver from "semver";
+import logUpdate from "log-update";
 import simpleGit, { ResetMode } from "simple-git";
 import type { SimpleGit, FileStatusResult } from "simple-git";
 import { Project, SyntaxKind } from "ts-morph";
 import { ActiveDeployment } from "../../commands/deployment/get";
 import { Logger, logOutput, openUrl, promptOptions } from "../../utils";
 import type { IDeploymentConfigJson } from "../../commands/deployment/common";
+import { PATHS } from "shared";
 
 class GitProvider {
   private git: SimpleGit;
@@ -20,8 +22,13 @@ class GitProvider {
 
   /** Access git clone methods directly independent of deployment */
   public async cloneRepo(repoPath: string, localPath: string) {
-    const git = simpleGit();
-    return git.clone(repoPath, localPath);
+    logUpdate();
+    const git = simpleGit(PATHS.DEPLOYMENTS_PATH, {
+      progress: ({ processed, total }) => logUpdate(chalk.gray(`${processed}/${total}`)),
+    });
+    const res = await git.clone(repoPath, localPath, ["--progress"]);
+    logUpdate.done();
+    return res;
   }
 
   /** Pull latest content from remote repo into local branch. Attempt to resolve any conflicts */

--- a/packages/scripts/src/tasks/providers/git.ts
+++ b/packages/scripts/src/tasks/providers/git.ts
@@ -9,7 +9,7 @@ import { Project, SyntaxKind } from "ts-morph";
 import { ActiveDeployment } from "../../commands/deployment/get";
 import { Logger, logOutput, openUrl, promptOptions } from "../../utils";
 import type { IDeploymentConfigJson } from "../../commands/deployment/common";
-import { PATHS } from "shared";
+import { pad, PATHS } from "shared";
 
 class GitProvider {
   private git: SimpleGit;
@@ -22,11 +22,12 @@ class GitProvider {
 
   /** Access git clone methods directly independent of deployment */
   public async cloneRepo(repoPath: string, localPath: string) {
-    logUpdate();
+    console.log("\n");
     const git = simpleGit(PATHS.DEPLOYMENTS_PATH, {
-      progress: ({ processed, total }) => logUpdate(chalk.gray(`${processed}/${total}`)),
+      progress: ({ stage, progress, processed, total }) =>
+        logUpdate(chalk.gray(`${stage} | ${pad(progress, 2)}% | ${processed}/${total}`)),
     });
-    const res = await git.clone(repoPath, localPath, ["--progress"]);
+    const res = await git.clone(repoPath, localPath);
     logUpdate.done();
     return res;
   }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
- add progress indicator for `deployment import` workflow

This adds gray text below the cloning console log and updates to provide overall status

## Review Notes
Import a deployment repo to see updates. E.g. 
```sh
yarn workflow deployment import https://github.com/ParentingForLifelongHealth/plh-kids-app-kw-content.git
```

## Dev Notes
It turns out `simple-git` hass support for progress callbacks that can be used for logging updates. The clone action provides processed, total and an overall percentage value.

## Git Issues

Closes #

## Screenshots/Videos
**Example - progress updating**
![image](https://github.com/user-attachments/assets/f1cdc64e-73fb-4b56-8ebd-452f95d9fc75)

![image](https://github.com/user-attachments/assets/339e8236-1539-4b59-88d3-90c826a7cd30)

