### PR TITLE
fix: audio modal close trigger

### DIFF
--- a/src/app/shared/components/template/components/audio/audio.component.ts
+++ b/src/app/shared/components/template/components/audio/audio.component.ts
@@ -92,6 +92,8 @@ export class TmplAudioComponent
   hasStarted: boolean = false;
   /** @ignore */
   trackerInterval: NodeJS.Timeout;
+  /** Track any opened transcript modal to close on destroy */
+  private transcriptModal: HTMLIonModalElement;
 
   constructor(
     private templateAssetService: TemplateAssetService,
@@ -255,7 +257,7 @@ export class TmplAudioComponent
   }
 
   private async openTranscriptPopup() {
-    const modal = await this.modalCtrl.create({
+    this.transcriptModal = await this.modalCtrl.create({
       component: TemplatePopupComponent,
       componentProps: {
         props: {
@@ -269,14 +271,13 @@ export class TmplAudioComponent
       cssClass: "template-popup-modal",
       showBackdrop: false,
     });
-    modal.present();
+    this.transcriptModal.present();
   }
 
   async ngOnDestroy() {
     this.player?.stop();
-    const activeModal = await this.modalCtrl.getTop();
-    if (activeModal) {
-      await activeModal.dismiss();
+    if (this.transcriptModal) {
+      await this.transcriptModal.dismiss();
     }
   }
 }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Fix issue where audio component would accidentally close any parent nav_stack it is presented in
Alt fix to #2603

## Dev Notes
The only other component that I could see that interacts directly with modal logic is the `combo_box`, so it might also be worth investigating if similar problems appear there, although it looks like the logic is setup to dismiss from inside the created modal so I think shouldn't be able to accidentally close the wrong one. 

## Git Issues

Closes #2603

## Screenshots/Videos

https://github.com/user-attachments/assets/924fa60a-b7cb-4c66-952f-dea2a29c1938
