### PR TITLE
spike: data-items nested change detection

### DIFF
--- a/src/app/shared/components/template/components/data-items/data-items.component.html
+++ b/src/app/shared/components/template/components/data-items/data-items.component.html
@@ -1,7 +1,8 @@
-@for (row of itemRows(); track row._nested_name) {
+@for (row of itemRows(); track trackByRow($index, row)) {
   <plh-template-component
     [row]="row"
     [parent]="parent"
     [attr.data-rowname]="row.name"
   ></plh-template-component>
+  <div>{{ row.rows | json }}</div>
 }

--- a/src/app/shared/components/template/components/data-items/data-items.component.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.ts
@@ -1,9 +1,9 @@
-import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from "@angular/core";
 import { FlowTypes } from "../../models";
 import { TemplateBaseComponent } from "../base";
 import { DataItemsService } from "./data-items.service";
 import { toObservable, toSignal } from "@angular/core/rxjs-interop";
-import { switchMap, filter } from "rxjs";
+import { switchMap, filter, tap } from "rxjs";
 
 @Component({
   selector: "plh-data-items",
@@ -23,11 +23,17 @@ export class TmplDataItemsComponent extends TemplateBaseComponent {
   public itemRows = toSignal(
     toObservable(this.rowSignal).pipe(
       filter((row) => row !== undefined),
-      switchMap((row) => this.subscribeToDynamicData(row))
+      switchMap((row) => this.subscribeToDynamicData(row)),
+      tap(() => {
+        this.cdr.detectChanges();
+      })
     )
   );
 
-  constructor(private dataItemsService: DataItemsService) {
+  constructor(
+    private dataItemsService: DataItemsService,
+    private cdr: ChangeDetectorRef
+  ) {
     super();
   }
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

WIP solution to #2636.

When rendering `row.rows` in the data-items component template, the value of the nested row does update dynamically when the local variable changes. But this change is not reflected in the value rendered in the title component.

[debug_data_items_local](https://docs.google.com/spreadsheets/d/14XXwZ7R_7qIBo5xKYuxnPVQbQidI--PPJ7TVvZxwy1k/edit?gid=1990453574#gid=1990453574):
<img width="280" alt="Screenshot 2024-12-17 at 18 26 11" src="https://github.com/user-attachments/assets/c704077a-70d0-42ce-b97e-bbadd6e0d4bd" />


## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
