### PR TITLE
chore: audio component handles RTL languages (LTR player controls enforced)

### DIFF
--- a/src/app/shared/components/template/components/audio/audio.component.html
+++ b/src/app/shared/components/template/components/audio/audio.component.html
@@ -15,7 +15,8 @@
       }
     </div>
   }
-  <div class="second-row">
+  <!-- Enforce LTR language direction for player controls,see https://github.com/IDEMSInternational/open-app-builder/issues/2617 -->
+  <div class="second-row" dir="ltr">
     @if (params.variant.includes("compact") && params.showInfoButton) {
       <ion-button fill="clear" class="action-button" (click)="handleActionButtonClick()">
         @if (params.infoIconAsset) {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

The audio component handles cases where the app language direction is right-to-left (RTL). This is achieved by enforcing the player controls to be displayed in their default LTR styling, regardless of app language direction, in accordance with the description of #2617.

## Git Issues

Closes #2617

## Screenshots/Videos

| Theme | Language direction: LTR | Language direction: RTL |
|-----|-----|-----|
| Default | <img width="180" alt="Screenshot 2024-12-28 at 12 14 58" src="https://github.com/user-attachments/assets/b13c896c-1e33-4446-bbd9-a51ce2f067fd" /> | <img width="180" alt="Screenshot 2024-12-28 at 12 14 43" src="https://github.com/user-attachments/assets/a8429b0d-40b6-4f2e-80cf-c2ebac240028" /> |
| `plh_kids_kw` | <img width="180" alt="Screenshot 2024-12-28 at 12 16 08" src="https://github.com/user-attachments/assets/200a5c55-567b-4365-9081-beecb9a4c3e8" /> | <img width="180" alt="Screenshot 2024-12-28 at 12 16 43" src="https://github.com/user-attachments/assets/b2146ec1-3c52-456e-8069-ba9f772cbcdd" /> |



