### PR TITLE
Feat: data list metadata

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -74,9 +74,25 @@ export namespace FlowTypes {
     flow_type: "asset_pack";
     rows: Data_listRow<IAssetEntry>[];
   }
+
+  /**
+   * Data types supported within data_lists
+   * These are a subset of types provided by Json Schema standards
+   * https://json-schema.org/draft/2020-12/json-schema-core#name-instance-data-model
+   *  */
+  export type Data_listColumnType = "boolean" | "number" | "object" | "string";
+
+  export interface Data_listColumnMetadata {
+    type: Data_listColumnType;
+  }
+
   export interface Data_list extends FlowTypeWithData {
     flow_type: "data_list";
     rows: Data_listRow[];
+    /** Hashmap of metadata for each data column */
+    metadata: {
+      [column_name: string]: Data_listColumnMetadata;
+    };
   }
   export interface DataPipeFlow extends FlowTypeWithData {
     flow_type: "data_pipe";

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -83,14 +83,15 @@ export namespace FlowTypes {
   export type Data_listColumnType = "boolean" | "number" | "object" | "string";
 
   export interface Data_listColumnMetadata {
-    type: Data_listColumnType;
+    /** Column data type. Default "string" when not defined */
+    type?: Data_listColumnType;
   }
 
   export interface Data_list extends FlowTypeWithData {
     flow_type: "data_list";
     rows: Data_listRow[];
-    /** Hashmap of metadata for each data column */
-    metadata: {
+    /** Hashmap of any additional column metadata (omitted if all columns default string type) */
+    _metadata?: {
       [column_name: string]: Data_listColumnMetadata;
     };
   }

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -4,7 +4,7 @@ import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
-const cacheVersion = 20241121.0;
+const cacheVersion = 20241121.1;
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -4,7 +4,7 @@ import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
-const cacheVersion = 20241024.0;
+const cacheVersion = 20241114.0;
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -4,7 +4,7 @@ import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
-const cacheVersion = 20241121.1;
+const cacheVersion = 20241121.2;
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -4,7 +4,7 @@ import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
-const cacheVersion = 20241114.0;
+const cacheVersion = 20241114.2;
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -4,7 +4,7 @@ import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
-const cacheVersion = 20241114.2;
+const cacheVersion = 20241121.0;
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.spec.ts
@@ -1,6 +1,6 @@
 import { FlowTypes } from "data-models";
 import { DataListParser } from ".";
-import { TEST_DATA_PATHS, useMockLogger } from "../../../../../../../test/helpers/utils";
+import { TEST_DATA_PATHS } from "../../../../../../../test/helpers/utils";
 import { FlowParserProcessor } from "../flowParser";
 
 const MOCK_DATA_LIST = (): FlowTypes.Data_list => ({
@@ -47,7 +47,7 @@ describe("data_list Parser Metadata", () => {
       additional: { type: "boolean" },
     });
   });
-  it("Assigns column metadata from metadata row", () => {
+  it("Assigns column metadata from metadata row (and removes it)", () => {
     const flowWithMetadataRow = {
       ...MOCK_DATA_LIST(),
       rows: [
@@ -55,10 +55,11 @@ describe("data_list Parser Metadata", () => {
         { id: "id_1", number: undefined, text: undefined },
       ],
     };
-    const { _metadata } = parser.postProcessFlow(flowWithMetadataRow);
+    const { _metadata, rows } = parser.postProcessFlow(flowWithMetadataRow);
     expect(_metadata).toEqual({
       number: { type: "number" },
     });
+    expect(rows.length).toEqual(1);
   });
   it("Omits metadata when all columns are strings", () => {
     const flowWithStringColumns = {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.spec.ts
@@ -1,8 +1,88 @@
+import { FlowTypes } from "data-models";
 import { DataListParser } from ".";
-import { TEST_DATA_PATHS } from "../../../../../../../test/helpers/utils";
+import { TEST_DATA_PATHS, useMockLogger } from "../../../../../../../test/helpers/utils";
 import { FlowParserProcessor } from "../flowParser";
 
-const testFlow = {
+const MOCK_DATA_LIST = (): FlowTypes.Data_list => ({
+  flow_type: "data_list",
+  flow_name: "mock_data_list",
+  rows: [
+    {
+      id: "id_1",
+      number: 1,
+      text: "hello",
+      boolean: true,
+      nested: { string: "hello" },
+    },
+    {
+      id: "id_1",
+      number: 1,
+      text: "hello",
+      boolean: true,
+      nested: { string: "hello" },
+      additional: "included",
+    },
+  ],
+  metadata: {},
+  _xlsxPath: "/mock/data/path",
+});
+
+/***********************************************************************
+ * Basic
+ **********************************************************************/
+
+/** yarn workspace scripts test -t  data_list.parser.spec.ts **/
+describe("data_list Parser Metadata", () => {
+  let parser: DataListParser;
+
+  beforeAll(() => {
+    parser = new DataListParser({ processedFlowHashmap: {} } as any);
+  });
+  it("Infers column metadata from data", () => {
+    const metadata = parser["getFlowMetadata"](MOCK_DATA_LIST());
+    expect(metadata).toEqual({
+      number: { type: "number" },
+      text: { type: "string" },
+      boolean: { type: "boolean" },
+      nested: { type: "object" },
+      // data missing or undefined in first row identified from subsequent
+      additional: { type: "string" },
+    });
+  });
+  it("Assigns column metadata from metadata row", () => {
+    const flowWithMetadataRow = {
+      ...MOCK_DATA_LIST(),
+      rows: [
+        { id: "@metadata", number: "type: number", text: "type: string" },
+        { id: "id_1", number: undefined, text: undefined },
+      ],
+    };
+    const metadata = parser["getFlowMetadata"](flowWithMetadataRow);
+    expect(metadata).toEqual({
+      number: { type: "number" },
+      text: { type: "string" },
+    });
+  });
+  it("QC metadata", () => {
+    const loggerSpy = useMockLogger(false);
+    const flowWithMetadataRow = {
+      ...MOCK_DATA_LIST(),
+      rows: [{ id: "id_1", number: 1, text: undefined }],
+    };
+    parser["getFlowMetadata"](flowWithMetadataRow);
+    expect(loggerSpy.error).toHaveBeenCalledTimes(1);
+    expect(loggerSpy.error).toHaveBeenCalledWith({
+      msg1: "[mock_data_list] Data List validation has (1) errors",
+      msg2: "/mock/data/path",
+    });
+  });
+});
+
+/***********************************************************************
+ * Advanced use cases
+ **********************************************************************/
+
+const testFlow: FlowTypes.Data_list = {
   flow_type: "data_list",
   flow_name: "test_data_list",
   rows: [
@@ -14,18 +94,19 @@ const testFlow = {
       "nested.test_2": "two",
     },
   ],
+  metadata: {},
 };
 
-/** yarn workspace scripts test -t  data_list.parser.spec.ts **/
 describe("data_list Parser (single)", () => {
-  let outputRows: any[];
+  let parser: DataListParser;
+
   beforeAll(() => {
-    const parser = new DataListParser({ processedFlowHashmap: {} } as any);
-    const output = parser.run(testFlow as any);
-    outputRows = output.rows;
+    parser = new DataListParser({ processedFlowHashmap: {} } as any);
   });
+
   it("Extracts condition_list", async () => {
-    const { test_condition_list } = outputRows[0];
+    const { rows } = parser.run(testFlow as any);
+    const { test_condition_list } = rows[0];
     expect(test_condition_list).toEqual([
       {
         condition_type: "calc",
@@ -35,12 +116,14 @@ describe("data_list Parser (single)", () => {
     ]);
   });
   it("Extracts nested properties", async () => {
-    const { nested } = outputRows[0];
+    const { rows } = parser.run(testFlow as any);
+    const { nested } = rows[0];
     expect(nested).toEqual({ test_1: 1, test_2: "two" });
   });
   // TODO - likely deprecated (can't see in codebase)
   it("Extracts notification_schedule", async () => {
-    const { test_notification_schedule } = outputRows[0];
+    const { rows } = parser.run(testFlow as any);
+    const { test_notification_schedule } = rows[0];
     expect(test_notification_schedule).toEqual({ key_1: "value_1", key_2: "value_2" });
   });
 });

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.ts
@@ -51,7 +51,7 @@ export class DataListParser extends DefaultParser {
     // assign from metadata row and remove
     if (firstRow?.id === "@metadata") {
       metadataInitial = this.assignMetadataFromRow(firstRow);
-      flow.rows = flow.rows.slice(0, 1);
+      flow.rows = flow.rows.slice(1);
     }
     // infer from data when metadata row not available
     else {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.ts
@@ -57,9 +57,11 @@ export class DataListParser extends DefaultParser {
     else {
       metadataInitial = this.inferMetadataFromData(flow.rows);
     }
-    // quality check metadata and assign cleaned meta to flow
+    // quality check metadata and assign cleaned meta to flow if non-empty
     const { warnings, metadata } = this.qualityCheckMetadata(metadataInitial);
-    flow._metadata = metadata;
+    if (!isEmptyObjectDeep(metadata)) {
+      flow._metadata = metadata;
+    }
 
     if (warnings.length > 0) {
       for (const warning of warnings) {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.ts
@@ -6,6 +6,7 @@ import {
   setNestedProperty,
 } from "../../../utils";
 import { DefaultParser } from "./default.parser";
+import { isObjectLiteral, Logger } from "shared";
 
 export class DataListParser extends DefaultParser {
   postProcessRow(row: FlowTypes.Data_listRow) {
@@ -33,8 +34,86 @@ export class DataListParser extends DefaultParser {
     return row;
   }
 
-  public postProcessFlows(flows: FlowTypes.FlowTypeWithData[]) {
+  public override postProcessFlow(flow: FlowTypes.Data_list): FlowTypes.Data_list {
+    flow.metadata = this.getFlowMetadata(flow);
+    return flow;
+  }
+
+  public postProcessFlows(flows: FlowTypes.Data_list[]) {
     const flowsWithOverrides = assignFlowOverrides(flows);
     return flowsWithOverrides;
+  }
+
+  /** Assign column metadata from @metadata row if provided, or infer from data if not*/
+  private getFlowMetadata(flow: FlowTypes.Data_list) {
+    const [firstRow] = flow.rows;
+    const metadata =
+      firstRow?.id === "@metadata"
+        ? this.assignMetadataFromRow(firstRow)
+        : this.inferMetadataFromData(flow.rows);
+
+    const errors = this.qualityCheckMetadata(metadata);
+    if (errors.length > 0) {
+      for (const error of errors) {
+        console.error(error);
+      }
+      Logger.error({
+        msg1: `[${flow.flow_name}] Data List validation has (${errors.length}) errors`,
+        msg2: flow._xlsxPath,
+      });
+    }
+    return metadata;
+  }
+
+  /** Assign data_list metadata using a first `@metadata` row */
+  private assignMetadataFromRow(metadataRow: FlowTypes.Data_listRow) {
+    // do not extract metadata for id column
+    const { id, ...values } = metadataRow;
+    const metadata: FlowTypes.Data_list["metadata"] = {};
+    for (const [field, metadataString] of Object.entries(values)) {
+      metadata[field] = parseAppDataCollectionString(metadataString as string) as any;
+    }
+    return metadata;
+  }
+
+  /** Infer data_list metadata from data */
+  private inferMetadataFromData(rows: FlowTypes.Data_listRow[]) {
+    const metadata: FlowTypes.Data_list["metadata"] = {};
+    for (const row of rows) {
+      // do not extract metadata for id column
+      const { id, ...values } = row;
+      for (const [field, value] of Object.entries(values)) {
+        if (!metadata[field]) {
+          metadata[field] = { type: undefined };
+        }
+        // only assign type if previously unassigned
+        if (!metadata[field].type) {
+          metadata[field].type = this.inferColumnDataType(value);
+        }
+      }
+    }
+    return metadata;
+  }
+
+  private inferColumnDataType(value: any): FlowTypes.Data_listColumnType {
+    if (value === undefined) return undefined;
+    if (typeof value === "string") return "string";
+    if (typeof value === "number") return "number";
+    if (typeof value === "boolean") return "boolean";
+    if (isObjectLiteral(value)) return "object";
+    return undefined;
+  }
+
+  private qualityCheckMetadata(metadata: FlowTypes.Data_list["metadata"]) {
+    const errors: string[] = [];
+    for (const [columnName, columnMetadata] of Object.entries(metadata)) {
+      // ensure all columns have data type
+      if (columnMetadata.type === undefined) {
+        errors.push(
+          `"${columnName}" column cannot infer type\nEither include an @metadata column or add example value to a row`
+        );
+      }
+    }
+    return errors;
   }
 }

--- a/packages/scripts/test/helpers/utils.ts
+++ b/packages/scripts/test/helpers/utils.ts
@@ -11,7 +11,7 @@ import { Logger } from "shared/src/utils/logging/console-logger";
  * @param callOriginal specify whether to still call original Logger
  * methods after spy intercept
  */
-export function useMockLogger(callOriginal = true) {
+export function useMockLogger(callOriginal = false) {
   const error = jest.spyOn(Logger, "error");
   const warning = jest.spyOn(Logger, "warning");
   if (!callOriginal) {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
Add methods to parser to add a `_metadata` column to data_lists and track data types of non-string columns

This is designed to improve on the type infer methods used in #2513 (can update post-merge), so that `set_data` operations can correctly use the expected column data types. 

## Author Notes
**Use**
There are 2 methods now included to infer data types within the parser
1. If the author includes an `@metadata` row can manually specify `type: number/boolean` within the corresponding column cell.
2. Find first non-empty data entry and use type from that (will check all rows if required).

Note - only `number`  or `boolean`  types need to be specified as assume `string` by default, an if using nested `object` types these will automatically be detected when creating the data_list (columns would be formatted with `.` notation, e.g. `time.hour` and `time.minute`.

**Data Changes**
The corresponding generated `_metadata` will be included in the parsed data_lists github. Metadata is only included if specific entries exist (so will not appear for simple data_lists where every column is represented by string values)

**Quality Control**
I had originally planned to include errors or warnings when the data_type could not be inferred (e.g. no data in the column), however realised this is probably a fairly common case and having lots of warnings would not be so helpful (example screenshot)

**Example - warning log output - not currently in use**
![image](https://github.com/user-attachments/assets/064b8713-02d9-40f1-943a-e2f94abe93c7)

So instead, when data types cannot be inferred it will simply be assumed that they are designed to be strings. The data types shouldn't really be all that important unless using `set_data` operation to update data from action list strings (or in the future when adding new rows).

Similarly `metadata` is only included for columns that are not formatted as strings, to avoid overload of potentially less helpful information. 

**Future Plans**
With the use of the metadata column we could look to expand in the future to include more things features such as data validation or default values

## Review Notes
The easiest way to examine the new metadata is to sync and review the deployment repo diffs generated
```
yarn workflow sync;
yarn workflow repo open
```

## Dev Notes
If this happens to be merged before #2513 I can update, but I don't think it should block it in any way (non-breaking changes, can just be implemented in future update when reviewing add_data action)

## Git Issues

Closes #2524 

## Screenshots/Videos
**Example** - metadata now included in data_lists for all non-string columns (as inferred from data)
![image](https://github.com/user-attachments/assets/2fa61cfc-5b0b-4af8-81b6-13e31a96ce17)

