### PR TITLE
fix: text wrapping in title component for RTL languages

### DIFF
--- a/src/app/shared/components/template/components/title/title.component.ts
+++ b/src/app/shared/components/template/components/title/title.component.ts
@@ -39,7 +39,7 @@ export class TmplTitleComponent extends TemplateBaseComponent implements ITempla
     this.params.textAlign = getStringParamFromTemplateRow(
       this._row,
       "text_align",
-      "left"
+      null
     ) as ITitleParams["textAlign"];
     this.params.variant = getStringParamFromTemplateRow(this._row, "variant", "")
       .split(",")


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where text within the title component would remain left-aligned when the app language direction was RTL, resulting a noticeable inconsistency when said text wrapped over multiple lines.

## Git Issues

Closes #2640 

## Screenshots/Videos

[comp_title](https://docs.google.com/spreadsheets/d/1pBCI7KkNNtF9sQAs_l_hcdjjFfdjC4vEL4jvF5sNk9c/edit?gid=569531329#gid=569531329):

| Language direction: LTR | Language direction: RTL |
|-----|-----|
| <img width="180" alt="Screenshot 2024-12-28 at 12 42 47" src="https://github.com/user-attachments/assets/89f73418-e7b6-462b-82aa-8bb9c9e59c5a" /> | <img width="180" alt="Screenshot 2024-12-28 at 12 43 10" src="https://github.com/user-attachments/assets/3edd1889-3e1b-4b78-9884-8ed7b4c22199" /> |
| <img width="180" alt="Screenshot 2024-12-28 at 12 43 43" src="https://github.com/user-attachments/assets/3e4a8bb3-2cab-4a5d-86ce-ea14558ea418" /> | <img width="180" alt="Screenshot 2024-12-28 at 12 44 04" src="https://github.com/user-attachments/assets/976efaf1-fc34-44c2-b559-6e91341ac850" /> |

