### PR TITLE
Fix: progress wheel percentage value

### DIFF
--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -156,7 +156,7 @@ export class TmplTaskProgressBarComponent
   }
 
   get progressPercentage() {
-    return (this.subtasksCompleted / this.subtasksTotal) * 100;
+    return Math.round((this.subtasksCompleted / this.subtasksTotal) * 100);
   }
 
   /** Calculate circumference of progress circle based on number of tasks completed */


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Ensures that the percentage value displayed in the progress wheel (`wheel` variant of the `task_progress_bar` component) is rounded to the nearest whole number. 

## Git Issues

Closes #2592 

## Screenshots/Videos

comp_task_progress_bar. This screenshot was generated by hardcoding the value `46.666666666666664` as the progress percentage.
<img width="400" alt="Screenshot 2024-12-03 at 16 02 10" src="https://github.com/user-attachments/assets/84d64fdd-acd4-4278-bd05-c4e195bd4c9a">

