### PR TITLE
refactor: header defaults and functions

### DIFF
--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -89,44 +89,27 @@ export type IHeaderVariantOptions = "default" | "compact";
 
 interface IAppConfigHeader {
   back_button: {
-    hidden: boolean;
+    hidden?: boolean;
   };
   collapse: boolean;
   colour: IHeaderFooterBackgroundOptions;
-  hidden: boolean;
+  hidden?: boolean;
   menu_button: {
-    hidden: boolean;
+    hidden?: boolean;
   };
   template: string | null;
   title: string;
   variant: IHeaderVariantOptions;
-  should_show_menu_button: (location: Location) => boolean;
-  should_show_back_button: (location: Location) => boolean;
-  should_minimize_app_on_back: (location: Location) => boolean;
 }
 
 const APP_HEADER_DEFAULTS: IAppConfigHeader = {
-  back_button: {
-    hidden: false,
-  },
+  back_button: {},
   collapse: false,
   colour: "primary",
-  hidden: false,
-  menu_button: {
-    hidden: false,
-  },
+  menu_button: {},
   template: null,
   title: "App",
   variant: "default",
-  // default only show menu button on home screen
-  should_show_menu_button: (location: Location) =>
-    activeRoute(location) === APP_ROUTE_DEFAULTS.home_route,
-  // default show back button on all screens except home screen
-  should_show_back_button: (location: Location) =>
-    activeRoute(location) !== APP_ROUTE_DEFAULTS.home_route,
-  // on device minimize app when back button pressed from home screen
-  should_minimize_app_on_back: (location: Location) =>
-    activeRoute(location) === APP_ROUTE_DEFAULTS.home_route,
 };
 
 /**

--- a/packages/data-models/skin.model.ts
+++ b/packages/data-models/skin.model.ts
@@ -12,7 +12,9 @@ import { IAppConfigOverride } from "./appConfig";
  *       enabled: false
  *     }
  *     APP_HEADER_DEFAULTS: {
- *       should_show_menu_button: false
+ *       menu_button: {
+ *         hidden: true
+ *       }
  *     }
  *   }
  * }

--- a/src/app/shared/services/skin/skin.service.spec.ts
+++ b/src/app/shared/services/skin/skin.service.spec.ts
@@ -32,14 +32,12 @@ const MOCK_SKIN_2: IAppSkin = {
 
 const MOCK_APP_CONFIG: Partial<IAppConfig> = {
   APP_HEADER_DEFAULTS: {
+    back_button: {},
+    menu_button: {},
     template: null,
-    show: true,
     title: "default",
     collapse: false,
     colour: "none",
-    should_minimize_app_on_back: () => true,
-    should_show_back_button: () => true,
-    should_show_menu_button: () => true,
     variant: "default",
   },
   APP_SKINS: {

--- a/src/app/shared/utils/angular.utils.ts
+++ b/src/app/shared/utils/angular.utils.ts
@@ -35,3 +35,13 @@ export function ngRouterMergedSnapshot$(router: Router) {
     startWith(mergeRouterSnapshots(router))
   );
 }
+
+/**
+ * Utility function to return the active pathname without any sidebar routing e.g. /home(sidebar:alt)
+ * or basename when deployed to subfolder path, e.g. /my-repo/template/home (provided by <base href='' /> in head)
+ * */
+export const activeRoute = (location: Location) => {
+  const baseHref = document.querySelector("base")?.getAttribute("href");
+  const path = location.pathname.replace(baseHref, "/").replace(/\(.+\)/, "");
+  return path;
+};


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Breaking Changes
Header config removes override for functions `should_show_menu_button`, `should_show_back_button` and `should_minimize_app_on_back`. All of these functions were by default linked to whether on app home page or not, and typically not overridden by deployments. Now that there are more specific parameters such as `back_button.hidden: true` that can be used to handle specific functionality

NOTE - probably good to mention this in the target PR if merging, although I'm not aware of any deployments that modify these functions

## Description

Targets branch of #2631 

- Remove some app header config defaults where they can be implied (`undefined` as falsy default)
- Refactor menu/back button home-specific side-effects to be included in component code (remove authoring override)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
