### PR TITLE
feat: add support for combo_box child data_items

### DIFF
--- a/src/app/shared/components/template/components/combo-box/combo-box-modal/combo-box-modal.component.html
+++ b/src/app/shared/components/template/components/combo-box/combo-box-modal/combo-box-modal.component.html
@@ -8,7 +8,7 @@
         <div
           class="container-radio"
           [class.checked-radio]="form.get('answer').value === radio.name"
-          *ngFor="let radio of valuesFromListAnswers"
+          *ngFor="let radio of answerOptions()"
         >
           <label>
             <input

--- a/src/app/shared/components/template/components/combo-box/combo-box-modal/combo-box-modal.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box-modal/combo-box-modal.component.ts
@@ -1,7 +1,6 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, input, Input, OnInit } from "@angular/core";
 import { FlowTypes } from "src/app/shared/model";
 import {
-  getAnswerListParamFromTemplateRow,
   getBooleanParamFromTemplateRow,
   getNumberParamFromTemplateRow,
   getStringParamFromTemplateRow,
@@ -16,8 +15,8 @@ import { ModalController } from "@ionic/angular";
   styleUrls: ["./combo-box-modal.component.scss"],
 })
 export class ComboBoxModalComponent implements OnInit {
+  public answerOptions = input.required<IAnswerListItem[]>();
   @Input() row: FlowTypes.TemplateRow;
-  @Input() template: FlowTypes.Template;
   @Input() selectedValue: string;
   @Input() customAnswerSelected: boolean;
   @Input() style: string;
@@ -29,7 +28,10 @@ export class ComboBoxModalComponent implements OnInit {
   inputPosition: boolean = false;
   maxLength: number = 30;
   placeholder: string = "";
-  constructor(private fb: FormBuilder, private modalController: ModalController) {}
+  constructor(
+    private fb: FormBuilder,
+    private modalController: ModalController
+  ) {}
 
   ngOnInit() {
     this.getParams();
@@ -37,7 +39,6 @@ export class ComboBoxModalComponent implements OnInit {
   }
 
   getParams() {
-    this.valuesFromListAnswers = getAnswerListParamFromTemplateRow(this.row, "answer_list", null);
     this.textTitle = getStringParamFromTemplateRow(this.row, "text", null);
     this.inputAllowed = getBooleanParamFromTemplateRow(this.row, "input_allowed", false);
     this.inputPosition =

--- a/src/app/shared/components/template/components/data-items/data-items.service.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.service.ts
@@ -45,6 +45,11 @@ export class DataItemsService {
                   const parsedItemList = await this.hackParseDataList(data);
                   const itemProcessor = new ItemProcessor(parsedItemList, parameter_list);
                   const { itemTemplateRows, itemData } = itemProcessor.process(rows);
+                  // if no child rows for data_items loop assume want back raw items
+                  if (rows.length === 0) {
+                    return itemData;
+                  }
+                  // otherwise process generated template rows
                   const itemRowsWithMeta = updateItemMeta(itemTemplateRows, itemData, dataListName);
                   const parsedItemRows = await this.hackProcessRows(
                     itemRowsWithMeta,

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -223,7 +223,6 @@ export function getAnswerListParamFromTemplateRow(
   _default: IAnswerListItem[]
 ): IAnswerListItem[] {
   const params = row.parameter_list || {};
-  console.log(params[name]);
   return params.hasOwnProperty(name) ? parseAnswerList(params[name]) : _default;
 }
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Add support for providing a `data_items` list to a combo_box to generate answer options

## Author Notes
See updated example in [comp_combo_box](https://docs.google.com/spreadsheets/d/1uIkaMlDjoDN7uTpHkSeEQ6Yp-4ehX9IrBQMrolpfjQc/edit?gid=569531329#gid=569531329)

Note - if passing a data_list it is expected that the list has columns for `name` and `text`, same as hardcoded lists. The `data_items` loop should not contain any child rows

If using `data_items` list there is not quite the same safeguards in place as with some of the hardcoded lists (e.g. filtering out incomplete item rows) - this is due to the assumption that data_lists are less prone to authoring error than long lists of hardcoded variables. 

There isn't currently any integration between the system used by combo_boxes to add custom items and the ability for data_lists to add new items (i.e. adding a custom combo box item will not make any changes to the data_list). If this functionality is required it should be prioritised with a follow-up issue

## Dev Notes
The core combo_box code has been left unchanged as much as possible (although could definitely do with a bit of tidying/refactor), the main change was to pass the generated `answerOptions` directly to the modal (save generating in multiple places), and add the binding to subscribe to data_lists. The input `template` variable was also removed as it appeared to not be in use

Additional knock-on was required to allow passing back the data_items as a pure item list, as typically a data_items loop expects child template rows to generate as looped template item rows. 

## Git Issues

Closes #

## Screenshots/Videos

[Screenity video - Dec 19, 2024 (1).webm](https://github.com/user-attachments/assets/84015daa-0aad-4cf9-bfa0-9cd3c4d1f2f8)

