### PR TITLE
fix: progress-bar-component post-2558

### DIFF
--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -152,6 +152,7 @@ export class TmplTaskProgressBarComponent
       this.params.showText = this.showText;
       this.params.completedColumnName = "completed";
       this.params.completedFieldColumnName = "completed_field";
+      this.params.variant = "bar";
     }
   }
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

#2558 added variants to the `task_progress_bar` component, however it didn't handle the case of setting the variant to the default (`"bar"`) when the component is instantiated within a parent component (e.g. the `task_card`). This PR resolves that.

## Git Issues

Closes #2590

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
