### PR TITLE
fix: pop-up close button position for RTL languages

### DIFF
--- a/src/app/shared/components/template/components/layout/popup/popup.component.html
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.html
@@ -6,9 +6,16 @@
   [attr.data-variant]="props.variant ? props.variant : null"
 >
   <div class="popup-container">
-    <div (click)="dismiss()" class="close-button" fill="clear" *ngIf="props.showCloseButton">
-      <ion-icon slot="icon-only" name="close"></ion-icon>
-    </div>
+    @if (props.showCloseButton) {
+      <div
+        (click)="dismiss()"
+        class="close-button"
+        fill="clear"
+        [attr.data-language-direction]="templateTranslateService.languageDirection()"
+      >
+        <ion-icon slot="icon-only" name="close"></ion-icon>
+      </div>
+    }
     <div class="popup-content" [attr.data-fullscreen]="props.fullscreen ? true : null">
       @if (props.popupText) {
         <!-- Use a text component row to display popup text -->

--- a/src/app/shared/components/template/components/layout/popup/popup.component.scss
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.scss
@@ -21,6 +21,10 @@
     .close-button {
       top: 10px;
       right: 10px;
+      &[data-language-direction~="rtl"] {
+        right: unset;
+        left: 10px;
+      }
     }
   }
   .popup-content {
@@ -44,7 +48,7 @@
   .close-button {
     position: absolute;
     top: 18px;
-    right: 19px;
+    right: 18px;
     background: white;
     width: 40px;
     height: 40px;
@@ -58,5 +62,9 @@
     z-index: 1;
     box-shadow: var(--ion-default-box-shadow);
     color: var(--ion-color-primary);
+    &[data-language-direction~="rtl"] {
+      right: unset;
+      left: 18px;
+    }
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Handles repositioning the pop-up close button when the app language direction is RTL. Changes applied to both fullscreen and non-fullscreen pop-ups.

## Git Issues

Closes #2618

## Screenshots/Videos

Pop-ups launched from [example_pop_ups](https://docs.google.com/spreadsheets/d/1K9JZ9Glnj73CFJmpfGIRa5dRA2TBxSsJmaguV6GL8Pc/edit?gid=402992224#gid=402992224):

<img width="200" alt="Screenshot 2024-12-30 at 12 35 08" src="https://github.com/user-attachments/assets/93d8534c-c4b2-482b-939a-6ca7444f1603" />

<img width="200" alt="Screenshot 2024-12-30 at 12 35 39" src="https://github.com/user-attachments/assets/8f3ae3f8-5479-469e-83dc-03efff821b2a" />

<img width="200" alt="Screenshot 2024-12-30 at 12 35 55" src="https://github.com/user-attachments/assets/1c6ee330-0fa1-4c61-8e5b-d0a98dcf40d4" />
