### PR TITLE
fix: get boolean param from template row

### DIFF
--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -208,7 +208,7 @@ export function getBooleanParamFromTemplateRow(
   _default: boolean
 ): boolean {
   const params = row.parameter_list || {};
-  return params.hasOwnProperty(name) ? params[name] === "true" : _default;
+  return params.hasOwnProperty(name) ? parseBoolean(params[name]) : _default;
 }
 
 export function getAnswerListParamFromTemplateRow(


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue with the `getBooleanParamFromTemplateRow()` method, used when a component parameter has a boolean value, would not parse the correct value in the case that the parameter value was provided via a local variable (#2560)

## Git Issues

Closes #2560, #2561 

## Screenshots/Videos

[comp_plh_module_list_item](https://docs.google.com/spreadsheets/d/1Tq8Ib_ZcJsABW9U9XbQxgnmtv_uayXk28DXoa94j1aE/edit?gid=569531329#gid=569531329) displaying as corrected, in contrast to screenshot on the issue:

<img width="271" alt="Screenshot 2024-11-27 at 12 54 22" src="https://github.com/user-attachments/assets/15471927-e75a-4553-8823-2d3fac6ebff5">

