### PR TITLE
feat: add display group variant, 'header'

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -42,6 +42,13 @@
   margin: 1em 0 0 0;
 }
 
+.display-group-wrapper[data-variant~="header"] {
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 var(--small-padding);
+}
+
 .display-group-wrapper {
   &[data-variant~="box_gray"],
   &[data-variant~="box_primary"],

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
@@ -4,7 +4,7 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
 
 interface IDisplayGroupParams {
   /** TEMPLATE PARAMETER: "variant" */
-  variant: "box_gray" | "box_primary" | "box_secondary" | "box_white" | "dashed_box";
+  variant: "box_gray" | "box_primary" | "box_secondary" | "box_white" | "dashed_box" | "header";
   /** TEMPLATE PARAMETER: "style". TODO: Various additional legacy styles, review and convert some to variants */
   style: "form" | "default" | string | null;
   /** TEMPLATE PARAMETER: "offset". Add a custom bottom margin */


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Includes #2608, which should be merged first for clear diffs.

Adds a new variant for the `display_group` component: `header`.

This is intended to be used in conjunction with the `sticky: top` param to position the content of the header to be 

NB, the [plh_kids_kw deployment repo ](https://github.com/ParentingForLifelongHealth/plh-kids-app-kw-content) has temporarily been configured to target this PR branch when building. This can be changed after this PR is merged.

## Git Issues

Closes #

## Screenshots/Videos


