### PR TITLE
fix: display group spacing RTL support

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -29,7 +29,9 @@
 .display-group-wrapper[data-param-style~="row"]
   > plh-template-component:not([data-hidden="true"])
   ~ plh-template-component:not([data-hidden="true"]) {
-  margin: 0 0 0 1em;
+  margin: 0;
+  // Use margin-inline-start to support LTR and RTL languages
+  margin-inline-start: 1em;
 }
 
 .display-group-wrapper[data-param-style~="column"]


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the spacing between components within a display group with `style: row` (the default style) would not appropriately handle the app language direction being RTL.

## Testing

As well as the two templates referenced in #2621, the issue can be observed in the debug template [example_dg](https://docs.google.com/spreadsheets/d/1i6Th92RAkGfardxSJdJYWVoMtTkaNr-Xn2kIHDvtQoQ/edit?gid=1745157248#gid=1745157248). On `master`, setting the app language to RTL (via the template `feature_rtl_language`), observe that the button has a margin applied to its left that should be applied to its right:

<img width="200" alt="Screenshot 2024-12-30 at 12 50 52" src="https://github.com/user-attachments/assets/4dbb39ce-bbb5-4e21-82a9-c0aea5dff6df" />

This is resolved on this PR branch:

<img width="200" alt="Screenshot 2024-12-30 at 13 14 00" src="https://github.com/user-attachments/assets/b7076a9f-0446-4a13-be99-900088274550" />


## Git Issues

Closes #2621 

## Screenshots/Videos

Templates referenced in #2621:

[debug_dg_button](https://docs.google.com/spreadsheets/d/19qLXy1PF6BOH9GZ-qpcZJ3-bOfxXAgj7J8H67Nfp9MM/edit?gid=1509937990#gid=1509937990):

<img width="200" alt="Screenshot 2024-12-30 at 13 17 19" src="https://github.com/user-attachments/assets/17f082f8-4777-4a2d-8a77-ba9077c64f62" />

[settings_header](https://docs.google.com/spreadsheets/d/1cNFMnElaJFjenwQCGt1K7m6fT7pGX69SiIBdu6mu-as/edit?gid=225548978#gid=225548978) template (`plh_kids_kw` deployment):

<img width="200" alt="Screenshot 2024-12-30 at 12 59 22" src="https://github.com/user-attachments/assets/750956bf-ead3-4841-beba-f7f47731fdab" />

