### PR TITLE
Feat: set data action standalone

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -432,6 +432,7 @@ export namespace FlowTypes {
     "pop_up",
     "process_template",
     "reset_app",
+    "reset_data",
     "save_to_device",
     "screen_orientation",
     "set_field",

--- a/packages/shared/src/utils/object-utils.ts
+++ b/packages/shared/src/utils/object-utils.ts
@@ -100,8 +100,7 @@ export function isEqual(a: any, b: any) {
     if (!isEqual(Object.keys(aSorted), Object.keys(bSorted))) return false;
     return isEqual(Object.values(aSorted), Object.values(bSorted));
   }
-  // could not compare (e.g. symbols, date objects, functions, buffers etc)
-  console.warn(`[isEqual] could not compare`, a, b);
+  // NOTE - does not compare symbols, date objects, functions, buffers etc.
   return false;
 }
 

--- a/src/app/shared/components/template/services/instance/template-action.registry.ts
+++ b/src/app/shared/components/template/services/instance/template-action.registry.ts
@@ -3,10 +3,8 @@ import clone from "clone";
 import { FlowTypes } from "data-models";
 
 export type IActionId = FlowTypes.TemplateRowAction["action_id"];
-export type IActionHandlers = Record<
-  IActionId,
-  (action: FlowTypes.TemplateRowAction) => Promise<any>
->;
+export type IActionHandler = (action: FlowTypes.TemplateRowAction) => Promise<any>;
+export type IActionHandlers = Record<IActionId, IActionHandler>;
 
 @Injectable({ providedIn: "root" })
 /**

--- a/src/app/shared/components/template/services/template-field.service.spec.ts
+++ b/src/app/shared/components/template/services/template-field.service.spec.ts
@@ -4,7 +4,7 @@ import { TemplateFieldService } from "./template-field.service";
 import type { PromiseExtended } from "dexie";
 import { booleanStringToBoolean } from "src/app/shared/utils";
 import { ErrorHandlerService } from "src/app/shared/services/error-handler/error-handler.service";
-import { MockErrorHandlerService } from "src/app/shared/services/error-handler/error-handler.service.spec";
+import { MockErrorHandlerService } from "src/app/shared/services/error-handler/error-handler.service.mock.spec";
 
 /** Mock calls for field values from the template field service to return test data */
 export class MockTemplateFieldService implements Partial<TemplateFieldService> {

--- a/src/app/shared/services/data/app-data.service.spec.ts
+++ b/src/app/shared/services/data/app-data.service.spec.ts
@@ -7,7 +7,7 @@ import { AppDataService, IAppDataCache } from "./app-data.service";
 import { FlowTypes } from "../../model";
 import { MockAppDataVariableService } from "./app-data-variable.service.spec";
 import { ErrorHandlerService } from "../error-handler/error-handler.service";
-import { MockErrorHandlerService } from "../error-handler/error-handler.service.spec";
+import { MockErrorHandlerService } from "../error-handler/error-handler.service.mock.spec";
 import { DbService } from "../db/db.service";
 import { MockDbService } from "../db/db.service.spec";
 import { Injectable } from "@angular/core";

--- a/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
@@ -135,7 +135,7 @@ export class PersistedMemoryAdapter {
     this.persistStateToDB();
   }
 
-  public async delete(flow_type: FlowTypes.FlowType, flow_name: string) {
+  public delete(flow_type: FlowTypes.FlowType, flow_name: string) {
     if (this.get(flow_type, flow_name)) {
       delete this.state[flow_type][flow_name];
       this.persistStateToDB();

--- a/src/app/shared/services/dynamic-data/dynamic-data.actions.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.actions.spec.ts
@@ -133,8 +133,9 @@ describe("DynamicDataService Actions", () => {
   });
 
   it("set_data ignores updates for unchanged data", async () => {
-    const { _updates } = await actions["parseParams"]({ _list_id: "test_flow", number: 1 });
-    expect(_updates).toEqual([{ id: "id_0", number: 1 }]);
+    const params: IActionSetDataParams = { _list_id: "test_flow", number: 1 };
+    const updates = await actions["generateUpdateList"](params);
+    expect(updates).toEqual([{ id: "id_0", number: 1 }]);
   });
 
   it("set_data prevents update to metadata fields", async () => {

--- a/src/app/shared/services/dynamic-data/dynamic-data.actions.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.actions.spec.ts
@@ -153,6 +153,27 @@ describe("DynamicDataService Actions", () => {
     expect(data[1].number).toEqual(1);
   });
 
+  it("reset_data action restores data to initial", async () => {
+    const updatedData = await triggerTestSetDataAction(service, { string: "updated string" });
+    expect(updatedData[0].string).toEqual("updated string");
+    const resetActionBase = getTestActionRow({});
+    await actions.reset_data({ ...resetActionBase, action_id: "reset_data" });
+    const obs = await service.query$<any>("data_list", "test_flow");
+    const resetData = await firstValueFrom(obs);
+    expect(resetData[0].string).toEqual("hello");
+  });
+
+  /*************************************************************
+   *  Misc
+   ************************************************************/
+
+  it("Coerces string params to correct data type", async () => {
+    // NOTE - there is no specific code that casts variables, but RXDB will infer from schema
+    const params: IActionSetDataParams = { number: "300" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].number).toEqual(300);
+  });
+
   /*************************************************************
    *  Quality Control
    ************************************************************/

--- a/src/app/shared/services/dynamic-data/dynamic-data.actions.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.actions.spec.ts
@@ -1,0 +1,178 @@
+import { TestBed } from "@angular/core/testing";
+
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { MockAppDataService } from "../data/app-data.service.spec";
+import { AppDataService } from "../data/app-data.service";
+
+import { IActionSetDataParams } from "./dynamic-data.actions";
+import { DynamicDataService } from "./dynamic-data.service";
+import ActionFactory from "./dynamic-data.actions";
+import { firstValueFrom } from "rxjs";
+import { FlowTypes } from "packages/data-models";
+import { DeploymentService } from "../deployment/deployment.service";
+import { MockDeploymentService } from "../deployment/deployment.service.spec";
+import { TemplateActionRegistry } from "../../components/template/services/instance/template-action.registry";
+
+const TEST_DATA_ROWS = [
+  { id: "id_0", number: 0, string: "hello", _meta: "original" },
+  { id: "id_1", number: 1, string: "hello", boolean: true, _meta: "original" },
+];
+
+/********************************************************************************
+ * Test Utilities
+ *******************************************************************************/
+
+/** Generate a rows to trigger set_data action with included params */
+function getTestActionRow(params: IActionSetDataParams) {
+  params._list_id = "test_flow";
+  const actionRow: FlowTypes.TemplateRowAction = {
+    action_id: "set_data",
+    trigger: "click",
+    args: [],
+    params,
+  };
+  return actionRow;
+}
+
+/**
+ * Trigger the set_data action with included params and return first update
+ * to corresponding data_list
+ * * */
+async function triggerTestSetDataAction(service: DynamicDataService, params: IActionSetDataParams) {
+  const actionRow = getTestActionRow(params);
+  const actions = new ActionFactory(service);
+  await actions.set_data(actionRow);
+  const obs = await service.query$<any>("data_list", "test_flow");
+  const data = await firstValueFrom(obs);
+  return data;
+}
+
+/********************************************************************************
+ * Tests
+ * yarn ng test --include src/app/shared/services/dynamic-data/dynamic-data.actions.spec.ts
+ *******************************************************************************/
+describe("DynamicDataService Actions", () => {
+  let service: DynamicDataService;
+  let actions: ActionFactory;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        DynamicDataService,
+        {
+          provide: AppDataService,
+          useValue: new MockAppDataService({
+            data_list: {
+              test_flow: {
+                flow_name: "test_flow",
+                flow_type: "data_list",
+                // Make deep clone of data to avoid data overwrite issues
+                rows: JSON.parse(JSON.stringify(TEST_DATA_ROWS)),
+              },
+            },
+          }),
+        },
+        {
+          provide: DeploymentService,
+          useValue: new MockDeploymentService({ name: "test" }),
+        },
+        {
+          provide: TemplateActionRegistry,
+          useValue: { register: () => null },
+        },
+      ],
+    });
+
+    // HACK - polyfill not loaded for rxdb dev plugin so manually fill global before running tests
+    window.global = window;
+
+    service = TestBed.inject(DynamicDataService);
+    await service.ready();
+    // Ensure any data previously persisted is cleared
+    await service.resetFlow("data_list", "test_flow");
+    actions = new ActionFactory(service);
+  });
+
+  /*************************************************************
+   *  Main Tests
+   ************************************************************/
+  it("set_data by _id", async () => {
+    const params: IActionSetDataParams = { _id: "id_1", string: "updated string" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].string).toEqual("hello");
+    expect(data[1].string).toEqual("updated string");
+  });
+
+  it("set_data by _index", async () => {
+    const params: IActionSetDataParams = { _index: 1, string: "updated string" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].string).toEqual("hello");
+    expect(data[1].string).toEqual("updated string");
+  });
+
+  it("set_data bulk", async () => {
+    const params: IActionSetDataParams = { string: "updated string" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].string).toEqual("updated string");
+    expect(data[1].string).toEqual("updated string");
+  });
+
+  it("set_data with item ref (single)", async () => {
+    const params: IActionSetDataParams = { _id: "id_1", number: "@item.number + 100" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].number).toEqual(0);
+    expect(data[1].number).toEqual(101);
+  });
+
+  it("set_data with item ref (bulk)", async () => {
+    const params: IActionSetDataParams = { number: "@item.number + 100" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].number).toEqual(100);
+    expect(data[1].number).toEqual(101);
+  });
+
+  it("set_data ignores updates for unchanged data", async () => {
+    const { _updates } = await actions["parseParams"]({ _list_id: "test_flow", number: 1 });
+    expect(_updates).toEqual([{ id: "id_0", number: 1 }]);
+  });
+
+  it("set_data prevents update to metadata fields", async () => {
+    const params: IActionSetDataParams = { _meta: "updated", string: "updated" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].string).toEqual("updated");
+    expect(data[0]._meta).toEqual("original");
+  });
+
+  it("set_data ignores evaluation when _updates provided", async () => {
+    const params: IActionSetDataParams = { _updates: [{ id: "id_0", number: "@item.number" }] };
+    const data = await triggerTestSetDataAction(service, params);
+    // test case illustrative only of not parsing data (would have been parsed independently)
+    expect(data[0].number).toEqual("@item.number");
+    expect(data[1].number).toEqual(1);
+  });
+
+  /*************************************************************
+   *  Quality Control
+   ************************************************************/
+
+  it("throws error if provided _id does not exist", async () => {
+    const params = getTestActionRow({
+      _id: "missing_id",
+      string: "sets an item correctly a given id",
+    });
+    await expectAsync(actions.set_data(params)).toBeRejectedWithError(
+      `[Update Fail] no doc exists\ndata_list: test_flow\n_id: missing_id`
+    );
+  });
+
+  it("throws error if provided _index does not exist", async () => {
+    const params = getTestActionRow({
+      _index: 10,
+      string: "sets an item correctly a given id",
+    });
+    await expectAsync(actions.set_data(params)).toBeRejectedWithError(
+      `[Update Fail] no doc exists\ndata_list: test_flow\n_index: 10`
+    );
+  });
+});

