### PR TITLE
feat: expose main app content padding as app config param

### DIFF
--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -117,6 +117,10 @@ const APP_FOOTER_DEFAULTS: { templateName: string | null } = {
   templateName: null,
 };
 
+const LAYOUT = {
+  main_content_padding: "24px",
+};
+
 const APP_SIDEMENU_DEFAULTS = {
   enabled: true,
   title: "App",
@@ -205,6 +209,7 @@ const APP_CONFIG = {
   APP_UPDATES,
   ASSET_PACKS,
   FEEDBACK_MODULE_DEFAULTS,
+  LAYOUT,
   NOTIFICATIONS_SYNC_FREQUENCY_MS,
   NOTIFICATION_DEFAULTS,
   SERVER_SYNC_FREQUENCY_MS,

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -42,7 +42,10 @@
     <ion-split-pane when="lg" contentId="main" [disabled]="!sidebarRouter.isActivated">
       <div style="display: flex; flex-direction: column; height: 100%; width: 100%" id="main">
         <plh-main-header></plh-main-header>
-        <div class="route-container">
+        <div
+          class="route-container"
+          [style.--main-content-padding]="layoutConfig().main_content_padding"
+        >
           <ion-router-outlet id="main-content"></ion-router-outlet>
         </div>
         @if (footerDefaults().templateName; as footerTemplateName) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,6 +53,7 @@ import { TemplateMetadataService } from "./shared/components/template/services/t
 export class AppComponent {
   sideMenuDefaults = computed(() => this.appConfigService.appConfig().APP_SIDEMENU_DEFAULTS);
   footerDefaults = computed(() => this.appConfigService.appConfig().APP_FOOTER_DEFAULTS);
+  layoutConfig = computed(() => this.appConfigService.appConfig().LAYOUT);
   /** Track when app ready to render sidebar and route templates */
   public renderAppTemplates = signal(false);
 

--- a/src/theme/deployment/_overrides.scss
+++ b/src/theme/deployment/_overrides.scss
@@ -5,10 +5,11 @@ plh-button > ion-button {
 
 /// Ensure all pages have padding
 ion-content {
-  --padding-top: 24px;
-  --padding-bottom: 24px;
-  --padding-start: 24px;
-  --padding-end: 24px;
+  $default-padding: 24px;
+  --padding-top: var(--main-content-padding, #{$default-padding});
+  --padding-bottom: var(--main-content-padding, #{$default-padding});
+  --padding-start: var(--main-content-padding, #{$default-padding});
+  --padding-end: var(--main-content-padding, #{$default-padding});
 
   // HACK: prevent scrollbar from hiding when interacting with ion-range, for example (this can cause visual glitches).
   // see https://github.com/ionic-team/ionic-framework/issues/25595#issuecomment-1330293954


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Exposes a new property for customising the padding around the main app content: `config.app_config.LAYOUT.main_content_padding`. This takes a string value representing a value in a standard CSS length unit, e.g. "20px", "2rem", etc.

As a property off `app_config`, this value can be set at 3 different levels (with setting at each subsequent level overriding any previous values):
- In the deployment config
- In a skin
- In a template's parameter list (as of #2531)

## Notes

I was unsure about how to name and nest this property, and am open to alternative suggestions. The `LAYOUT` namespace could potentially be expanded to include what is currently in `APP_HEADER_DEFAULTS` and `APP_FOOTER_DEFAULTS`

## Git Issues

Closes #

## Screenshots/Videos

