### PR TITLE
chore: fix linebreaks

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/index.ts
+++ b/packages/scripts/src/commands/app-data/convert/index.ts
@@ -60,7 +60,7 @@ export default program
  */
 export class AppDataConverter {
   /** Change version to invalidate all underlying caches */
-  public version = 20231002.0;
+  public version = 20241104.0;
 
   public activeDeployment = ActiveDeployment.get();
 

--- a/packages/scripts/src/commands/app-data/convert/utils/app-data-string.utils.ts
+++ b/packages/scripts/src/commands/app-data/convert/utils/app-data-string.utils.ts
@@ -97,6 +97,7 @@ export function extractDynamicDependencies(dynamicFields: FlowTypes.TemplateRow[
 }
 
 // Standardise newline characters within a string (i.e. replace "\r\n" (CRLF) with "\n" (LF))
+// also replace any remaining \r with \n (https://github.com/IDEMSInternational/open-app-builder/issues/2499)
 export function standardiseNewlines(str: string) {
-  return str.replace(/\\r\\n/g, "\\n");
+  return str.replace(/\\r\\n/g, "\\n").replace(/\\r/g, "\\n");
 }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Review Notes
Just to confirm whether this fixes the issues seen at deployment repo. It might also be good to check whether the amount of whitespace this introduces is desirable or not (e.g. there's quite a few instances of `\r\r` which now becomes `\n\n` and should result in a full empty line - but worth checking it looks as expected)

I tried to identify the root cause but was unsuccessful. Interestingly when trying to open sheets locally excel automatically replaces the `\r`, but definitely does appear to be in the google sheets so I'm guessing somehow coming from copy-paste operations elsewhere. In any case seems sensible to me to just replacee with a newline character.

## Git Issues

Closes #2499

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
