### PR TITLE
refactor: display group sticky component

### DIFF
--- a/src/app/feature/nav-stack/components/nav-stack/nav-stack.component.global.scss
+++ b/src/app/feature/nav-stack/components/nav-stack/nav-stack.component.global.scss
@@ -8,8 +8,6 @@ ion-modal.nav-stack-modal {
   --box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --backdrop-opacity: 0.5;
 
-  z-index: calc(10 + var(--nav-stack-index));
-
   // Override defalut ion-modal behaviour of hiding backdrop for subsequent modals after first
   &:not([data-nav-stack-index="0"]) {
     --backdrop-opacity: 0.2 !important;

--- a/src/app/shared/components/template/components/index.ts
+++ b/src/app/shared/components/template/components/index.ts
@@ -30,6 +30,7 @@ import { TmplDashedBoxComponent } from "./dashed-box/dashed-box.component";
 import { TmplDataItemsComponent } from "./data-items/data-items.component";
 import { TmplDisplayGridComponent } from "./layout/display-grid/display-grid.component";
 import { TmplDisplayGroupComponent } from "./layout/display-group/display-group.component";
+import { TmplDisplayGroupStickyComponent } from "./layout/display-group/sticky/display-group-sticky.component";
 import { TmplDrawerComponent } from "./drawer/drawer.component";
 import { TmplHelpIconComponent } from "./help-icon";
 import { TmplIconBannerComponent } from "./icon-banner/icon-banner.component";
@@ -92,6 +93,7 @@ export const TEMPLATE_COMPONENTS = [
   TmplDataItemsComponent,
   TmplDisplayGridComponent,
   TmplDisplayGroupComponent,
+  TmplDisplayGroupStickyComponent,
   TmplDrawerComponent,
   TmplHelpIconComponent,
   TmplIconBannerComponent,
@@ -156,6 +158,7 @@ const COMMON_COMPONENT_MAPPING = {
   debug_toggle: PLHDebugToggleComponent,
   display_grid: TmplDisplayGridComponent,
   display_group: TmplDisplayGroupComponent,
+  display_group_sticky: TmplDisplayGroupStickyComponent,
   drawer: TmplDrawerComponent,
   form: FormComponent,
   help_icon: TmplHelpIconComponent,

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.html
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.html
@@ -1,39 +1,50 @@
-<div
-  #displayGroupWrapper
-  (click)="clickDisplayGroup()"
-  class="display-group-wrapper"
-  [attr.data-param-style]="params.style"
-  [attr.data-rowname]="_row.name"
-  [attr.data-variant]="params.variant"
-  [attr.data-sticky]="params.sticky"
-  [style.marginBottom.px]="params.offset"
-  [ngSwitch]="type"
-  [style]="_row.style_list | styleList"
->
-  <!-- Default Layout -->
-  <ng-container *ngSwitchDefault>
-    <plh-template-component
-      *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
-      [row]="childRow"
+@if (params.sticky) {
+  <!-- Sticky display group - includes placeholder padding elements above/below main content -->
+  @if (params.sticky === "top") {
+    <div [style.height.px]="sticky.height()"></div>
+  }
+  <tmpl-display-group-sticky [position]="params.sticky" #sticky>
+    <ng-container *ngTemplateOutlet="content"></ng-container>
+  </tmpl-display-group-sticky>
+  @if (params.sticky === "bottom") {
+    <div [style.height.px]="sticky.height()"></div>
+  }
+} @else {
+  <!-- Regular display group - render templated content -->
+  <ng-container *ngTemplateOutlet="content"></ng-container>
+}
+
+<!-- Main Content - shown either within sticky or standard versions -->
+<ng-template #content>
+  <!--  -->
+  <div
+    (click)="clickDisplayGroup()"
+    class="display-group-wrapper"
+    [attr.data-param-style]="params.style"
+    [attr.data-rowname]="_row.name"
+    [attr.data-variant]="params.variant"
+    [style.marginBottom.px]="params.offset"
+    [ngSwitch]="type"
+    [style]="_row.style_list | styleList"
+  >
+    <!-- Default Layout -->
+    <ng-container *ngSwitchDefault>
+      <plh-template-component
+        *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
+        [row]="childRow"
+        [parent]="parent"
+        [attr.data-rowname]="_row.name"
+      >
+      </plh-template-component>
+    </ng-container>
+    <!-- Dashed-box -->
+    <plh-advanced-dashed-box
+      *ngSwitchCase="'dashed_box'"
+      [inputRow]="_row"
       [parent]="parent"
-      [attr.data-rowname]="_row.name"
-    >
-    </plh-template-component>
-  </ng-container>
-  <!-- Dashed-box -->
-  <plh-advanced-dashed-box
-    *ngSwitchCase="'dashed_box'"
-    [inputRow]="_row"
-    [parent]="parent"
-    style="flex: 1"
-  ></plh-advanced-dashed-box>
-  <!-- Form layout -->
-  <plh-tmpl-form *ngSwitchCase="'form'" [inputRow]="_row" [parent]="parent"></plh-tmpl-form>
-</div>
-<!-- If sticky, add inline element so that rest of content doesn't shift behind -->
-@if (params.sticky === "top") {
-  <div class="sticky-top-placeholder" [style.height.px]="stickyHeight()"></div>
-}
-@if (params.sticky === "bottom") {
-  <div class="sticky-bottom-placeholder" [style.height.px]="stickyHeight()"></div>
-}
+      style="flex: 1"
+    ></plh-advanced-dashed-box>
+    <!-- Form layout -->
+    <plh-tmpl-form *ngSwitchCase="'form'" [inputRow]="_row" [parent]="parent"></plh-tmpl-form>
+  </div>
+</ng-template>

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -5,29 +5,6 @@
   display: flex;
   align-items: center;
 }
-
-// When the display group is "sticky", style it as an inline header/footer
-.display-group-wrapper {
-  &[data-sticky="top"],
-  &[data-sticky="bottom"] {
-    background-color: var(--ion-background-color);
-    position: fixed;
-    left: 0;
-    width: 100vw;
-    display: flex;
-    justify-content: center;
-    // nav-stacks have a z-index of (10 + var(--nav-stack-index))
-    z-index: calc(10 + var(--nav-stack-index, 0));
-  }
-
-  &[data-sticky="top"] {
-    top: 0;
-  }
-
-  &[data-sticky="bottom"] {
-    bottom: 0;
-  }
-}
 /// In flex box components should try to fill height, but not width (leave to flex property)
 .display-group-wrapper > plh-template-component {
   height: 100%;

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
@@ -1,12 +1,4 @@
-import {
-  AfterViewInit,
-  Component,
-  ElementRef,
-  OnDestroy,
-  OnInit,
-  signal,
-  ViewChild,
-} from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { TemplateBaseComponent } from "../../base";
 import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "../../../../../utils";
 
@@ -26,26 +18,13 @@ interface IDisplayGroupParams {
   templateUrl: "./display-group.component.html",
   styleUrls: ["../../tmpl-components-common.scss", "./display-group.component.scss"],
 })
-export class TmplDisplayGroupComponent
-  extends TemplateBaseComponent
-  implements OnInit, AfterViewInit, OnDestroy
-{
+export class TmplDisplayGroupComponent extends TemplateBaseComponent implements OnInit {
   params: Partial<IDisplayGroupParams> = {};
   bgColor: string;
   type: "form" | "dashed_box" | "default";
 
-  @ViewChild("displayGroupWrapper") displayGroupWrapper: ElementRef;
-  private resizeObserver: ResizeObserver;
-  stickyHeight = signal<number>(0);
-
   ngOnInit() {
     this.getParams();
-  }
-
-  ngAfterViewInit() {
-    if (this.params.sticky) {
-      this.initResizeObserver();
-    }
   }
 
   public clickDisplayGroup() {
@@ -59,11 +38,7 @@ export class TmplDisplayGroupComponent
       .split(",")
       .join(" ")
       .concat(" " + this.params.style) as IDisplayGroupParams["variant"];
-    this.params.sticky = getStringParamFromTemplateRow(
-      this._row,
-      "sticky",
-      null
-    ) as IDisplayGroupParams["sticky"];
+    this.params.sticky = getStringParamFromTemplateRow(this._row, "sticky", null) as any;
     this.type = this.getTypeFromStyles();
   }
 
@@ -72,39 +47,5 @@ export class TmplDisplayGroupComponent
     if (this.params.style?.includes("dashed_box") || this.params.variant?.includes("dashed_box"))
       return "dashed_box";
     return "default";
-  }
-
-  /** Observe the height of the display group wrapper element and update the height of the placeholder accordingly */
-  private initResizeObserver() {
-    if (this.displayGroupWrapper) {
-      this.resizeObserver = new ResizeObserver((entries) => {
-        let containerPadding = 0;
-        // In the case of a sticky header, the top padding/margin of the main app content and template container need to be accounted for,
-        // now that the display group sits at the very top of the content window outside of the main content and template container
-        if (this.params.sticky === "top") {
-          containerPadding = this.getTotalContainerTopPadding();
-        }
-        const entry = entries[0];
-        this.stickyHeight.set(entry.contentRect.height - containerPadding);
-      });
-
-      this.resizeObserver.observe(this.displayGroupWrapper.nativeElement);
-    }
-  }
-
-  private getTotalContainerTopPadding() {
-    const computedStyles = getComputedStyle(this.displayGroupWrapper.nativeElement);
-    const ionContentPaddingStart =
-      parseFloat(computedStyles.getPropertyValue("--padding-start")) || 0;
-    const templateContainerMarginEm = computedStyles.getPropertyValue("--row-margin-top").trim();
-    const fontSize = parseFloat(computedStyles.fontSize) || 0;
-    const templateContainerMarginPx = parseFloat(templateContainerMarginEm) * fontSize || 0;
-    return ionContentPaddingStart + templateContainerMarginPx;
-  }
-
-  ngOnDestroy() {
-    if (this.resizeObserver) {
-      this.resizeObserver.disconnect();
-    }
   }
 }

--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.html
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
@@ -1,0 +1,22 @@
+// When the display group is "sticky", style it as an inline header/footer
+:host {
+  display: flex;
+  position: fixed;
+  left: 0;
+  width: 100vw;
+  justify-content: center;
+  background-color: var(--ion-background-color);
+
+  // HACK - nav-stacks have a z-index of (10 + var(--nav-stack-index))
+  // TODO - is this required??
+  // z-index: calc(10 + var(--nav-stack-index, 0));
+
+  // use provided inputs to specify host top/bottom as signals do not nicely
+  // map to hostAttribute https://github.com/angular/angular/issues/53888
+  &[ng-reflect-position="top"] {
+    top: 0;
+  }
+  &[ng-reflect-position="bottom"] {
+    bottom: 0;
+  }
+}

--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
@@ -6,10 +6,7 @@
   width: 100vw;
   justify-content: center;
   background-color: var(--ion-background-color);
-
-  // HACK - nav-stacks have a z-index of (10 + var(--nav-stack-index))
-  // TODO - is this required??
-  // z-index: calc(10 + var(--nav-stack-index, 0));
+  z-index: 10;
 
   // use provided inputs to specify host top/bottom as signals do not nicely
   // map to hostAttribute https://github.com/angular/angular/issues/53888

--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.ts
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.ts
@@ -34,9 +34,22 @@ export class TmplDisplayGroupStickyComponent implements AfterViewInit, OnDestroy
   }
 
   private handleSizeChange(entries: ResizeObserverEntry[]) {
-    // In the case of a sticky header, the top padding/margin of the main app content and template container need to be accounted for,
-    // now that the display group sits at the very top of the content window outside of the main content and template container
     const [{ contentRect }] = entries;
-    this.height.set(contentRect.height);
+
+    let topPadding = 0;
+    if (this.position() === "top") {
+      // As the display group now sits at the top of the content window ignoring the app-wide padding applied to ion-content,
+      // the height of the inline display group placeholder should account for this padding
+      topPadding = this.getContentContainerTopPadding();
+    }
+
+    this.height.set(contentRect.height - topPadding);
+  }
+
+  private getContentContainerTopPadding() {
+    const computedStyles = getComputedStyle(this.viewRef.element.nativeElement);
+    const ionContentPaddingStart =
+      parseFloat(computedStyles.getPropertyValue("--padding-start")) || 0;
+    return ionContentPaddingStart;
   }
 }

--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.ts
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.ts
@@ -1,0 +1,42 @@
+import {
+  AfterViewInit,
+  Component,
+  input,
+  OnDestroy,
+  signal,
+  ViewContainerRef,
+} from "@angular/core";
+
+@Component({
+  selector: "tmpl-display-group-sticky",
+  templateUrl: "display-group-sticky.component.html",
+  styleUrl: "display-group-sticky.component.scss",
+})
+/**
+ *
+ */
+export class TmplDisplayGroupStickyComponent implements AfterViewInit, OnDestroy {
+  position = input.required<"top" | "bottom">();
+  height = signal(0);
+
+  private resizeObserver = new ResizeObserver((entries) => this.handleSizeChange(entries));
+
+  constructor(private readonly viewRef: ViewContainerRef) {}
+
+  ngAfterViewInit() {
+    // Observe own component height and update signal so that parent display-group
+    // can adjust padding as required
+    this.resizeObserver.observe(this.viewRef.element.nativeElement);
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver.disconnect();
+  }
+
+  private handleSizeChange(entries: ResizeObserverEntry[]) {
+    // In the case of a sticky header, the top padding/margin of the main app content and template container need to be accounted for,
+    // now that the display group sits at the very top of the content window outside of the main content and template container
+    const [{ contentRect }] = entries;
+    this.height.set(contentRect.height);
+  }
+}

--- a/src/app/shared/components/template/components/manifest.ts
+++ b/src/app/shared/components/template/components/manifest.ts
@@ -6,7 +6,7 @@ import { PLH_COMPONENT_MANIFEST } from "components/plh/manifest";
 const COMMON_COMPONENT_MANIFEST: IComponentManifest<ICommonComponentName> = {
   carousel: { module: "SwiperModule" },
   display_group: {
-    implicit: ["form", "advanced_dashed_box"],
+    implicit: ["advanced_dashed_box", "display_group_sticky", "form"],
   },
   lottie_animation: { module: "LottieModule" },
   pdf: { assets: "/assets/comp-pdf", module: "NgxExtendedPdfViewerModule" },


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Targets branch of #2564 

Rework to move all sticky display logic to separate component

## Review Notes
To confirm if still functions identically to target branch pr

## Dev Notes
This creates a child `display-group-sticky` component that is rendered within the main `display-group` component, with the sole purpose of tracking content height for use in the included padding offsets.

Most of the code was copy-pasted, although I wasn't sure whether it still needed all the logic to calculate additional padding, given that it is now still rendered inside the main display-group component (I think maybe not). I also wasn't sure if the CSS z-index that references nav-stacks is required (commented out, but should be removed if not needed).

Although it declares a new `display_group_sticky` component, that is only to support the current optimisation system (only named templating components can be marked as implicit dependencies)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
