### PR TITLE
Kuwait Theme: Map View Styling

### DIFF
--- a/src/app/shared/components/template/components/progress-path/progress-path.component.ts
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.ts
@@ -5,7 +5,7 @@ import { TemplateTranslateService } from "../../services/template-translate.serv
 
 interface IProgressPathParams {
   /** TEMPLATE_PARAMETER: "variant". Default "wavy" */
-  variant: "basic" | "wavy";
+  variant: "basic" | "wavy" | "curved";
 }
 
 // HACK - hardcoded sizing values to make content fit reasonably well
@@ -27,7 +27,7 @@ const SIZING = {
 })
 export class TmplProgressPathComponent extends TemplateBaseComponent implements OnInit {
   private params: Partial<IProgressPathParams> = {};
-  private pathVariant: "basic" | "wavy";
+  private pathVariant: "basic" | "wavy" | "curved";
 
   public svgPath: string;
   public svgViewBox: string;
@@ -47,14 +47,14 @@ export class TmplProgressPathComponent extends TemplateBaseComponent implements 
     this.params.variant = getStringParamFromTemplateRow(this._row, "variant", "wavy")
       .split(",")
       .join(" ") as IProgressPathParams["variant"];
-    this.pathVariant = this.params.variant.includes("basic") ? "basic" : "wavy";
+    this.pathVariant = this.params.variant;
   }
 
   /**
    * Generate a base SVG segment used to connect 2 progress items together
    * Roughly a horizontal line and smooth bend, adjusted for sizing
    */
-  private generateSVGPath(variant: "basic" | "wavy" = "wavy") {
+  private generateSVGPath(variant: "basic" | "curved" | "wavy" = "wavy") {
     // arbitrary values used to make base width/height fit
     const { widthPx, xOffset, yOffset, textContentHeight } = SIZING;
 
@@ -87,7 +87,14 @@ export class TmplProgressPathComponent extends TemplateBaseComponent implements 
     c 48,0 72,64 48,${viewboxHeight - yOffset - 4}
     `.trim();
 
-    this.svgPath = variant === "basic" ? basic() : wavy();
+    const curved = () =>
+      `
+    M ${xOffset},${yOffset}
+    c 0,140 280,-80 252,160 1
+    v 80
+    `.trim();
+
+    this.svgPath = variant === "basic" ? basic() : variant === "wavy" ? wavy() : curved();
     this.svgViewBox = `0 0 ${widthPx} ${viewboxHeight}`;
     this.contentHeight = `${textContentHeight}px`;
   }

--- a/src/app/shared/components/template/components/progress-path/progress-path.component.ts
+++ b/src/app/shared/components/template/components/progress-path/progress-path.component.ts
@@ -94,7 +94,16 @@ export class TmplProgressPathComponent extends TemplateBaseComponent implements 
     v 80
     `.trim();
 
-    this.svgPath = variant === "basic" ? basic() : variant === "wavy" ? wavy() : curved();
+    switch (variant) {
+      case "basic":
+        this.svgPath = basic();
+        break;
+      case "curved":
+        this.svgPath = curved();
+        break;
+      default:
+        this.svgPath = wavy();
+    }
     this.svgViewBox = `0 0 ${widthPx} ${viewboxHeight}`;
     this.contentHeight = `${textContentHeight}px`;
   }

--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -111,8 +111,13 @@
           />
         </span>
       }
-      <div class="circle-wrapper">
+      <div class="circle-wrapper" [class]="progressStatus">
         <img [src]="image | plhAsset" />
