### PR TITLE
feat: button card-portrait variant handles disabled param; custom styling of button card-portrait variant for plh_kids_kw theme

### DIFF
--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -31,9 +31,10 @@
   <div
     *ngSwitchCase="true"
     class="button-container"
-    (click)="triggerActions('click')"
+    (click)="handleClick()"
     [attr.data-variant]="params.variant"
     [attr.data-has-children]="_row.rows ? true : false"
+    [attr.data-disabled]="params.disabled"
   >
     <img *ngIf="params.image" src="{{ params.image | plhAsset }}" />
     <div *ngIf="_row.value" [class]="'button-text ' + params.textAlign">

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -93,8 +93,14 @@ ion-button[data-variant~="card"] {
   // TODO: make a variable
   width: 160px;
 
-  &:active {
-    background-color: var(--ion-color-gray-light);
+  &[data-disabled="true"] {
+    opacity: 0.6;
+  }
+
+  &:not([data-disabled="true"]) {
+    &:active {
+      background-color: var(--ion-color-gray-light);
+    }
   }
 
   img {
@@ -121,7 +127,7 @@ ion-button[data-variant~="card"] {
   .children {
     position: absolute;
     align-self: flex-end;
-    right: -4px;
+    inset-inline-end: -4px;
     top: -12px;
     display: flex;
     align-items: center;

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -55,6 +55,11 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
     this.getParams();
   }
 
+  public handleClick() {
+    if (this.params.disabled) return;
+    this.triggerActions("click");
+  }
+
   private getParams() {
     this.params.style = `${getStringParamFromTemplateRow(this._row, "style", "information")} ${
       this.isTwoColumns() ? "two_columns" : ""

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -62,6 +62,19 @@ body[data-theme="plh_kids_kw"] {
         --background: var(--ion-color-primary-500);
       }
     }
+
+    // card-portrait variant (designed to handle a single icon as child rows
+    .button-container[data-variant~="card-portrait"][data-has-children] {
+      .button-text {
+        text-align: start !important;
+        padding-inline-end: 36px !important;
+      }
+      .children {
+        inset-inline-end: -2px !important;
+        bottom: 2px !important;
+        padding: 0px !important;
+      }
+    }
   }
 
   // audio


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Button component with `variant: card-portrait` now handles `disabled` param
  - Previously this param would have no effect on this variant, but now the button will appear faded and will not be clickable
- Custom styling of button component with `variant: card-portrait` for `plh_kids_kw` theme
  - Repositions child rows for use as a button in activity library. See example in [comp_button](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit?gid=569531329#gid=569531329) below for proposed authoring

## Author notes

While it may make sense to create a new dedicated plh component, minimal changes were needed to the existing button card-portrait variant to achieve the desired result. Note that I've proposed authoring the locked icon and toggle bar both as child rows of the component, rather than exposing new parameters – this allows the toggle bar, and its action list, to be directly available from the template.

## Git Issues

Closes #2651

## Screenshots/Videos

[comp_button](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit?gid=569531329#gid=569531329) with theme set to `plh_kids_kw`:

<img width="600" alt="Screenshot 2025-01-03 at 13 06 49" src="https://github.com/user-attachments/assets/5d54cee2-f5fe-4770-946e-5dc9a8f88e0b" />

LTR:
<img width="240" alt="Screenshot 2025-01-03 at 12 51 56" src="https://github.com/user-attachments/assets/3ad6fbaf-1c98-4bbe-8d38-66530a3c6072" />

RTL:
<img width="240" alt="Screenshot 2025-01-03 at 12 52 11" src="https://github.com/user-attachments/assets/8c902072-ed34-40b4-a900-b6bd9dfcc34d" />