--- a/src/app/shared/services/dynamic-data/dynamic-data.actions.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.actions.ts
@@ -1,0 +1,107 @@
+import { IActionHandler } from "../../components/template/services/instance/template-action.registry";
+import type { DynamicDataService } from "./dynamic-data.service";
+import { firstValueFrom } from "rxjs";
+import { isEqual, isObjectLiteral } from "packages/shared/src/utils/object-utils";
+import { FlowTypes } from "packages/data-models";
+import { MangoQuery } from "rxdb";
+import { evaluateDynamicDataUpdate } from "./dynamic-data.utils";
+
+/** Metadata passed to set_data action to specify data for update **/
+interface IActionSetDataParamsMeta {
+  /** Reference to source data_list id. All rows in list will be updated */
+  _list_id?: string;
+
+  /** ID of data_list row for single update */
+  _id?: string;
+
+  /** Index of data_list row for single update */
+  _index?: number;
+
+  /** List of compiled data updates if computed outside of action (e.g. data_items)  */
+  _updates?: FlowTypes.Data_listRow[];
+}
+
+/** Key-value pairs to update. These support reference to self `@item` context */
+export type IActionSetDataParams = IActionSetDataParamsMeta & Record<string, any>;
+
+class DynamicDataActionFactory {
+  constructor(private service: DynamicDataService) {}
+
+  /**
+   * Similar syntax can be used for multiple items.
+   *
+   * or from outside a loop can specify
+   * click | set_data | _list: @data.example_list, completed:true;
+   */
+  public set_data: IActionHandler = async ({ params }: { params?: IActionSetDataParams }) => {
+    const { _list_id, _updates } = await this.parseParams(params);
+    // Hack, no current method for bulk update so make successive (changes debounced in component)
+    for (const { id, ...writeableProps } of _updates) {
+      await this.service.update("data_list", _list_id, id, writeableProps);
+    }
+  };
+
+  private async parseParams(params: IActionSetDataParams) {
+    // util to log item params and add name prefix as part of thrown errors
+    function throwParseError(msg: string) {
+      console.error(params);
+      throw new Error("[set_data] " + msg);
+    }
+    if (isObjectLiteral(params)) {
+      let { _updates, _list_id } = params;
+
+      // handle parse from item reference string
+      if (_list_id) {
+        if (!_updates) {
+          _updates = await this.generateUpdateList(params);
+        }
+
+        return { _updates, _list_id };
+      }
+    }
+
+    // throw error if args not parsed correctly
+    throwParseError("invalid params");
+  }
+
+  private async generateUpdateList(params: IActionSetDataParams) {
+    // remove metadata from rest of update
+    const { _id, _index, _list_id, _updates, ...update } = params;
+    const query: MangoQuery = {};
+    if (_id) {
+      query.selector = { id: _id };
+    }
+    let ref = await this.service.query$<any>("data_list", _list_id, query);
+    let items = await firstValueFrom(ref);
+    if (items.length === 0) {
+      const msg = `[Update Fail] no doc exists\ndata_list: ${_list_id}\n_id: ${_id}`;
+      throw new Error(msg);
+    }
+    // NOTE - RXDB doesn't support querying by index or pagination so still retrieve all and then reduce
+    if (typeof _index === "number") {
+      const targetItem = items[_index];
+      if (!targetItem) {
+        const msg = `[Update Fail] no doc exists\ndata_list: ${_list_id}\n_index: ${_index}`;
+        throw new Error(msg);
+      }
+      items = [items[_index]];
+    }
+
+    const cleanedUpdate = this.removeUpdateMetadata(update);
+
+    // Evaluate item updates for any `@item` self-references
+    const evaluated = evaluateDynamicDataUpdate(items, cleanedUpdate);
+
+    // Filter to only include updates that will change original item
+    return evaluated.filter((data, i) => !isEqual(items[i], data));
+  }
+
+  private removeUpdateMetadata(update: Record<string, any>) {
+    for (const key of Object.keys(update)) {
+      if (key.startsWith("_")) delete update[key];
+    }
+    return update;
+  }
+}
+
+export default DynamicDataActionFactory;

