### PR TITLE
hotfix: nav-stack dismissal

### DIFF
--- a/src/app/feature/nav-stack/components/nav-stack/nav-stack.component.ts
+++ b/src/app/feature/nav-stack/components/nav-stack/nav-stack.component.ts
@@ -17,6 +17,6 @@ export class NavStackComponent {
   constructor(private modalCtrl: ModalController) {}
 
   public close() {
-    this.modalCtrl.dismiss();
+    this.modalCtrl.dismiss("", "close-button");
   }
 }

--- a/src/app/feature/nav-stack/nav-stack.service.ts
+++ b/src/app/feature/nav-stack/nav-stack.service.ts
@@ -2,16 +2,24 @@ import { Injectable } from "@angular/core";
 import { ModalController } from "@ionic/angular";
 import { INavStackConfig, NavStackComponent } from "./components/nav-stack/nav-stack.component";
 import { SyncServiceBase } from "src/app/shared/services/syncService.base";
+import { TemplateNavService } from "src/app/shared/components/template/services/template-nav.service";
 
 interface NavStackModal extends HTMLIonModalElement {}
+
+// Modal dismiss 'roles' that are allowed to dismiss the nav-stack
+const ALLOWED_DISMISS_ROLES = ["close-button", "backdrop", "programmatic"];
 
 @Injectable({
   providedIn: "root",
 })
 export class NavStackService extends SyncServiceBase {
   private openNavStacks: HTMLIonModalElement[] = [];
+  private readonly MAX_NAV_STACKS = 10;
 
-  constructor(private modalCtrl: ModalController) {
+  constructor(
+    private modalCtrl: ModalController,
+    private templateNavService: TemplateNavService
+  ) {
     super("navStack");
     // NB: Actions are registered in nav-stack module
   }
@@ -21,29 +29,45 @@ export class NavStackService extends SyncServiceBase {
    * Await and remove from openNavStacks array on dismiss
    */
   public async pushNavStack(navStackConfig: INavStackConfig) {
+    if (this.openNavStacks.length >= this.MAX_NAV_STACKS) {
+      console.warn(`[NAV STACK] Maximum number of nav stacks reached: ${this.MAX_NAV_STACKS}`);
+      return null;
+    }
     const modal = await this.createNavStackModal(navStackConfig);
     await this.presentAndTrackModal(modal);
     return modal;
   }
 
   public async closeAllNavStacks() {
-    await Promise.all(this.openNavStacks.map(async (navStack) => await navStack.dismiss()));
+    await Promise.all(
+      this.openNavStacks.map(async (navStack) => await this.dismissNavStackModal(navStack))
+    );
   }
 
   public async closeTopNavStack() {
     if (this.openNavStacks.length === 0) return;
-    await this.closeNavStack(this.openNavStacks.length - 1);
+    await this.closeNavStackAtIndex(this.openNavStacks.length - 1);
   }
 
   /**
    * Creates a new nav-stack modal instance
    */
   private async createNavStackModal(config: INavStackConfig) {
+    console.log("[NAV STACK] config", config);
     const modal = await this.modalCtrl.create({
       component: NavStackComponent,
       componentProps: { config },
       // Styling must be done in global theme scss as the modal is injected dynamically into the dom
       cssClass: "nav-stack-modal",
+      canDismiss: (data, role) => {
+        console.log("Dismiss requested", data, role);
+        console.log("Allowed dismiss roles", ALLOWED_DISMISS_ROLES);
+        if (ALLOWED_DISMISS_ROLES.includes(role)) {
+          console.log("Dismiss allowed");
+          return Promise.resolve(true);
+        }
+        return Promise.resolve(false);
+      },
     });
     return modal as NavStackModal;
   }
@@ -53,22 +77,53 @@ export class NavStackService extends SyncServiceBase {
     modal.setAttribute("data-nav-stack-index", navStackIndex.toString());
     modal.style.setProperty("--nav-stack-index", navStackIndex.toString());
 
-    // Remove array entry whenever modal is dismissed
-    modal.onWillDismiss().then(() => {
-      const index = this.getNavStackIndex(modal);
-      if (index === -1) return;
-      this.openNavStacks.splice(index, 1);
-    });
+    // Handle nav stack dismissal here (whether programmatically from service or from nav-stack component)
+    modal.onWillDismiss().then(() => this.handleNavStackDismissal(modal));
+
+    this.addNavStackToArray(modal);
     await modal.present();
-    this.openNavStacks.push(modal);
+  }
+
+  private handleNavStackDismissal(modal: NavStackModal) {
+    const index = this.getNavStackIndex(modal);
+    if (index === -1) return;
+    this.removeNavStackFromArray(index);
   }
 
   private getNavStackIndex(modalElement: HTMLIonModalElement) {
     return this.openNavStacks.indexOf(modalElement);
   }
 
-  private async closeNavStack(index: number) {
-    await this.openNavStacks[index].dismiss();
+  /**
+   * Programmiatcally dismiss a nav-stack. Handling removing from openNavStacks array is done elsewhere
+   * to handle both programmatic dismissal and dismissal from nav-stack component (e.g. via close button)
+   */
+  private async closeNavStackAtIndex(index: number) {
+    const modal = this.openNavStacks[index];
+    if (modal) {
+      await this.dismissNavStackModal(modal);
+    }
+  }
+
+  private async dismissNavStackModal(modal: NavStackModal) {
+    modal.dismiss("", "programmatic");
+  }
+
+  private addNavStackToArray(modal: NavStackModal) {
+    if (this.openNavStacks.length === 0) {
+      this.setCustomBackHandler();
+    }
+    this.openNavStacks.push(modal);
+  }
+
+  private removeNavStackFromArray(index: number) {
     this.openNavStacks.splice(index, 1);
+    if (this.openNavStacks.length === 0) {
+      this.templateNavService.destroyBackButtonHandler();
+    }
+  }
+
+  private setCustomBackHandler() {
+    this.templateNavService.initializeBackButtonHandler(() => this.closeAllNavStacks());
   }
 }

--- a/src/app/feature/nav-stack/nav-stack.service.ts
+++ b/src/app/feature/nav-stack/nav-stack.service.ts
@@ -53,17 +53,13 @@ export class NavStackService extends SyncServiceBase {
    * Creates a new nav-stack modal instance
    */
   private async createNavStackModal(config: INavStackConfig) {
-    console.log("[NAV STACK] config", config);
     const modal = await this.modalCtrl.create({
       component: NavStackComponent,
       componentProps: { config },
       // Styling must be done in global theme scss as the modal is injected dynamically into the dom
       cssClass: "nav-stack-modal",
       canDismiss: (data, role) => {
-        console.log("Dismiss requested", data, role);
-        console.log("Allowed dismiss roles", ALLOWED_DISMISS_ROLES);
         if (ALLOWED_DISMISS_ROLES.includes(role)) {
-          console.log("Dismiss allowed");
           return Promise.resolve(true);
         }
         return Promise.resolve(false);

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -16,6 +16,8 @@ import { TemplateContainerComponent } from "../template-container.component";
 const SHOW_DEBUG_LOGS = false;
 const log = SHOW_DEBUG_LOGS ? console.log : () => null;
 
+type ICustomBackHandler = () => any;
+
 @Injectable({
   providedIn: "root",
 })
@@ -24,6 +26,11 @@ const log = SHOW_DEBUG_LOGS ? console.log : () => null;
  * ...
  */
 export class TemplateNavService extends SyncServiceBase {
+  // Custom function to handle browser's back button press
+  customBackHandler: ICustomBackHandler | null = null;
+  popStateListener: ((event: PopStateEvent) => void) | null = null;
+  public suppressPopState: boolean = false;
+
   constructor(
     private modalCtrl: ModalController,
     private location: Location,
@@ -75,6 +82,43 @@ export class TemplateNavService extends SyncServiceBase {
       ]);
     }
   }
+
+  /*****************************************************************************************************
+   *  Handling browser navigation
+   ****************************************************************************************************/
+
+  public initializeBackButtonHandler(handler?: ICustomBackHandler) {
+    if (handler) {
+      this.setCustomBackHandler(handler);
+    }
+    if (!this.popStateListener) {
+      this.popStateListener = this.onPopState.bind(this);
+      window.addEventListener("popstate", this.popStateListener);
+    }
+  }
+
+  public destroyBackButtonHandler() {
+    if (this.popStateListener) {
+      window.removeEventListener("popstate", this.popStateListener);
+      this.popStateListener = null;
+    }
+    this.customBackHandler = null;
+  }
+
+  private setCustomBackHandler(handler: ICustomBackHandler) {
+    this.customBackHandler = handler;
+  }
+
+  private onPopState(event: PopStateEvent) {
+    if (this.suppressPopState) {
+      this.suppressPopState = false;
+      return;
+    }
+    if (this.customBackHandler) {
+      this.customBackHandler();
+    }
+  }
+
   /*****************************************************************************************************
    *  Nav Actions
    ****************************************************************************************************/

--- a/src/app/shared/services/task/task.service.ts
+++ b/src/app/shared/services/task/task.service.ts
@@ -188,7 +188,7 @@ export class TaskService extends AsyncServiceBase {
   }
 
   async setTaskGroupCompletedField(completedField: string, isCompleted: boolean) {
-    console.log(`Setting ${completedField} to ${isCompleted}`);
+    if (!completedField) return;
     await this.templateFieldService.setField(completedField, `${isCompleted}`);
   }
 

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -217,7 +217,6 @@ export function getAnswerListParamFromTemplateRow(
   _default: IAnswerListItem[]
 ): IAnswerListItem[] {
   const params = row.parameter_list || {};
-  console.log(params[name]);
   return params.hasOwnProperty(name) ? parseAnswerList(params[name]) : _default;
 }
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Provides a temporary fix to https://github.com/ParentingForLifelongHealth/plh-kids-app-kw-content/issues/88. This allows for a working web preview to be demonstrated on 09/12/24, but the bug should be investigated further.

The workaround is achieved by implementing the following:

- Nav-stacks now only dismiss when the dismiss is triggered in one of the following ways:
  - programmatically through the nav-stack service code
    - including action calls to `nav_stack: close_top` and `nav_stack: close_all`
  - via the "close" button on the nav-stack
  - via clicking the "backdrop" over the page behind the nav-stack
  - when the browser navigates back
    - this is newly implemented behaviour, borrowing logic from #2594 

This represents an exhaustive list of the pre-existing expected triggers to close nav stacks, however by making this explicit in the code, the bug that causes the nav-stack to close unexpectedly, as documented in https://github.com/ParentingForLifelongHealth/plh-kids-app-kw-content/issues/88, is avoided.

Also includes
- Minor refactoring of nav-stack service code
- Removal of debug logs from task code and answer-list utils

## Git Issues

Closes #

## Screenshots/Videos

Article navigation launched from [module_landing](https://docs.google.com/spreadsheets/d/1nvyc-d_noz-W7guO6x_33c6cCXMXpexGt5HYf5T5J50/edit?gid=452625780#gid=452625780), working as expected. Compare to behaviour on [live web preview](https://plh-kids-kw-uat1.web.app/template/module_landing_selfcare?nav_parent=home_screen&nav_parent_triggered_by=task_card).

https://github.com/user-attachments/assets/ced8b560-6d66-49bf-9789-bcf455308dbc

