### PR TITLE
feat: set screen orientation on fullscreen pop-ups

### DIFF
--- a/src/app/shared/components/template/components/layout/popup/popup.component.ts
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from "@angular/core";
 import { ModalController } from "@ionic/angular";
 import { FlowTypes, ITemplateContainerProps } from "../../../models";
 import { TemplateContainerComponent } from "../../../template-container.component";
+import { ScreenOrientationService } from "src/app/shared/services/screen-orientation/screen-orientation.service";
 
 @Component({
   templateUrl: "./popup.component.html",
@@ -14,7 +15,10 @@ import { TemplateContainerComponent } from "../../../template-container.componen
 export class TemplatePopupComponent {
   @Input() props: ITemplatePopupComponentProps;
 
-  constructor(private modalCtrl: ModalController) {}
+  constructor(
+    private modalCtrl: ModalController,
+    private screenOrientationService: ScreenOrientationService
+  ) {}
 
   /**
    * When templates emit completed/uncompleted value from standalone popup close the popup
@@ -38,6 +42,11 @@ export class TemplatePopupComponent {
 
   dismiss(value?: { emit_value: string; emit_data: any }) {
     this.modalCtrl.dismiss(value);
+    // HACK - unlock screen orientation when dismissing a fullscreen pop-up. This allows screen orientation
+    // to be set on a fullscreen pop-up (and crucially, unset) despite it not being a top-level template
+    if (this.props.fullscreen) {
+      this.screenOrientationService.setOrientation("unlock");
+    }
   }
 }
 

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -48,7 +48,7 @@ export class ScreenOrientationService extends SyncServiceBase {
     });
   }
 
-  private async setOrientation(orientation: IScreenOrientation) {
+  public async setOrientation(orientation: IScreenOrientation) {
     // avoid re-locking same orientation
     if (orientation === this.lockedOrientation) return;
 

--- a/src/app/shared/services/screen-orientation/screen-orientation.service.ts
+++ b/src/app/shared/services/screen-orientation/screen-orientation.service.ts
@@ -9,7 +9,7 @@ import { environment } from "src/environments/environment";
 /** List of possible orientations provided by authors */
 const SCREEN_ORIENTATIONS = ["portrait", "landscape", "unlock"] as const;
 
-type IScreenOrientation = (typeof SCREEN_ORIENTATIONS)[number];
+export type IScreenOrientation = (typeof SCREEN_ORIENTATIONS)[number];
 
 @Injectable({
   providedIn: "root",


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Following on from #2501, allows fullscreen pop-ups to display in landscape mode – i.e. when a template has an `orientation` value set in its `parameter_list`, e.g. `orientation: landscape`, the screen orientation will be set to the respective value when launching the template as a fullscreen popup, and reset when the pop-up is closed, whether through the "close" button or through emitting `completed`/`uncompleted`.

## Notes

Originally I had sought to find a solution from authoring within the current system, along the lines of:
```
click | screen_orientation: landscape;
click | pop_up:example_emit | fullscreen: true;
uncompleted | screen_orientation: portrait;
completed | screen_orientation: portrait;
```
But while this works for setting the orientation when launching the pop-up, for whatever reason `completed`/`uncompleted` events from the pop-up template to not trigger the action as expected. So it was still required to set the orientation to "unlock" within the `dismiss()` method of the popup component (see https://github.com/IDEMSInternational/open-app-builder/pull/2511/commits/5f210d100a972856de88b9173b625d977b9faa07), at which point it made sense to handle the screen orientation entirely within the component based on the template `parameter_list`, and remove the need for authoring the action explicitly.

Whilst still a hack, this approach means it doesn't rely on the screen orientation template action, which could still be removed as suggested [here](https://github.com/IDEMSInternational/open-app-builder/pull/2501#issuecomment-2462699823).

## Testing

Latest debug builds updated on Appetize:
- [Android](https://appetize.io/apps/android/international.idems.debug_app)
- [iOS](https://appetize.io/apps/ios/international.idems.debug-app)

## Git Issues

Closes #

## Screenshots/Videos

[feature_screen_orienation](https://docs.google.com/spreadsheets/d/13KnDdmBicPDZaWFNnlIck7WNMLlM02HjD0-_UiqZ4z8/edit?gid=569531329#gid=569531329)

<img width="620" alt="Screenshot 2024-11-07 at 19 29 41" src="https://github.com/user-attachments/assets/2cdeebfa-c290-4d82-ac4c-d3a02c763815">

Android:


https://github.com/user-attachments/assets/5a9352ca-d065-41c4-abf2-54e1dc6a85f8

