### PR TITLE
hotfix: processTemplateWithoutRender issue

### DIFF
--- a/src/app/shared/components/template/services/instance/template-process.service.ts
+++ b/src/app/shared/components/template/services/instance/template-process.service.ts
@@ -57,7 +57,10 @@ export class TemplateProcessService extends SyncServiceBase {
     this.container = new TemplateContainerComponent(
       this.templateService,
       this.templateNavService,
-      this.injector
+      this.injector,
+      undefined,
+      undefined,
+      true
     );
     // this.container.name = this.container.name || this.templatename;
     // this.templateBreadcrumbs = [...(this.parent?.templateBreadcrumbs || []), this.name];

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -245,11 +245,6 @@ export class TemplateContainerComponent implements OnInit, OnDestroy {
     log_group = SHOW_DEBUG_LOGS ? console.group : () => null;
     log_groupEnd = SHOW_DEBUG_LOGS ? console.groupEnd : () => null;
   }
-
-  private isCreatedProgrammatically(): boolean {
-    // Check call stack for programmatic creation indicators
-    return new Error().stack.includes("createComponent");
-  }
 }
 
 /** helper function used for dev to wait a fixed amount of time */

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -43,7 +43,7 @@ export class TemplateContainerComponent implements OnInit, OnDestroy {
   /** unique instance_name of template if created as a child of another template */
   @Input() name: string;
   /** flow_name of template for lookup */
-  templatename = input.required<string>();
+  templatename = input<string>();
   /** reference to parent template (when nested) */
   @Input() parent?: TemplateContainerComponent;
   /** reference to the full row if template instantiated from a parent */


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

A hotfix for an issue where any templates processed without being rendered (e.g. startup templates, which are processed on app start without rendering), would throw an error. This is a regression issue introduced by #2531. See [this mattermost thread](https://chat.idems.international/all/pl/pgm7d7ccepfb3qottn76frboco) for an identification of the issue.

## Dev Notes

Error log on master, for `plh_kids_tz` deployment:

<img width="480" alt="Screenshot 2024-12-02 at 14 04 05" src="https://github.com/user-attachments/assets/37a16a15-4430-4451-90b4-7ab43bf32afe">

The issue arises when we try to instantiate a template container component programmatically, outside of Angular's component lifecycle, as we do in the `TemplateProcessService.processTemplateWithoutRender()` method (which is called to handle lifecycle action templates). In that case, the `effect()` in the component's constructor, introduced in #2531, throws an error.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
