### PR TITLE
Kuwait Theme: Round Button Variants

### DIFF
--- a/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.html
+++ b/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.html
@@ -1,16 +1,17 @@
 <div class="wrapper" [class.home_screen_wrapper]="isHomeScreen">
   <ion-tab-button
-    [class]="style"
+    [attr.data-variant]="params.variant"
+    [class]="params.style || 'information'"
     (click)="onClick($event)"
     class="round-icon-button"
     [disabled]="_row.disabled"
   >
     <ion-icon
-      [name]="icon_src"
-      [style.place-items]="text ? 'flex-end' : 'center'"
-      [style.margin-top]="text ? '5px' : '0'"
-      [src]="isCustomIcon ? (icon_src | plhAsset) : icon_src"
+      [name]="params.icon_src"
+      [style.place-items]="params.text ? 'flex-end' : 'center'"
+      [style.margin-top]="params.text ? '5px' : '0'"
+      [src]="isCustomIcon ? (params.icon_src | plhAsset) : params.icon_src"
     ></ion-icon>
-    <div *ngIf="text">{{ text }}</div>
+    <div *ngIf="params.text">{{ params.text }}</div>
   </ion-tab-button>
 </div>

--- a/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.scss
+++ b/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.scss
@@ -3,9 +3,18 @@
 $background-primary: var(--button-background-primary, var(--gradient-primary-mid-vertical));
 $background-secondary: var(--button-background-secondary, var(--gradient-secondary-mid-vertical));
 $background-option: (--button-background-option, var(--gradient-primary-dark-vertical));
-$background-secondary-light: var(--round-button-background-secondary-light, var(--ion-color-secondary-200));
-$background-secondary-mid: var(--round-button-background-secondary-mid, var(--ion-color-secondary-400));
-$background-secondary-dark: var(--round-button-background-secondary-dark, var(--ion-color-secondary-600));
+$background-secondary-light: var(
+  --round-button-background-secondary-light,
+  var(--ion-color-secondary-200)
+);
+$background-secondary-mid: var(
+  --round-button-background-secondary-mid,
+  var(--ion-color-secondary-400)
+);
+$background-secondary-dark: var(
+  --round-button-background-secondary-dark,
+  var(--ion-color-secondary-600)
+);
 
 ion-tab-button {
   color: var(--ion-color-primary-contrast);
@@ -129,4 +138,11 @@ ion-tab-button {
 }
 .alternative {
   color: var(--ion-color-primary);
+}
+
+.no-background {
+  background-color: transparent;
+  ion-icon {
+    height: 32px;
+  }
 }

--- a/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.scss
+++ b/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.scss
@@ -63,6 +63,7 @@ ion-tab-button {
     text-transform: none;
   }
 }
+
 .home_screen {
   @include mixins.largest-square;
   @include mixins.absolute-centered;
@@ -98,51 +99,69 @@ ion-tab-button {
     height: var(--round-button-wrapper-small-device-height);
   }
 }
-.yellow {
-  background: $background-secondary-light;
-}
-.orange {
-  background: $background-secondary-mid;
-}
-.dark_orange {
-  background: $background-secondary-dark;
-}
 
