### PR TITLE
Hotfix: Module List Item getParams()

### DIFF
--- a/packages/components/plh/plh-kids-kw/components/module-list-item/module-list-item.component.ts
+++ b/packages/components/plh/plh-kids-kw/components/module-list-item/module-list-item.component.ts
@@ -1,11 +1,7 @@
 import { Component, OnInit } from "@angular/core";
-import { FlowTypes } from "packages/data-models";
 import { TemplateBaseComponent } from "src/app/shared/components/template/components/base";
 import { TemplateTranslateService } from "src/app/shared/components/template/services/template-translate.service";
-import {
-  getBooleanParamFromTemplateRow,
-  getStringParamFromTemplateRow,
-} from "src/app/shared/utils";
+import { getParamFromTemplateRow, getStringParamFromTemplateRow } from "src/app/shared/utils";
 
 interface IModuleListItemParams {
   /* TEMPLATE PARAMETER: "module_image_asset". The image attached to the module */
@@ -45,7 +41,7 @@ export class PlhModuleListItemComponent extends TemplateBaseComponent implements
     this.params.textTransform = getStringParamFromTemplateRow(this._row, "text_transform", null) as
       | "capitalise"
       | "uppercase";
-    this.params.isLocked = getBooleanParamFromTemplateRow(this._row, "is_locked", false);
+    this.params.isLocked = getParamFromTemplateRow(this._row, "is_locked", false);
     this.params.navImageAsset = getStringParamFromTemplateRow(this._row, "nav_image_asset", null);
     this.params.lockedImageAsset = getStringParamFromTemplateRow(
       this._row,

--- a/packages/components/plh/plh-kids-kw/components/module-list-item/module-list-item.component.ts
+++ b/packages/components/plh/plh-kids-kw/components/module-list-item/module-list-item.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from "@angular/core";
 import { TemplateBaseComponent } from "src/app/shared/components/template/components/base";
 import { TemplateTranslateService } from "src/app/shared/components/template/services/template-translate.service";
-import { getParamFromTemplateRow, getStringParamFromTemplateRow } from "src/app/shared/utils";
+import {
+  getBooleanParamFromTemplateRow,
+  getStringParamFromTemplateRow,
+} from "src/app/shared/utils";
 
 interface IModuleListItemParams {
   /* TEMPLATE PARAMETER: "module_image_asset". The image attached to the module */
@@ -41,7 +44,7 @@ export class PlhModuleListItemComponent extends TemplateBaseComponent implements
     this.params.textTransform = getStringParamFromTemplateRow(this._row, "text_transform", null) as
       | "capitalise"
       | "uppercase";
-    this.params.isLocked = getParamFromTemplateRow(this._row, "is_locked", false);
+    this.params.isLocked = getBooleanParamFromTemplateRow(this._row, "is_locked", false);
     this.params.navImageAsset = getStringParamFromTemplateRow(this._row, "nav_image_asset", null);
     this.params.lockedImageAsset = getStringParamFromTemplateRow(
       this._row,

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -208,7 +208,7 @@ export function getBooleanParamFromTemplateRow(
   _default: boolean
 ): boolean {
   const params = row.parameter_list || {};
-  return params.hasOwnProperty(name) ? params[name] === "true" : _default;
+  return params.hasOwnProperty(name) ? parseBoolean(params[name]) : _default;
 }
 
 export function getAnswerListParamFromTemplateRow(

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -312,7 +312,9 @@ body[data-theme="plh_kids_kw"] {
         }
       }
     }
-    .module-item[data-lock~="true"] {
+    .module-item[data-lock~="true"],
+    .module-item[data-lock~="TRUE"],
+    .module-item[data-lock~="True"] {
       box-shadow: none;
       opacity: 0.5;
       border: 2px solid #dbe3f2;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Allows `is_locked` param to be read from a local variable.

Fixes #2560 
