### PR TITLE
fix: sticky header position

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
@@ -8,8 +8,6 @@
   background-color: var(--ion-background-color);
   z-index: 10;
 
-  // use provided inputs to specify host top/bottom as signals do not nicely
-  // map to hostAttribute https://github.com/angular/angular/issues/53888
   &[sticky-position="top"] {
     top: 0;
   }

--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
@@ -10,10 +10,10 @@
 
   // use provided inputs to specify host top/bottom as signals do not nicely
   // map to hostAttribute https://github.com/angular/angular/issues/53888
-  &[ng-reflect-position="top"] {
+  &[sticky-position="top"] {
     top: 0;
   }
-  &[ng-reflect-position="bottom"] {
+  &[sticky-position="bottom"] {
     bottom: 0;
   }
 }

--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.ts
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   Component,
+  HostBinding,
   input,
   OnDestroy,
   signal,
@@ -18,6 +19,12 @@ import {
 export class TmplDisplayGroupStickyComponent implements AfterViewInit, OnDestroy {
   position = input.required<"top" | "bottom">();
   height = signal(0);
+  // use hostBinding to specify host top/bottom as signals do not nicely
+  // map to hostAttribute https://github.com/angular/angular/issues/53888
+  @HostBinding("attr.sticky-position")
+  get stickyPosition() {
+    return this.position();
+  }
 
   private resizeObserver = new ResizeObserver((entries) => this.handleSizeChange(entries));
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Refactors the logic for setting the fixed position of the display group with the `sticky` parameter set.

## Dev notes

The #2564 SCSS implementation of of setting the `top`/`bottom` position of the sticky header element used the `ng-reflect-*` property, see [this file](https://github.com/IDEMSInternational/open-app-builder/pull/2564/files#diff-492b1201007ae8d64daf79c9373c48770dc5bbfb6c950a00aefe397915c99fa1). For whatever reason, these CSS rules were not being applied as expected on the web preview of the KW deployment (I couldn't replicate this locally). In this screenshot, the element was not having the styling `top: 0` applied:

<img width="280" alt="Screenshot 2024-12-09 at 11 00 36" src="https://github.com/user-attachments/assets/a2ce78ae-8a95-4c35-b2da-08090975c212">

This PR uses a different approach, recommended on the [linked thread](https://github.com/angular/angular/issues/53888), to achieve the same result of applying the styling conditionally.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