-.navigation {
-  width: var(--round-button-navigation-width);
-  min-height: var(--round-button-navigation-min-height);
-  background: $background-secondary;
-}
+ion-tab-button {
+  &[data-variant~="information"],
+  &.information {
+    background: $background-primary;
+  }
 
-.information {
-  background: $background-primary;
-}
+  &[data-variant~="yellow"],
+  &.yellow {
+    background: $background-secondary-light;
+  }
 
-.make_me_smile {
-  background: $background-primary;
-  color: var(--ion-color-primary-contrast);
-}
+  &[data-variant~="orange"],
+  &.orange {
+    background: $background-secondary-mid;
+  }
 
-.get_me_going {
-  background: $background-secondary;
-  color: var(--ion-color-primary-contrast);
-}
+  &[data-variant~="dark_orange"],
+  &.dark_orange {
+    background: $background-secondary-dark;
+  }
 
-.options {
-  background: $background-option;
-  color: var(--ion-color-primary-contrast);
-}
+  &[data-variant~="navigation"],
+  &.navigation {
+    width: var(--round-button-navigation-width);
+    min-height: var(--round-button-navigation-min-height);
+    background: $background-secondary;
+  }
 
-.standard {
-  color: var(--ion-color-primary-contrast);
-}
-.alternative {
-  color: var(--ion-color-primary);
-}
+  &[data-variant~="make_me_smile"],
+  &.make_me_smile {
+    background: $background-primary;
+    color: var(--ion-color-primary-contrast);
+  }
 
-.no-background {
-  background-color: transparent;
-  ion-icon {
-    height: 32px;
+  &[data-variant~="get_me_going"],
+  &.get_me_going {
+    background: $background-secondary;
+    color: var(--ion-color-primary-contrast);
+  }
+
+  &[data-variant~="options"],
+  &.options {
+    background: $background-option;
+    color: var(--ion-color-primary-contrast);
+  }
+
+  &[data-variant~="standard"],
+  &.standard {
+    color: var(--ion-color-primary-contrast);
+  }
+
+  &[data-variant~="alternative"],
+  &.alternative {
+    color: var(--ion-color-primary);
+  }
+
+  &[data-variant~="no-background"],
+  &.no-background {
+    background: transparent;
+    box-shadow: none;
+    ion-icon {
+      height: 32px;
+    }
   }
 }

--- a/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.ts
+++ b/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.ts
@@ -5,6 +5,23 @@ import { TemplateContainerComponent } from "../../template-container.component";
 import { TemplateBaseComponent } from "../base";
 import { getBooleanParamFromTemplateRow, getStringParamFromTemplateRow } from "../../../../utils";
 
+interface IRoundButtonParams {
+  /** TEMPLATE_PARAMETER: 'icon_src' */
+  buttonAlign: string;
+  /** TEMPLATE_PARAMETER: 'icon_src' */
+  disabled: boolean;
+  /** TEMPLATE_PARAMETER: 'icon_src' */
+  icon_src: string;
+  /** TEMPLATE_PARAMETER: 'icon_src' */
+  style: string;
+  /** TEMPLATE_PARAMETER: 'icon_src' */
+  text: string;
+  /** TEMPLATE_PARAMETER: 'style'. Legacy, use 'variant' instead */
+  textAlign: string;
+  /** TEMPLATE_PARAMETER: 'variant' */
+  variant: "no-background" | "module" | "category" | "navigation" | "information" | "module" | "home_screen" | "orange" | "dark_orange" | "yellow" | "standard" | "alternative";
+}
+
 @Component({
   selector: "plh-round-button",
   templateUrl: "./round-icon-button.component.html",
@@ -16,12 +33,7 @@ export class RoundIconButtonComponent
 {
   @Input() parent: TemplateContainerComponent;
   @Input() template: FlowTypes.Template;
-  icon_src: string;
-  text: string;
-  style: string;
-  disabled: boolean = false;
-  textAlign: string;
-  buttonAlign: string;
+  params: Partial<IRoundButtonParams> = {};
   isHomeScreen: boolean = false;
   isCustomIcon: boolean = false;
   constructor(private elRef: ElementRef) {
@@ -44,15 +56,19 @@ export class RoundIconButtonComponent
   }
 
   getParams() {
-    this.style = getStringParamFromTemplateRow(this._row, "style", "information");
-    this.disabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
+    this.params.style = getStringParamFromTemplateRow(this._row, "style", "");
+    this.params.variant = getStringParamFromTemplateRow(this._row, "variant", "")
+      .split(",")
+      .join(" ")
+      .concat(" ") as IRoundButtonParams["variant"];
+    this.params.disabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
     if (this._row.disabled) {
-      this.disabled = true;
+      this.params.disabled = true;
     }
-    this.text = getStringParamFromTemplateRow(this._row, "text", "");
-    this.icon_src = getStringParamFromTemplateRow(this._row, "icon_src", "");
-    this.buttonAlign = getStringParamFromTemplateRow(this._row, "button_align", "center");
-    this.isHomeScreen = this.style.includes("home_screen");
-    this.isCustomIcon = this.icon_src.includes("/");
+    this.params.text = getStringParamFromTemplateRow(this._row, "text", "");
+    this.params.icon_src = getStringParamFromTemplateRow(this._row, "icon_src", "");
+    this.params.buttonAlign = getStringParamFromTemplateRow(this._row, "button_align", "center");
+    this.isHomeScreen = this.params.style.includes("home_screen");
+    this.isCustomIcon = this.params.icon_src.includes("/");
   }
 }

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -671,12 +671,12 @@ body[data-theme="plh_kids_kw"] {
   ion-tab-button {
     box-shadow: none;
     background: var(--ion-color-primary-600);
-    &.navigation {
+    &[data-variant~="navigation"] {
       background: var(--ion-color-primary-700) !important;
       border-radius: var(--ion-border-radius-standard);
       box-shadow: none !important;
     }
-    &.module {
+    &[data-variant~="module"] {
       background: var(--color-secondary-blue-40) !important;
       border-radius: var(--ion-border-radius-rounded);
       box-shadow: -1px 2px 12px rgba(43, 144, 199, 0.6);
@@ -684,16 +684,16 @@ body[data-theme="plh_kids_kw"] {
       min-width: 68px;
       min-height: 64px;
     }
-    &.orange {
+    &[data-variant~="orange"] {
       background: var(--color-accent-orange-70);
     }
-    &.yellow {
+    &[data-variant~="yellow"] {
       background: var(--color-accent-yellow-70);
     }
-    &.dark-orange {
+    &[data-variant~="dark-orange"] {
       background: var(--color-accent-orange-40);
     }
-    &.information {
+    &[data-variant~="information"] {
       background: var(--color-secondary-blue-40);
     }
   }

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -673,7 +673,7 @@ body[data-theme="plh_kids_kw"] {
     box-shadow: none;
     background: var(--ion-color-primary-600);
     &.navigation {
-      background: var(--ion-color-primary-600) !important;
+      background: var(--ion-color-primary-700) !important;
       border-radius: var(--ion-border-radius-standard);
       box-shadow: none !important;
     }

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -667,4 +667,35 @@ body[data-theme="plh_kids_kw"] {
       padding: 8px;
     }
   }
+
+  // Round Button
+  ion-tab-button {
+    box-shadow: none;
+    background: var(--ion-color-primary-600);
+    &.navigation {
+      background: var(--ion-color-primary-600) !important;
+      border-radius: var(--ion-border-radius-standard);
+      box-shadow: none !important;
+    }
+    &.module {
+      background: var(--color-secondary-blue-40) !important;
+      border-radius: var(--ion-border-radius-rounded);
+      box-shadow: -1px 2px 12px rgba(43, 144, 199, 0.6);
+      border: 1px solid var(--color-secondary-blue-60);
+      min-width: 68px;
+      min-height: 64px;
+    }
+    &.orange {
+      background: var(--color-accent-orange-70);
+    }
+    &.yellow {
+      background: var(--color-accent-yellow-70);
+    }
+    &.dark-orange {
+      background: var(--color-accent-orange-40);
+    }
+    &.information {
+      background: var(--color-secondary-blue-40);
+    }
+  }
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Includes styling of Navigation and Module `comp_round_button` under Kuwait theme. [Link](https://docs.google.com/spreadsheets/d/161GZue4jkQNJzyfYvMWesMp2vwvbkJgpNqkDlVIGJDw/edit?usp=sharing)

Refactors the `rounf_button` component to use varaints. `style` is still supported, but should be considered legacy.

## Author Notes

Round Button with `navigation` variant can be used for **back** buttons and now appears as:
<img width="140" src="https://github.com/user-attachments/assets/e9fc02a3-50e0-4d86-9df9-5f4b3899216a">

Round Button with `module` variant can be used for module navigation and now appears as:
<img width="140" src="https://github.com/user-attachments/assets/6ebdc153-448c-4dcb-9e72-49ab32f56cfe">

Round Button with `no-background` variant:
<img width="200" src="https://github.com/user-attachments/assets/3faf2098-8c9d-4e28-837e-594a0b528170">

## Git Issues

Closes #2578

## Screenshots

| variant  | Design        | Kuwait Theme    |
|----------- |---------------|----------|
| `module` | <img width="250" src="https://github.com/user-attachments/assets/1442d5ac-c36a-49ae-a934-34073a433462"> | <img width="180" src="https://github.com/user-attachments/assets/6ebdc153-448c-4dcb-9e72-49ab32f56cfe"> |
| `navigation` | <img width="240" src="https://github.com/user-attachments/assets/cc956a19-891d-4f33-8f8e-fc77b174a4a7"> | <img width="180" src="https://github.com/user-attachments/assets/e9fc02a3-50e0-4d86-9df9-5f4b3899216a"> |


