### PR TITLE
fix: seo service config

### DIFF
--- a/src/app/shared/services/seo/seo.service.ts
+++ b/src/app/shared/services/seo/seo.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@angular/core";
 import { SyncServiceBase } from "../syncService.base";
 import { DeploymentService } from "../deployment/deployment.service";
+import { AppConfigService } from "../app-config/app-config.service";
 
 interface ISEOMeta {
   title: string;
@@ -21,7 +22,10 @@ type IMetaName =
   providedIn: "root",
 })
 export class SeoService extends SyncServiceBase {
-  constructor(private deploymentService: DeploymentService) {
+  constructor(
+    private deploymentService: DeploymentService,
+    private appConfigService: AppConfigService
+  ) {
     super("SEO Service");
     // call after init to apply defaults
     this.updateMeta({});
@@ -65,12 +69,14 @@ export class SeoService extends SyncServiceBase {
   private getDefaultSEOTags(): ISEOMeta {
     const PUBLIC_URL = location.origin;
     let faviconUrl = `${PUBLIC_URL}/assets/icon/favicon.svg`;
-    const { web, app_config } = this.deploymentService.config;
+    const { web } = this.deploymentService.config;
+    const { title } = this.appConfigService.appConfig().APP_HEADER_DEFAULTS;
+
     if (web?.favicon_asset) {
       faviconUrl = `${PUBLIC_URL}/assets/app_data/assets/${web.favicon_asset}`;
     }
     return {
-      title: app_config.APP_HEADER_DEFAULTS.title,
+      title,
       description: "",
       faviconUrl,
       imageUrl: ``,


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Fix issue where seo service fails to initialise if deployment does not have any app header config set

## Dev Notes
The reason for the issue is that the seo-service was importing app config via the deployment config (which only includes config overrides), instead of app config service (which includes full merged config). So when accessing nested properties it would throw an error if no APP_HEADER_DEFAULTS had been overwritten.

Most deployments typically have app header overrides so would mostly go unnoticed, it was only when running the local deployment that the error was noticed. Searching the codebase this is the only service that I could see that tried to access app config in this way.


## Git Issues

Closes #

## Screenshots/Videos
**Source code search for other services accessing app_config** - only case is a comment in task-card component and the app-config service itself which handles merging full config values
![image](https://github.com/user-attachments/assets/6b07a020-e23c-487f-94ca-881d69165324)
