### PR TITLE
Feat!: Auth user db sync

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",

--- a/packages/api/spec-export.json
+++ b/packages/api/spec-export.json
@@ -130,6 +130,39 @@
         ]
       }
     },
+    "/auth_users/{auth_user_id}": {
+      "get": {
+        "operationId": "AuthUsersController_findOne",
+        "summary": "Get auth user profile",
+        "parameters": [
+          {
+            "name": "auth_user_id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-deployment-db-name",
+            "in": "header",
+            "description": "Name of db for deployment to populate",
+            "schema": {
+              "type": "string",
+              "default": "plh"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Auth Users"
+        ]
+      }
+    },
     "/contact_fields": {
       "get": {
         "operationId": "ContactFieldController_findAll",
@@ -339,7 +372,7 @@
   "info": {
     "title": "IDEMS Apps API",
     "description": "App-Server Communication",
-    "version": "1.4.4",
+    "version": "1.6.0",
     "contact": {}
   },
   "tags": [

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -31,6 +31,7 @@ import { DeploymentModule } from "./modules";
     }),
     DefaultModule,
     Endpoints.AppUsersModule,
+    Endpoints.AuthUsersModule,
     Endpoints.ContactFieldsModule,
     Endpoints.AppFeedbackModule,
     Endpoints.AppNotificationInteractionModule,

--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -32,14 +32,15 @@ export class DBInstance {
         database: this.dbName,
         // disable verbose migration logs in test
         logging: process.env.NODE_ENV === "test" ? false : true,
-        // Fix SSL issue
+        // Enable ssl mode when running on production
         // https://dev.to/rodjosh/connectionerror-sequelizeconnectionerror-no-pghbaconf-entry-for-host-in-heroku-postgresql-using-sequelize-3icj
-        dialectOptions: {
-          ssl: {
+        // https://stackoverflow.com/a/61411969
+        dialectOptions: environment.production ? {
+          ssl:  {
             require: true,
             rejectUnauthorized: false,
           },
-        },
+        } : {},
       });
       await this.runMigrations(migrationClient);
       await migrationClient.close();

--- a/packages/api/src/db/migrations/008-auth-user-column.ts
+++ b/packages/api/src/db/migrations/008-auth-user-column.ts
@@ -1,0 +1,13 @@
+import { DataTypes, QueryInterface } from "sequelize";
+import { UmzugOptions } from "umzug";
+
+export const up = async (options: UmzugOptions<QueryInterface>) => {
+  const queryInterface = options.context as QueryInterface;
+  await queryInterface.addColumn("app_users", "auth_user_id", {
+    type: DataTypes.STRING,
+  });
+};
+export const down = async (options: UmzugOptions<QueryInterface>) => {
+  const queryInterface = options.context as QueryInterface;
+  await queryInterface.removeColumn("app_users", "auth_user_id");
+};

--- a/packages/api/src/endpoints/app_users/app_user.model.ts
+++ b/packages/api/src/endpoints/app_users/app_user.model.ts
@@ -13,6 +13,9 @@ export class AppUser extends Model<InferAttributes<AppUser>, InferCreationAttrib
   @Column({ allowNull: false })
   app_deployment_name: string;
 
+  @Column({ allowNull: false })
+  auth_user_id: string;
+
   @Column({ type: DataType.JSONB })
   contact_fields: any;
 

--- a/packages/api/src/endpoints/app_users/app_user.model.ts
+++ b/packages/api/src/endpoints/app_users/app_user.model.ts
@@ -13,7 +13,7 @@ export class AppUser extends Model<InferAttributes<AppUser>, InferCreationAttrib
   @Column({ allowNull: false })
   app_deployment_name: string;
 
-  @Column({ allowNull: false })
+  @Column
   auth_user_id: string;
 
   @Column({ type: DataType.JSONB })

--- a/packages/api/src/endpoints/auth_users/auth_user.controller.ts
+++ b/packages/api/src/endpoints/auth_users/auth_user.controller.ts
@@ -17,8 +17,8 @@ export class AuthUsersController {
   @ApiParam({ name: "auth_user_id", type: String })
   @ApiOperation({ summary: "Get auth user profile" })
   @DeploymentHeaders()
-  findOne(@Param("auth_user_id") auth_user_id: string): Promise<AppUser> {
+  findOne(@Param("auth_user_id") auth_user_id: string): Promise<AppUser[]> {
     const model = this.deploymentService.model(AppUser);
-    return model.findOne({where:{auth_user_id}})
+    return model.findAll({where:{auth_user_id}})
   }
 }

--- a/packages/api/src/endpoints/auth_users/auth_user.controller.ts
+++ b/packages/api/src/endpoints/auth_users/auth_user.controller.ts
@@ -1,0 +1,24 @@
+import {  Controller, Get,  Param,  } from "@nestjs/common";
+import {  ApiOperation, ApiParam, ApiTags } from "@nestjs/swagger";
+import { DeploymentHeaders } from "src/modules/deployment.decorators";
+import { DeploymentService } from "src/modules/deployment.service";
+import { AppUser } from "../app_users/app_user.model";
+
+@ApiTags("Auth Users")
+@Controller("auth_users")
+/**
+ * The auth_users endpoint are a thin wrapper around the app_users table to enable
+ * user lookup by auth_user_id
+ */
+export class AuthUsersController {
+  constructor(private readonly deploymentService: DeploymentService) {}
+
+  @Get(":auth_user_id")
+  @ApiParam({ name: "auth_user_id", type: String })
+  @ApiOperation({ summary: "Get auth user profile" })
+  @DeploymentHeaders()
+  findOne(@Param("auth_user_id") auth_user_id: string): Promise<AppUser> {
+    const model = this.deploymentService.model(AppUser);
+    return model.findOne({where:{auth_user_id}})
+  }
+}

--- a/packages/api/src/endpoints/auth_users/index.ts
+++ b/packages/api/src/endpoints/auth_users/index.ts
@@ -1,0 +1,7 @@
+import { AuthUsersController } from './auth_user.controller';
+import { Module } from '@nestjs/common';
+
+@Module({
+  controllers: [AuthUsersController],
+})
+export class AuthUsersModule {}

--- a/packages/api/src/endpoints/index.ts
+++ b/packages/api/src/endpoints/index.ts
@@ -1,4 +1,5 @@
 export * from "./app_users";
+export * from './auth_users'
 export * from "./contact_fields";
 export * from "./tables";
 export * from "./app_feedback";

--- a/packages/data-models/fields.ts
+++ b/packages/data-models/fields.ts
@@ -3,7 +3,6 @@
  * They are used to store store computed or exported variables and are not user overridable
  */
 enum PROTECTED_FIELDS {
-  APP_AUTH_USER = "app_auth_user",
   APP_FIRST_LAUNCH = "app_first_launch",
   APP_LANGUAGE = "app_language",
   APP_SKIN = "app_skin",
@@ -14,6 +13,7 @@ enum PROTECTED_FIELDS {
   APP_UPDATE_DOWNLOADED = "app_update_downloaded",
   APP_USER_ID = "app_user_id",
   APP_VERSION = "app_version",
+  AUTH_USER_ID = "auth_user_id",
   CONTENT_VERSION = "content_version",
   DEPLOYMENT_NAME = "deployment_name",
   FEEDBACK_SELECTED_TEXT = "feedback_selected_text",

--- a/packages/server/docker/docker-compose.yml
+++ b/packages/server/docker/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     #   context: ../../api
     #   dockerfile: Dockerfile
     #   target: prod-env
-    image: idems/apps-api:1.5.1
+    image: idems/apps-api:1.6.0
     env_file:
       - ../../api/.env
     environment:

--- a/src/app/shared/services/auth/auth.service.ts
+++ b/src/app/shared/services/auth/auth.service.ts
@@ -29,6 +29,7 @@ export class AuthService extends AsyncServiceBase {
     this.registerInitFunction(this.initialise);
     effect(async () => {
       const authUser = this.provider.authUser();
+      await this.checkProfileRestore(authUser);
       this.addStorageEntry(authUser);
     });
   }
@@ -44,6 +45,11 @@ export class AuthService extends AsyncServiceBase {
       // NOTE - Do not await the enforce login to allow other services to initialise in background
       this.enforceLogin(this.config.enforceLoginTemplate);
     }
+  }
+
+  private async checkProfileRestore(authUser: IAuthUser) {
+    const existingUser = this.localStorageService.getProtected("AUTH_USER_ID");
+    if (existingUser) return;
   }
 
   private async enforceLogin(templateName: string) {
@@ -91,13 +97,13 @@ export class AuthService extends AsyncServiceBase {
     });
   }
 
-  /** Keep a subset of auth user info in contact fields for db lookup*/
+  /** Keep id of auth user info in contact fields for db lookup*/
   private addStorageEntry(user?: IAuthUser) {
     if (user) {
       const { uid } = user;
-      this.localStorageService.setProtected("APP_AUTH_USER", JSON.stringify({ uid }));
+      this.localStorageService.setProtected("AUTH_USER_ID", uid);
     } else {
-      this.localStorageService.removeProtected("APP_AUTH_USER");
+      this.localStorageService.removeProtected("AUTH_USER_ID");
     }
   }
 }

--- a/src/app/shared/services/server/server.service.ts
+++ b/src/app/shared/services/server/server.service.ts
@@ -76,7 +76,7 @@ export class ServerService extends SyncServiceBase {
     const timestamp = generateTimestamp();
     contact_fields[getProtectedFieldName("SERVER_SYNC_LATEST")] = timestamp;
 
-    const auth_id = this.localStorageService.getProtected("AUTH_USER_ID");
+    const auth_id = this.localStorageService.getProtected("AUTH_USER_ID") || null;
 
     // TODO - get DTO from api (?)
     const data = {

--- a/src/app/shared/services/server/server.service.ts
+++ b/src/app/shared/services/server/server.service.ts
@@ -76,11 +76,11 @@ export class ServerService extends SyncServiceBase {
     const timestamp = generateTimestamp();
     contact_fields[getProtectedFieldName("SERVER_SYNC_LATEST")] = timestamp;
 
-    const auth_id = this.localStorageService.getProtected("AUTH_USER_ID") || null;
+    const auth_user_id = this.localStorageService.getProtected("AUTH_USER_ID") || null;
 
     // TODO - get DTO from api (?)
     const data = {
-      auth_id,
+      auth_user_id,
       contact_fields,
       app_version: _app_builder_version,
       device_info: this.device_info,

--- a/src/app/shared/services/server/server.service.ts
+++ b/src/app/shared/services/server/server.service.ts
@@ -76,14 +76,18 @@ export class ServerService extends SyncServiceBase {
     const timestamp = generateTimestamp();
     contact_fields[getProtectedFieldName("SERVER_SYNC_LATEST")] = timestamp;
 
+    const auth_id = this.localStorageService.getProtected("AUTH_USER_ID");
+
     // TODO - get DTO from api (?)
     const data = {
+      auth_id,
       contact_fields,
       app_version: _app_builder_version,
       device_info: this.device_info,
       app_deployment_name: name,
       dynamic_data,
     };
+
     console.log("[SERVER] sync data", data);
     return new Promise<string>((resolve, reject) => {
       this.http


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Breaking Changes
The contact field `_app_auth_user` has been renamed to `auth_user_id` and is no longer formatted as json but instead just an id. I'm not sure if this protected field was included in any templates beyond debug ones. It has been updated in [example_google_auth](https://docs.google.com/spreadsheets/d/12xo0ewDN0bbeVrs3klWd9J8DkFQLTCYX1zhGWnovqIo/edit?gid=579616705#gid=579616705)

The current `app_user_id` remains unchanged

## Description
Adds an `auth_users` endpoint to the server that can be used to retrieve a user by a given `auth_user_id`. It also creates an explicit `auth_user_id` column within the `app_users` table to make it more efficient to retrieve (instead of looking at contact_fields)

Updates server sync code to include `auth_user_id` when available

These server updates are required to then enable lookup and restore of a given user by their auth_id (instead of device id)

**Follow-ups**

- [ ] Deploy changes to server
- [ ] Add frontend code to lookup auth user from db and restore as required

## Author Notes
The updates here are mostly at the server level and will not work until the server is updated post-merge.

I had thought about exposing action triggers to better-enable authors to update templates based on auth events (e.g. `auth_signed_in` and `auth_signed_out`), however this started to get a little bit complicated so for now I've manually updated it so whenever a user signs in the `server_sync` action is immediately triggered to ensure the signed in user profile is backed up to the db. If wanting to have more fine-grained support at an authoring level can create a follow-up issue.

## Review Notes
If testing endpoints locally will need locally running postgres and API
```sh
yarn workspace api start
```
A local deployment will also need to be set to target the locally running endpoint
```ts
config.api.endpoint = 'http://localhost:3000'
```

Alternatively can build API and run in docker container following instructions from the `api` and `server` package readmes

Once running performing a user sync from the `debug_sync_id` template or `/user` debug page. 
You should see the user populated without an `auth_user_id`

Sign_in either from the _example_google_auth_ template and trigger sync and should see db populated with `auth_user_id` property

Examples in screenshots below

## Dev Notes
The `app_auth_user` property has been removed in favour of `auth_user_id` which is namespaced better and also stores a simple string representation instead of JSON. 

There is a small amount of placeholder code for the start of the user profile restore frontend feature, although for now this is still a work-in-progress and can be ignored for review

## Git Issues

Closes #

## Screenshots/Videos
**Example sync non-auth user to API running locally**
![image](https://github.com/user-attachments/assets/bb06e5a2-f9f1-46ab-ac38-bf48661eb29f)

**Note that the response now includes an auth_user_id (null)**
![image](https://github.com/user-attachments/assets/795ef540-a6f6-4d5e-8932-d764df7470e8)

**Example sync post-login - includes `auth_user_id` response from server**
![image](https://github.com/user-attachments/assets/b5d312de-ff57-428d-af43-cd55571de2ff)

