### PR TITLE
feat: data_items triggered actions

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -391,6 +391,7 @@ export namespace FlowTypes {
     | "changed"
     | "click"
     | "completed"
+    | "data_changed"
     | "info_click"
     | "nav_resume" // return to template after navigation or popup close;
     | "sent" // notification sent

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -4,7 +4,7 @@ import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
-const cacheVersion = 20241203.0;
+const cacheVersion = 20241230.0;
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {

--- a/packages/scripts/src/commands/app-data/convert/utils/app-data-action.utils.ts
+++ b/packages/scripts/src/commands/app-data/convert/utils/app-data-action.utils.ts
@@ -27,6 +27,7 @@ export function parseAppDataActionString(actionString: string): FlowTypes.Templa
     changed: true,
     click: true,
     completed: true,
+    data_changed: true,
     uncompleted: true,
     nav_resume: true,
     sent: true,

--- a/src/app/shared/components/template/components/base.ts
+++ b/src/app/shared/components/template/components/base.ts
@@ -25,7 +25,9 @@ export class TemplateBaseComponent implements ITemplateRowProps {
   rowSignal = signal<FlowTypes.TemplateRow>(undefined, { equal: isEqual });
   value = computed(() => this.rowSignal().value, { equal: isEqual });
   parameterList = computed(() => this.rowSignal().parameter_list || {}, { equal: isEqual });
-  actionList = computed(() => this.rowSignal().action_list || [], { equal: isEqual });
+  actionList = computed<FlowTypes.TemplateRowAction[]>(() => this.rowSignal().action_list || [], {
+    equal: isEqual,
+  });
   rows = computed<FlowTypes.TemplateRow[]>(() => this.rowSignal().rows || [], { equal: isEqual });
 
   /**
@@ -56,7 +58,9 @@ export class TemplateBaseComponent implements ITemplateRowProps {
     }
     const action_list = this._row.action_list || [];
     const actionsForTrigger = action_list.filter((a) => a.trigger === trigger);
-    return this.parent.handleActions(actionsForTrigger, this._row);
+    if (actionsForTrigger.length > 0) {
+      return this.parent.handleActions(actionsForTrigger, this._row);
+    }
   }
 
   /**

--- a/src/app/shared/components/template/components/data-items/data-items.service.spec.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.service.spec.ts
@@ -128,6 +128,42 @@ describe("DataItemsService", () => {
     });
   });
 
+  it("evaluates data actions rows with items context (if empty)", async () => {
+    // HACK - Actions only trigger correctly if data_items do not contain looped child rows
+    const emptyItemsRow = { ...MOCK_DATA_ITEMS_ROW, rows: undefined };
+    const obs = service.getItemsObservable(emptyItemsRow, {});
+    const data = await firstValueFrom(obs);
+    const [evaluated] = service.evaluateDataActions(
+      [
+        {
+          trigger: "data_changed",
+          action_id: "set_local",
+          args: ["my_local_var", "@items.length"],
+        },
+      ],
+      data
+    );
+    console.log({ evaluated });
+    expect(evaluated.args).toEqual(["my_local_var", 3]);
+  });
+  // TODO - fix case where items context refers to generated loop items and not list items
+  xit("evaluates data actions rows with items context", async () => {
+    const obs = service.getItemsObservable(MOCK_DATA_ITEMS_ROW, {});
+    const data = await firstValueFrom(obs);
+    const [evaluated] = service.evaluateDataActions(
+      [
+        {
+          trigger: "data_changed",
+          action_id: "set_local",
+          args: ["my_local_var", "@items.length"],
+        },
+      ],
+      data
+    );
+    // Note - currently return 6 due to generated loop item rows
+    expect(evaluated.args).toEqual(["my_local_var", 3]);
+  });
+
   // TODO - requires improvement to mocked dynamic data service
   // it("provides live update when data changes", async () => {
   //   const obs = service.getItemsObservable(MOCK_DATA_ITEMS_ROW, {});


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Add a custom `data_changed` action trigger that updates in sync with data_items loops.
This can be used to set local or field values depending on data queries

**Follow-up Tasks**
- [ ] Add support for triggered actions when data_items loop includes child rows
- [ ] Update data_actions RFC with reference to changes made here

## Author Notes

The action list is defined in the normal way, with the exception that the `@items` variable will contain the value of the associated item list

| type             | value    | action_list                                                 | parameter_list          |
|------------------|----------|-------------------------------------------------------------|-------------------------|
| begin_data_items | my_items | data_changed \| set_local : total_completed : @items.length | filter: @item.completed |
| end_data_items   |          |                                                             |                         |

See examples in [component_data_items](https://docs.google.com/spreadsheets/d/1khGTrDekzqDQyW1r2x0ADqknanrlkmhOz1RRzhP6-7c/edit?gid=845703892#gid=845703892)

**NOTE 1** - If the begin/end data_items has inner rows used for templating, the list of `@items` will include the loop of generated rows. E.g. If a data_list has 3 rows and there are 2 child text/buttons in the loop the list will represent 6 items.

So for now it is recommended to leave any data_items loops free of inner data which returns just the raw data_list data (will be fixed in a future PR).

**NOTE 2** - A new `data_changed` trigger has been included instead of using the existing `changed` as the action is processed differently (includes extra evaluation step for items context), and may be further differentiated in the future as needs arise (easy to make changes in isolation).

**NOTE 3** - The action hasn't been tested with more complex use cases such/mixed contexts, e.g. 
```
data_changed | set_local : @local.field_name_look_up : @items.length
``` 
So for now it's designed more around setting specific locals/fields based on the list values, however could be further developed as required

## Review Notes
See examples in [component_data_items](https://docs.google.com/spreadsheets/d/1khGTrDekzqDQyW1r2x0ADqknanrlkmhOz1RRzhP6-7c/edit?gid=845703892#gid=845703892)

Tests can be run from the updated specs

## Dev Notes
It's noted in a couple places that there is currently a limitation due to the way the data-items service only emits a stream of generated loop item rows (with fallback to data_list rows if no inner child rows exist). I'm planning to address this in a follow-up that provides different emits for the list rows vs generated item rows, but it has a few knock-ons so I figured best to omit from this PR

When the data_items action trigger a local/field update that automatically triggers reprocessing template rows, which in turn triggers the data_items subscription to update. This resulted in an infinite loop of data updates and action triggers. The issue has been resolved by updating the service subscription to include `distinctUntilChanged` which allows passing our custom equality checker function that will only re-emit when data has changed. It would also usually be possible to include within signal/computed code, however the `toSignal` operator does not allow this (and figured it makes sense to include at the service level anyways)

## Git Issues

Closes #

## Screenshots/Videos

https://github.com/user-attachments/assets/4743a902-40bc-4701-9d94-307c5c30c0d9




