### PR TITLE
hotfix: plh components loading from external package

### DIFF
--- a/packages/components/demo/index.ts
+++ b/packages/components/demo/index.ts
@@ -1,16 +1,11 @@
-import { NgModule, Type } from "@angular/core";
+import { Type } from "@angular/core";
 
 import { DemoBasicComponent } from "./basic/basic.component";
 import type { ITemplateRowProps } from "src/app/shared/components/template/models";
-import { CommonModule } from "@angular/common";
-import { IonicModule } from "@ionic/angular";
 
-@NgModule({
-  imports: [CommonModule, IonicModule],
-  exports: [DemoBasicComponent],
-  declarations: [DemoBasicComponent],
-})
-export class DemoComponentsModule {}
+export { DemoBasicComponent };
+
+export const DEMO_COMPONENTS = [DemoBasicComponent];
 
 export const DEMO_COMPONENT_MAPPING: Record<string, Type<ITemplateRowProps>> = {
   demo_basic: DemoBasicComponent,

--- a/packages/components/plh/index.ts
+++ b/packages/components/plh/index.ts
@@ -1,25 +1,14 @@
-import { NgModule } from "@angular/core";
-
-import { CommonModule } from "@angular/common";
-import { IonicModule } from "@ionic/angular";
-import { TemplatePipesModule } from "src/app/shared/components/template/pipes";
-import { LottieModule } from "ngx-lottie";
 import { PlhParentPointCounterComponent } from "./parent-point-counter/parent-point-counter.component";
 import { PlhParentPointBoxComponent } from "./parent-point-box/parent-point-box.component";
 import { PlhModuleListItemComponent } from "./plh-kids-kw/components/module-list-item/module-list-item.component";
-import { RouterModule } from "@angular/router";
 
-@NgModule({
-  imports: [CommonModule, IonicModule, TemplatePipesModule, LottieModule, RouterModule],
-  exports: [PlhParentPointCounterComponent, PlhParentPointBoxComponent, PlhModuleListItemComponent],
-  declarations: [
-    PlhParentPointCounterComponent,
-    PlhParentPointBoxComponent,
-    PlhModuleListItemComponent,
-  ],
-  providers: [],
-})
-export class PlhComponentsModule {}
+export { PlhParentPointCounterComponent, PlhParentPointBoxComponent, PlhModuleListItemComponent };
+
+export const PLH_COMPONENTS = [
+  PlhParentPointCounterComponent,
+  PlhParentPointBoxComponent,
+  PlhModuleListItemComponent,
+];
 
 export const PLH_COMPONENT_MAPPING = {
   parent_point_counter: PlhParentPointCounterComponent,

--- a/src/app/shared/components/template/template.module.ts
+++ b/src/app/shared/components/template/template.module.ts
@@ -18,6 +18,10 @@ import { appendStyleSvgDirective } from "./directives/shadowStyleSvg.directive";
 import { createCustomElement } from "@angular/elements";
 import { TemplatePipesModule } from "./pipes";
 
+// Components from external packages
+import { PLH_COMPONENTS } from "packages/components/plh";
+import { DEMO_COMPONENTS } from "packages/components/demo";
+
 @NgModule({
   imports: [
     CommonModule,
@@ -32,12 +36,19 @@ import { TemplatePipesModule } from "./pipes";
     NgxExtendedPdfViewerModule,
     TemplatePipesModule,
   ],
-  exports: [...TEMPLATE_COMPONENTS, TemplateContainerComponent],
+  exports: [
+    ...TEMPLATE_COMPONENTS,
+    ...PLH_COMPONENTS,
+    ...DEMO_COMPONENTS,
+    TemplateContainerComponent,
+  ],
   declarations: [
     TmplCompHostDirective,
     TemplateComponent,
     TooltipDirective,
     ...TEMPLATE_COMPONENTS,
+    ...PLH_COMPONENTS,
+    ...DEMO_COMPONENTS,
     TemplateContainerComponent,
     appendStyleSvgDirective,
   ],


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the components defined in the PLH components package (`packages/components/plh`) were not available in the app. On `master`, these components defined in packages cannot be instantiated from templates (no error is thrown, the component row is just not rendered), and do not appear in the list available on the `/component` page.

Based on when this issue was first observed (by @FaithDaka a couple of days ago), this is likely a regression introduced by #2520. I haven't been able to track down why those changes would cause the issue, but it seems to be likely due to some circular imports between our different module and component declaration files that is resolved by this PR.

I've marked is at a `hotfix` because it seems to move us in the wrong direction with regards to eventually being able to declare external packages containing components and other dependencies outside of the main codebase. I wasn't able to resolve the issue from the package level. However, as the packages were already not independent of the core code (we have to explicitly import and consume the `PLH_COMPONENT_MAPPING` object in the core code, for example), this doesn't add a new dependency.

@FaithDaka, you should be able to merge this PR's feature branch into your working branch in order to continue working on the PLH components' styling.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
