### PR TITLE
fix: filtered/excluded colours reversed

### DIFF
--- a/src/app/shared/components/template/components/map/map.component.ts
+++ b/src/app/shared/components/template/components/map/map.component.ts
@@ -171,7 +171,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
     };
     vectorLayer.getSource().forEachFeature((feature: Feature) => {
       if (excludedFeaturesColour) {
-        feature.set("overrideColour", filterFeatures(feature));
+        feature.set("overrideColour", !filterFeatures(feature));
       } else {
         feature.set("visible", filterFeatures(feature));
       }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Previously, the `excluded_features_color` was being applied inversely, i.e. to those features that are included in the filter. This PR fixes that.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