+        @if (progressStatus === "notStarted" && lockedImageAsset) {
+          <div class="locked">
+            <img [src]="lockedImageAsset | plhAsset" />
+          </div>
+        }
       </div>
     </div>
     @if (title) {

--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -114,7 +114,7 @@
       <div class="circle-wrapper" [class]="progressStatus">
         <img [src]="image | plhAsset" />
         @if (progressStatus === "notStarted" && lockedImageAsset) {
-          <div class="locked">
+          <div class="locked-image">
             <img [src]="lockedImageAsset | plhAsset" />
           </div>
         }

--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -79,7 +79,7 @@
     </div>
   </div>
 } @else {
-  <div class="circle-card-wrapper" (click)="triggerActions('click')">
+  <div class="circle-card-wrapper" (click)="handleClick()">
     <div class="image-and-badge-wrapper">
       <div *ngIf="taskGroupId && !taskId">
         <plh-task-progress-bar
@@ -113,7 +113,7 @@
       }
       <div class="circle-wrapper" [class]="progressStatus">
         <img [src]="image | plhAsset" />
-        @if (progressStatus === "notStarted" && lockedImageAsset) {
+        @if (locked) {
           <div class="locked-image">
             <img [src]="lockedImageAsset | plhAsset" />
           </div>

--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -196,6 +196,9 @@
         height: 100%;
         clip-path: circle(#{$circle-width / 2 - 4px} at center);
       }
+      .locked {
+        display: none;
+      }
     }
 
     plh-task-progress-bar {

--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -196,7 +196,8 @@
         height: 100%;
         clip-path: circle(#{$circle-width / 2 - 4px} at center);
       }
-      .locked {
+      // TODO: Currently only enabled for `plh_kids_kw` theme
+      .locked-image {
         display: none;
       }
     }

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -84,8 +84,7 @@ interface ITaskCardParams {
    */
   show_progress_text: boolean;
   /**
-   * The icon to display in the "badge" added to the task card
-   * when its associated task/task group has been completed
+   * The icon to mark a task as "locked"
    */
   locked_image_asset: string;
 }

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -83,6 +83,11 @@ interface ITaskCardParams {
    * Default true
    */
   show_progress_text: boolean;
+  /**
+   * The icon to display in the "badge" added to the task card
+   * when its associated task/task group has been completed
+   */
+  locked_image_asset: string;
 }
 
 @Component({
@@ -112,6 +117,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
   inProgressIcon: string;
   isButton: boolean;
   variant: ITaskCardParams["variant"];
+  lockedImageAsset: string;
 
   constructor(
     private taskService: TaskService,
@@ -156,6 +162,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
       "sections"
     );
     this.showProgressText = getBooleanParamFromTemplateRow(this._row, "show_progress_text", true);
+    this.lockedImageAsset = getStringParamFromTemplateRow(this._row, "locked_image_asset", null);
   }
 
   checkProgressStatus() {

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -84,6 +84,10 @@ interface ITaskCardParams {
    */
   show_progress_text: boolean;
   /**
+   * Whether or not the task card is in a "locked" state. Any logic to determint this should be handled in the template
+   */
+  locked: boolean;
+  /**
    * The icon that will be displayed if the task is "locked" (currently only implemented for plh_kids_kw theme)
    */
   locked_image_asset: string;
@@ -116,6 +120,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
   inProgressIcon: string;
   isButton: boolean;
   variant: ITaskCardParams["variant"];
+  locked: boolean;
   lockedImageAsset: string;
 
   constructor(
@@ -129,6 +134,11 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
     this.getParams();
     this.highlighted = this.checkGroupHighlighted();
     this.checkProgressStatus();
+  }
+
+  public handleClick() {
+    if (this.locked) return;
+    this.triggerActions("click");
   }
 
   getParams() {
@@ -161,6 +171,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
       "sections"
     );
     this.showProgressText = getBooleanParamFromTemplateRow(this._row, "show_progress_text", true);
+    this.locked = getBooleanParamFromTemplateRow(this._row, "locked", false);
     this.lockedImageAsset = getStringParamFromTemplateRow(this._row, "locked_image_asset", null);
   }
 

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -84,7 +84,7 @@ interface ITaskCardParams {
    */
   show_progress_text: boolean;
   /**
-   * The icon to mark a task as "locked"
+   * The icon that will be displayed if the task is "locked" (currently only implemented for plh_kids_kw theme)
    */
   locked_image_asset: string;
 }

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -914,8 +914,59 @@ body[data-theme="plh_kids_kw"] {
     .circle-card-wrapper {
       .circle-wrapper {
         filter: none !important;
-        border: 1px solid #e1e2e4 !important;
-        box-shadow: 0px 2px 8px rgba($color: #000000, $alpha: 0.1);
+        border: 2px solid #edeeef !important;
+        box-shadow: -2px 2px 5px rgba($color: #7e8386, $alpha: 0.8);
+        background-color: #e7e8e9;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        position: relative;
+        img {
+          opacity: 0.5 !important;
+          border-radius: 50% !important;
+          width: 75% !important;
+          height: 75% !important;
+        }
+        .locked {
+          display: flex !important;
+          position: absolute;
+          margin: 0 auto;
+          top: 0px;
+          left: 0px;
+          right: 0px;
+          bottom: 0px;
+
+          align-items: center;
+          justify-content: center;
+
+          img {
+            width: 42px;
+            max-width: 48px;
+            object-fit: contain;
+            opacity: 1 !important;
+          }
+        }
+      }
+      .circle-wrapper.inProgress {
+        border: 4px solid #c99529 !important;
+        box-shadow: 0px 2px 12px rgba($color: #007fbf, $alpha: 0.7);
+        img {
+          opacity: 1 !important;
+        }
+      }
+      .circle-wrapper.completed {
+        border: 4px solid var(--ion-color-secondary-100) !important;
+        box-shadow: 0px 2px 12px rgba($color: #007fbf, $alpha: 0.7);
+        img {
+          opacity: 1 !important;
+          width: 100% !important;
+          height: 100% !important;
+        }
+      }
+      .badge {
+        display: none !important;
       }
     }
   }
@@ -965,7 +1016,7 @@ body[data-theme="plh_kids_kw"] {
     }
   }
 
-  // bottom_nav
+  // Bottom Nav
   .plh-bottom-nav-wrapper {
     @include mixins.flex-space-between;
     flex-direction: row;
@@ -1034,6 +1085,19 @@ body[data-theme="plh_kids_kw"] {
         .close-button {
           border: 0.8px solid var(--color-secondary-blue-80);
           color: var(--color-secondary-blue-50);
+        }
+      }
+    }
+  }
+
+  // Progress Path
+  plh-progress-path {
+    .progress-path-child-wrapper {
+      margin-bottom: 48px !important;
+      .path-segment {
+        svg {
+          stroke-width: 26px;
+          stroke: var(--color-surface-white-variant) !important;
         }
       }
     }

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -967,7 +967,7 @@ body[data-theme="plh_kids_kw"] {
           width: 75% !important;
           height: 75% !important;
         }
-        .locked {
+        .locked-image {
           display: flex !important;
           position: absolute;
           margin: 0 auto;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
- Styling support added for a curved map path

## Author Notes
- The Kuwait map design has paths that wind a lot more than the `wavy` variant accommodates. A new variant, `curved`, is added in this update to support curvier paths.
- The task card now includes an additional attribute, `locked_image_asset`, to accommodate the locked icon that appears on top of the module.

Attributes added to [sheet](https://docs.google.com/spreadsheets/d/14BBKG07nqUWDmcscdUMv1AKYSWGBUPCNDT-VcSERHyU/edit?usp=sharing):
- `variant`: "curved"
- `locked_image_asset`

## Git Issues

Closes #2667 

## Screenshots

To visualise the map path, the color stroke here is dark

<img width="300" src="https://github.com/user-attachments/assets/6b231bc4-4e68-4c32-9b24-8b131992ac98">

Otherwise the map path is a light color to contrast with the proposed background image

<img width="300" src="https://github.com/user-attachments/assets/0346d1dd-1ae5-4a02-a0fd-77bc8e455b79">

A `completed` module is highlighted with a blue border while an `in_progress` module is highlighted with a yellow border