--- a/src/app/shared/services/dynamic-data/dynamic-data.actions.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.actions.ts
@@ -55,7 +55,6 @@ class DynamicDataActionFactory {
     if (isObjectLiteral(params)) {
       const parsed = this.hackParseTemplatedParams(params);
       let { _updates, _list_id } = parsed;
-      console.log("params", { params, parsed });
       // handle parse from item reference string
       if (_list_id) {
         if (!_updates) {

--- a/src/app/shared/services/dynamic-data/dynamic-data.actions.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.actions.ts
@@ -1,10 +1,10 @@
 import { IActionHandler } from "../../components/template/services/instance/template-action.registry";
 import type { DynamicDataService } from "./dynamic-data.service";
 import { firstValueFrom } from "rxjs";
-import { isEqual, isObjectLiteral } from "packages/shared/src/utils/object-utils";
+import { isObjectLiteral } from "packages/shared/src/utils/object-utils";
 import { FlowTypes } from "packages/data-models";
 import { MangoQuery } from "rxdb";
-import { evaluateDynamicDataUpdate } from "./dynamic-data.utils";
+import { evaluateDynamicDataUpdate, isItemChanged } from "./dynamic-data.utils";
 
 /** Metadata passed to set_data action to specify data for update **/
 interface IActionSetDataParamsMeta {
@@ -93,7 +93,7 @@ class DynamicDataActionFactory {
     const evaluated = evaluateDynamicDataUpdate(items, cleanedUpdate);
 
     // Filter to only include updates that will change original item
-    return evaluated.filter((data, i) => !isEqual(items[i], data));
+    return evaluated.filter((data, i) => isItemChanged(items[i], data));
   }
 
   private removeUpdateMetadata(update: Record<string, any>) {

--- a/src/app/shared/services/dynamic-data/dynamic-data.actions.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.actions.ts
@@ -41,6 +41,11 @@ class DynamicDataActionFactory {
     }
   };
 
+  public reset_data: IActionHandler = async ({ params }: { params?: IActionSetDataParams }) => {
+    const { _list_id } = await this.parseParams(params);
+    return this.service.resetFlow("data_list", _list_id);
+  };
+
   private async parseParams(params: IActionSetDataParams) {
     // util to log item params and add name prefix as part of thrown errors
     function throwParseError(msg: string) {

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.mock.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.mock.spec.ts
@@ -1,0 +1,16 @@
+import { FlowTypes } from "packages/data-models";
+import { DynamicDataService } from "./dynamic-data.service";
+import { of } from "rxjs";
+
+/** Mock implementation used in other tests */
+export class MockDynamicDataService implements Partial<DynamicDataService> {
+  constructor(private mockQueryData = {}) {}
+  // mock query just returns data provided as observable
+  public async query$(flow_type: FlowTypes.FlowType, flow_name: string) {
+    return of(this.mockQueryData[flow_type]?.[flow_name]);
+  }
+
+  public async ready() {
+    return true;
+  }
+}

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
@@ -2,9 +2,11 @@ import { TestBed } from "@angular/core/testing";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { firstValueFrom } from "rxjs";
 
-import { DynamicDataService, ISetItemContext } from "./dynamic-data.service";
+import { DynamicDataService } from "./dynamic-data.service";
 import { AppDataService } from "../data/app-data.service";
 import { MockAppDataService } from "../data/app-data.service.spec";
+import { DeploymentService } from "../deployment/deployment.service";
+import { MockDeploymentService } from "../deployment/deployment.service.spec";
 
 const TEST_DATA_ROWS = [
   { id: "id1", number: 1, string: "hello", boolean: true, _meta_field: { test: "hello" } },
@@ -12,12 +14,6 @@ const TEST_DATA_ROWS = [
   { id: "id0", number: 3, string: "goodbye", boolean: false },
 ];
 type ITestRow = (typeof TEST_DATA_ROWS)[number];
-
-const SET_ITEM_CONTEXT: ISetItemContext = {
-  flow_name: "test_flow",
-  itemDataIDs: ["id1", "id2"],
-  currentItemId: "id1",
-};
 
 /**
  * Call standalone tests via:
@@ -44,6 +40,10 @@ describe("DynamicDataService", () => {
             },
           }),
         },
+        {
+          provide: DeploymentService,
+          useValue: new MockDeploymentService({ name: "test" }),
+        },
       ],
     });
 
@@ -51,7 +51,6 @@ describe("DynamicDataService", () => {
     window.global = window;
 
     service = TestBed.inject(DynamicDataService);
-    TestBed.inject(AppDataService);
     await service.ready();
     // Ensure any data previously persisted is cleared
     await service.resetFlow("data_list", "test_flow");
@@ -109,56 +108,12 @@ describe("DynamicDataService", () => {
     expect(res.length).toEqual(20);
   });
 
-  it("sets an item correctly for current item", async () => {
-    await service.setItem({
-      context: SET_ITEM_CONTEXT,
-      writeableProps: { string: "sets an item correctly for current item" },
-    });
-    const obs = await service.query$<any>("data_list", "test_flow");
-    const data = await firstValueFrom(obs);
-    expect(data[0].string).toEqual("sets an item correctly for current item");
-    expect(data[1].string).toEqual("goodbye");
-  });
-
-  it("sets an item correctly for a given _id", async () => {
-    await service.setItem({
-      context: SET_ITEM_CONTEXT,
-      _id: "id2",
-      writeableProps: { string: "sets an item correctly for a given _id" },
-    });
-    const obs = await service.query$<any>("data_list", "test_flow");
-    const data = await firstValueFrom(obs);
-    expect(data[0].string).toEqual("hello");
-    expect(data[1].string).toEqual("sets an item correctly for a given _id");
-  });
-
-  it("sets an item correctly for a given _index", async () => {
-    await service.setItem({
-      context: SET_ITEM_CONTEXT,
-      _index: 1,
-      writeableProps: { string: "sets an item correctly for a given _index" },
-    });
-    const obs = await service.query$<any>("data_list", "test_flow");
-    const data = await firstValueFrom(obs);
-    expect(data[0].string).toEqual("hello");
-    expect(data[1].string).toEqual("sets an item correctly for a given _index");
-  });
-
   it("supports reading data with protected fields", async () => {
     const obs = await service.query$("data_list", "test_flow");
     const data = await firstValueFrom(obs);
     expect(data[0]["_meta_field"]).toEqual({ test: "hello" });
   });
-  it("ignores writes to protected fields", async () => {
-    await service.setItem({
-      context: SET_ITEM_CONTEXT,
-      writeableProps: { _meta_field: "updated", string: "updated" },
-    });
-    const obs = await service.query$("data_list", "test_flow");
-    const data = await firstValueFrom(obs);
-    expect(data[0]["string"]).toEqual("updated");
-    expect(data[0]["_meta_field"]).toEqual({ test: "hello" });
-  });
+
   it("adds metadata (row_index) to docs", async () => {
     const obs = await service.query$<any>("data_list", "test_flow");
     const data = await firstValueFrom(obs);

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -54,8 +54,8 @@ export class DynamicDataService extends AsyncServiceBase {
     super("Dynamic Data");
     this.registerInitFunction(this.initialise);
     // register action handlers
-    const { set_data } = new ActionsFactory(this);
-    this.templateActionRegistry.register({ set_data });
+    const { set_data, reset_data } = new ActionsFactory(this);
+    this.templateActionRegistry.register({ set_data, reset_data });
     // HACK - Legacy `set_item` action still managed here (will be removed in #2454)
     this.registerTemplateActionHandlers();
   }
@@ -166,14 +166,20 @@ export class DynamicDataService extends AsyncServiceBase {
       await lastValueFrom(this.collectionCreators[collectionName]);
     }
     // Ensure any persisted data deleted
-    await this.writeCache.delete(flow_type, flow_name);
+    this.writeCache.delete(flow_type, flow_name);
 
     // Remove in-memory db if exists
     const existingCollection = this.db.getCollection(collectionName);
     if (existingCollection) {
-      await this.db.removeCollection(collectionName);
+      // Empty existing data and re-seed initial data
+      const docs = await existingCollection.find().exec();
+      await existingCollection.bulkRemove(docs.map((d) => d.id));
+      // Re-seed initial data
+      const initialData = await this.getInitialData(flow_type, flow_name);
+      await existingCollection.bulkInsert(initialData);
+    } else {
+      await this.createCollection(flow_type, flow_name);
     }
-    await this.createCollection(flow_type, flow_name);
   }
 
   /** Access full state of all persisted data layers */
@@ -205,17 +211,10 @@ export class DynamicDataService extends AsyncServiceBase {
     if (initialData.length === 0) {
       throw new Error(`No data exists for collection [${flow_name}], cannot initialise`);
     }
-    // add index property to each element before insert, for sorting queried data by original order
-    const initialDataWithMeta = initialData.map((el) => {
-      return {
-        ...el,
-        row_index: initialData.indexOf(el),
-      };
-    });
 
-    const schema = this.inferSchema(initialDataWithMeta[0]);
+    const schema = this.inferSchema(initialData[0]);
     await this.db.createCollection(collectionName, schema);
-    await this.db.bulkInsert(collectionName, initialDataWithMeta);
+    await this.db.bulkInsert(collectionName, initialData);
     // notify any observers that collection has been created
     this.collectionCreators[collectionName].next(collectionName);
     this.collectionCreators[collectionName].complete();
@@ -233,7 +232,10 @@ export class DynamicDataService extends AsyncServiceBase {
     const mergedData = this.mergeData(flowData?.rows, writeDataArray);
     // HACK - rxdb can't write any fields prefixed with `_` so extract all to top-level APP_META key
     const cleaned = mergedData.map((el) => this.extractMeta(el));
-    return cleaned;
+
+    // add index property to each element before insert, for sorting queried data by original order
+    const initialDataWithMeta = cleaned.map((el) => ({ ...el, row_index: cleaned.indexOf(el) }));
+    return initialDataWithMeta;
   }
 
   /** When working with rxdb collections only alphanumeric lower case names allowed  */

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -189,6 +189,11 @@ export class DynamicDataService extends AsyncServiceBase {
     return this.writeCache.state;
   }
 
+  public getSchema(flow_type: FlowTypes.FlowType, flow_name: string) {
+    const collectionName = this.normaliseCollectionName(flow_type, flow_name);
+    return this.db.getCollection(collectionName)?.schema;
+  }
+
   /** Ensure a collection exists, creating if not and populating with corresponding list data */
   private async ensureCollection(flow_type: FlowTypes.FlowType, flow_name: string) {
     const collectionName = this.normaliseCollectionName(flow_type, flow_name);

--- a/src/app/shared/services/dynamic-data/dynamic-data.utils.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.utils.spec.ts
@@ -1,5 +1,5 @@
 import { FlowTypes } from "packages/data-models";
-import { evaluateDynamicDataUpdate } from "./dynamic-data.utils";
+import { evaluateDynamicDataUpdate, isItemChanged } from "./dynamic-data.utils";
 
 const itemRows: FlowTypes.Data_listRow[] = [
   { id: "id_0", number: 0, string: "hello" },
@@ -20,5 +20,12 @@ describe("DynamicDataService Utils", () => {
       { id: "id_0", number: 10 },
       { id: "id_1", number: 11 },
     ]);
+  });
+
+  it("isItemChanged true", async () => {
+    const res1 = isItemChanged({ id: "id_1", number: 1, string: "hello" }, { number: 2 });
+    expect(res1).toEqual(true);
+    const res2 = isItemChanged({ id: "id_1", number: 1 }, { number: 1 });
+    expect(res2).toEqual(false);
   });
 });

--- a/src/app/shared/services/dynamic-data/dynamic-data.utils.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.utils.spec.ts
@@ -1,0 +1,24 @@
+import { FlowTypes } from "packages/data-models";
+import { evaluateDynamicDataUpdate } from "./dynamic-data.utils";
+
+const itemRows: FlowTypes.Data_listRow[] = [
+  { id: "id_0", number: 0, string: "hello" },
+  { id: "id_1", number: 1, string: "hello", boolean: true },
+];
+
+/********************************************************************************
+ * Tests
+ * yarn ng test --include src/app/shared/services/dynamic-data/dynamic-data.utils.spec.ts
+ *******************************************************************************/
+describe("DynamicDataService Utils", () => {
+  /*************************************************************
+   *  Main Tests
+   ************************************************************/
+  it("evaluateDynamicDataUpdate", async () => {
+    const res = evaluateDynamicDataUpdate(itemRows, { number: "@item.number+10" });
+    expect(res).toEqual([
+      { id: "id_0", number: 10 },
+      { id: "id_1", number: 11 },
+    ]);
+  });
+});

--- a/src/app/shared/services/dynamic-data/dynamic-data.utils.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.utils.spec.ts
@@ -1,5 +1,10 @@
 import { FlowTypes } from "packages/data-models";
-import { evaluateDynamicDataUpdate, isItemChanged } from "./dynamic-data.utils";
+import {
+  coerceDataUpdateTypes,
+  evaluateDynamicDataUpdate,
+  isItemChanged,
+} from "./dynamic-data.utils";
+import { JsonSchema } from "rxdb";
 
 const itemRows: FlowTypes.Data_listRow[] = [
   { id: "id_0", number: 0, string: "hello" },
@@ -27,5 +32,36 @@ describe("DynamicDataService Utils", () => {
     expect(res1).toEqual(true);
     const res2 = isItemChanged({ id: "id_1", number: 1 }, { number: 1 });
     expect(res2).toEqual(false);
+  });
+
+  it("coerceDataUpdateTypes", () => {
+    const schemaMapping: Record<string, JsonSchema> = {
+      number: { type: "number" },
+      boolean: { type: "boolean" },
+      text: { type: "string" },
+    };
+    const res1 = coerceDataUpdateTypes(schemaMapping, [
+      {
+        number: "1",
+        boolean: "true",
+        text: "hello",
+        additional: "string",
+      },
+    ]);
+    expect(res1).toEqual([
+      {
+        number: 1,
+        boolean: true,
+        text: "hello",
+        additional: "string",
+      },
+    ]);
+    // does not coerce missing or undefined properties
+    const res2 = coerceDataUpdateTypes(schemaMapping, [
+      {
+        number: undefined,
+      },
+    ]);
+    expect(res2).toEqual([{ number: undefined }]);
   });
 });

--- a/src/app/shared/services/dynamic-data/dynamic-data.utils.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.utils.ts
@@ -1,6 +1,7 @@
 import type { FlowTypes } from "packages/data-models/flowTypes";
 import { TemplatedData } from "packages/shared/src/models/templatedData/templatedData";
 import { AppDataEvaluator } from "packages/shared/src/models/appDataEvaluator/appDataEvaluator";
+import { isEqual } from "packages/shared/src/utils/object-utils";
 
 /**
  * Given an update to apply to a list of items check whether the update self-references
@@ -30,4 +31,16 @@ export function evaluateDynamicDataUpdate(
 function hasDynamicDataItemReferences(data: any) {
   const contextVariables = new TemplatedData().listContextVariables(data, ["item"]);
   return contextVariables.item;
+}
+
+/**
+ * Compare an item with update snapshot and determine whether the update contains
+ * any changes. As updates are partials only compare properties in update against item equivalent
+ */
+export function isItemChanged(
+  item: FlowTypes.Data_listRow,
+  update: Partial<FlowTypes.Data_listRow>
+) {
+  const isChanged = Object.entries(update).find(([key, value]) => !isEqual(item[key], value));
+  return isChanged ? true : false;
 }

--- a/src/app/shared/services/dynamic-data/dynamic-data.utils.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.utils.ts
@@ -1,0 +1,33 @@
+import type { FlowTypes } from "packages/data-models/flowTypes";
+import { TemplatedData } from "packages/shared/src/models/templatedData/templatedData";
+import { AppDataEvaluator } from "packages/shared/src/models/appDataEvaluator/appDataEvaluator";
+
+/**
+ * Given an update to apply to a list of items check whether the update self-references
+ * `@item.some_field` within any part of the update, and if so evaluated for each
+ * individual item context. Return list of updates to apply, evaluated for item context
+ */
+export function evaluateDynamicDataUpdate(
+  items: FlowTypes.Data_listRow[],
+  update: Record<string, any>
+) {
+  if (hasDynamicDataItemReferences(update)) {
+    const evaluator = new AppDataEvaluator();
+    return items.map((item) => {
+      evaluator.setExecutionContext({ item });
+      const evaluated = evaluator.evaluate(update);
+      // ensure target item id also included in update
+      return { ...evaluated, id: item.id };
+    });
+  } else {
+    return items.map((item) => {
+      return { ...update, id: item.id };
+    });
+  }
+}
+
+/** Check whether the update does include any `@item` references */
+function hasDynamicDataItemReferences(data: any) {
+  const contextVariables = new TemplatedData().listContextVariables(data, ["item"]);
+  return contextVariables.item;
+}

--- a/src/app/shared/services/dynamic-data/dynamic-data.utils.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.utils.ts
@@ -1,7 +1,9 @@
 import type { FlowTypes } from "packages/data-models/flowTypes";
 import { TemplatedData } from "packages/shared/src/models/templatedData/templatedData";
 import { AppDataEvaluator } from "packages/shared/src/models/appDataEvaluator/appDataEvaluator";
-import { isEqual } from "packages/shared/src/utils/object-utils";
+import { isEqual, isObjectLiteral } from "packages/shared/src/utils/object-utils";
+import { JsonSchema, JsonSchemaTypes } from "rxdb";
+import { booleanStringToBoolean } from "../../utils";
 
 /**
  * Given an update to apply to a list of items check whether the update self-references
@@ -44,3 +46,55 @@ export function isItemChanged(
   const isChanged = Object.entries(update).find(([key, value]) => !isEqual(item[key], value));
   return isChanged ? true : false;
 }
+
+/**
+ * Use rxdb schema to cast data updates to the correct data types
+ * Used to convert parameter_list values stored as strings to number or boolean where required
+ * */
+export function coerceDataUpdateTypes(schemaProperties: Record<string, JsonSchema>, data: any[]) {
+  // create a general mapping to convert any listed schema property from a string value
+  // to the correct schema value type
+  const propertyMapping: Record<string, (v: string) => any> = {};
+  for (const [key, { type }] of Object.entries(schemaProperties)) {
+    // do not map metadata fields (can't be set by user input)
+    if (!key.startsWith("_")) {
+      propertyMapping[key] = typeMappings[type as JsonSchemaTypes];
+    }
+  }
+  // coerce data values using mapping
+  const coerced = [];
+  for (const el of data) {
+    if (isObjectLiteral(el)) {
+      for (const [key, value] of Object.entries(el)) {
+        // only map values if they are strings and have a defined mapping function
+        if (propertyMapping[key] && typeof value === "string") {
+          el[key] = propertyMapping[key](value);
+        }
+      }
+    }
+    coerced.push(el);
+  }
+  return coerced;
+}
+
+/**
+ * Mapping functions used to coerce string values to RXDB schema types
+ * This is a subset of mappings that could alternatively be provided by
+ * https://ajv.js.org/coercion.html
+ * **/
+const typeMappings: Record<JsonSchemaTypes, (v: string) => any | undefined> = {
+  // do not attempt to coerce arrays (data_list does not store array values)
+  array: undefined,
+  // convert boolean string to boolean
+  boolean: (v) => booleanStringToBoolean(v),
+  // convert string integer to integer
+  integer: (v) => parseInt(v, 10),
+  // do not attempt to coerce null schema
+  null: undefined,
+  // convert string number to number
+  number: (v) => Number(v),
+  // do not attempt to coerce objects (data_list does not store object values)
+  object: undefined,
+  // as incoming values will be formatted as strings do not provide any additional mapping
+  string: undefined,
+};

--- a/src/app/shared/services/error-handler/error-handler.service.mock.spec.ts
+++ b/src/app/shared/services/error-handler/error-handler.service.mock.spec.ts
@@ -1,0 +1,11 @@
+import { ErrorHandlerService } from "./error-handler.service";
+
+/** Mock calls for sheets from the appData service to return test data */
+export class MockErrorHandlerService implements Partial<ErrorHandlerService> {
+  public logError(error: Error): Promise<void> {
+    throw error;
+  }
+  public handleError(error: Error): Promise<void> {
+    throw error;
+  }
+}

--- a/src/app/shared/services/error-handler/error-handler.service.spec.ts
+++ b/src/app/shared/services/error-handler/error-handler.service.spec.ts
@@ -3,16 +3,6 @@ import { TestBed } from "@angular/core/testing";
 import { ErrorHandlerService } from "./error-handler.service";
 import { FirebaseService } from "../firebase/firebase.service";
 
-/** Mock calls for sheets from the appData service to return test data */
-export class MockErrorHandlerService implements Partial<ErrorHandlerService> {
-  public logError(error: Error): Promise<void> {
-    throw error;
-  }
-  public handleError(error: Error): Promise<void> {
-    throw error;
-  }
-}
-
 describe("ErrorHandlerService", () => {
   let service: ErrorHandlerService;
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
Add actions to support data_list manipulation from outside of `data_items` context loops, originally discussed in [RFC 21. Data Actions](https://docs.google.com/document/d/1qJi9Nk--CFwGTPMn9ksmOgoVq_dnXrTMlN9a_i7kUyY/edit?tab=t.0#heading=h.93c0t57zwuyv)

This PR originally started in #2454, but has been separated out. This does not include any changes to `set_item` syntax or `data_items` loop handling (will be addressed in follow-ups)

**Main Changes**
- add `set_data` action
- add `reset_data` action 
- add tests

**Additional Changes**
- Create new [feat_data_actions](https://docs.google.com/spreadsheets/d/1nREviZhw2HG1YQy6KA1S9PU4Q36RRVHdwSYf3TMbduk/edit?gid=434509236#gid=434509236) sheet for demo
- Minor test tidying

**Future Follow-ups**

- [ ] Add `insert_data` action
- [ ] Add `remove_data` action
- [ ] Remove `hackParseTemplatedParams` method added (requires update to items loop code)
- [ ] Update dynamic data documentation to include use-cases and examples
- [ ] Support additional operators to change what data actions apply on, e.g. filter, sort, limit

## Author Notes
**Syntax**   
See examples in sheet [feat_data_actions](https://docs.google.com/spreadsheets/d/1nREviZhw2HG1YQy6KA1S9PU4Q36RRVHdwSYf3TMbduk/edit?gid=434509236#gid=434509236)

**Question**   
We previously said `set_data` would be the preferred name for actions to align with `set_field` , `set_local` etc. Although do we still want to keep this convention given we will likely need several follow-up actions, namely:
`set_data`, `reset_data`, `insert_data`, `remove_data`
vs
`data_set`, `data_reset`, `data_insert`, `data_remove`

**Key Point**   
This PR does not change how data_lists are updated from within `data_items` loops. For now authors can still use `set_item`, but be aware it uses different code to the `set_data` action and so might behave slightly differently. Follow-up PRs are planned to unify the handling so that the `set_item` code can function in the same way as `set_data`, using the context of the item loop to set default `_list_id` and `_id` variables for the item (so author only needs to write explicit values to update)

**Key Point**   
When setting data from a parameter_list, by default all the key-value pairs defined in the parameter list are parsed as strings (unless set as an intermediate local variable first). As this has high potential to confuse authoring, additional code has been added to try and convert the string into the correct data type, using the original data_list as source of which columns contain which type of data. As such it means the first row of any data_list currently needs to contain values for this to work correctly. It might be worth creating a follow-up issue to provide alternate ways to define the schema of a data_list, for example allowing a top-row metadata row that just specifies data types. 



## Review Notes
Functional test of [feat_data_actions](https://docs.google.com/spreadsheets/d/1nREviZhw2HG1YQy6KA1S9PU4Q36RRVHdwSYf3TMbduk/edit?gid=434509236#gid=434509236)

For code tests, see updated specs (will need to run individually)

## Dev Notes
This includes quite a few updates to tests, however as the angular tests are still not built into CI (due to #2196) they all need to be run manually. As we continue to work on refactoring service code it would be really useful to get these tests unblocked so that we can identify any regressions introduced. 

A few of the mock tests have been moved to their own folder instead of the original spec file just so that the corresponding tests aren't triggered when importing from the file (looks like there's a few tests that will have been broken recently, likely with changes to deployment and app config - but beyond scope to fix). So again, would be good to get the full angular test suite passing so that we can include in CI

Some of the existing code and tests within the `dynamic-data.service` file has been migrated into the new `data-actions.service`, and further developed from there. This is to try and keep code a little bit more separated and easy to iterate on

I remember some of the initial discussion for the `set_data` action started in https://github.com/IDEMSInternational/open-app-builder/pull/2388, however I lost track of that PR when creating the various follow-ups. So I'm assuming the code here (and in other draft PRs) should supercede, but I'll hold off closing that for now until I do another follow-up on data_items lists in #2454

While developing I realised the issue with all parameter_list values being parsed as strings and added the workaround to coerce data types. I think generally this is useful to have and could be build on in the future to include more things like data validation (or any other rxdb schema options that we want to expose to authors). I haven't tried to address object or array types as I don't think there's a way for authors to include those data_types in lists (although maybe if a column ends `_list`...?). I think more advanced data type handling could possibly be saved for follow-up

You'll notice I've update the `resetFlow` method of the `dynamic-data.service`. Previously the method would delete the entire table and recreate from scratch. The problem with doing this when resetting data is that any existing data subscriptions also get destroyed, so the `data-items` component would somehow need to know to resubscribe once recreated. Instead it now deletes all rows and repopulates. This is more desirable than just trying to reverting values within existing rows for future cases where we have the ability to append new rows. 

## Git Issues

Closes #

## Screenshots/Videos
[Screenity video - Nov 9, 2024.webm](https://github.com/user-attachments/assets/8f21f4ec-ce73-442c-b555-087ac7abbbda)