### PR TITLE
fix: rtl language config is applied to app launch templates

### DIFF
--- a/src/app/shared/components/template/components/layout/popup/popup.component.html
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.html
@@ -2,6 +2,7 @@
   class="popup-backdrop"
   (click)="dismissOnBackdrop($event)"
   [attr.data-fullscreen]="props.fullscreen ? true : null"
+  [dir]="templateTranslateService.languageDirection()"
 >
   <div class="popup-container">
     <div (click)="dismiss()" class="close-button" fill="clear" *ngIf="props.showCloseButton">

--- a/src/app/shared/components/template/components/layout/popup/popup.component.ts
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from "@angular/core";
 import { ModalController } from "@ionic/angular";
 import { FlowTypes } from "../../../models";
 import { TemplateContainerComponent } from "../../../template-container.component";
+import { TemplateTranslateService } from "../../../services/template-translate.service";
 
 @Component({
   templateUrl: "./popup.component.html",
@@ -14,7 +15,12 @@ import { TemplateContainerComponent } from "../../../template-container.componen
 export class TemplatePopupComponent {
   @Input() props: ITemplatePopupComponentProps;
 
-  constructor(private modalCtrl: ModalController) {}
+  constructor(
+    private modalCtrl: ModalController,
+    // HACK: Since pop-ups can be launched outside of main app container (e.g. as part of launch actions),
+    // handle RTL language support directly in this component
+    public templateTranslateService: TemplateTranslateService
+  ) {}
 
   /**
    * When templates emit completed/uncompleted value from standalone popup close the popup


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes a bug where templates launched as part of app launch actions would not have the app's RTL config applied to them.

The template [debug_launch_actions](https://docs.google.com/spreadsheets/d/1zofHkaZ9NMcUgM7U7fPXxclVw4qXN8crHkXcQf-HCr8/edit?gid=1541644091#gid=1541644091) has been updated such that launch actions can be tested from the debug deployment. On first app launch, you will be prompted to select a language. This will not apply on subsequent app launches, until the app data is reset.

## Testing

### Recreating the issue

On `master`, run a sync to pull the latest changes to [debug_launch_actions](https://docs.google.com/spreadsheets/d/1zofHkaZ9NMcUgM7U7fPXxclVw4qXN8crHkXcQf-HCr8/edit?gid=1541644091#gid=1541644091). Run the app and confirm that the bug documented in #2615 is present for the language select template that is displayed on launch (you may need to reset the app data if this template is not displayed)

### Testing the resolution

Now checkout this PR feature branch and perform the same test. The issue should be resolved.

## Git Issues

Closes #2615

## Screenshots/Videos

Updated [debug_launch_actions](https://docs.google.com/spreadsheets/d/1zofHkaZ9NMcUgM7U7fPXxclVw4qXN8crHkXcQf-HCr8/edit?gid=1541644091#gid=1541644091)

<img width="600" alt="Screenshot 2024-12-20 at 12 51 19" src="https://github.com/user-attachments/assets/a6be9937-0dd5-4888-9d39-3617b2850243" />


https://github.com/user-attachments/assets/dd1a32a5-ec6e-4ebb-aacf-2f62f2af3c75

