### PR TITLE
[Bug Fix] Kuwait Theme: Combo box center align text

### DIFF
--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -816,6 +816,7 @@ body[data-theme="plh_kids_kw"] {
         min-height: 56px !important;
         border-radius: var(--ion-border-radius-small) !important;
         font-weight: var(--font-weight-medium) !important;
+        text-align: center !important;
       }
     }
     .checked-radio {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Sets the text alignment in the `combo-box` input field to center by default

## Git Issues

Closes #2668

## Screenshots
<img width="200" src="https://github.com/user-attachments/assets/f460f1a8-2779-41cf-9a5a-f9660a07f27c">
