### PR TITLE
fix(plh-kids-kw): text-bubble speaker position for RTL language

### DIFF
--- a/src/app/shared/components/template/components/text-bubble/text-bubble.component.scss
+++ b/src/app/shared/components/template/components/text-bubble/text-bubble.component.scss
@@ -143,7 +143,7 @@ $bubble-border-color-4: var(--text-bubble-border-color-4, --ion-color-secondary-
 }
 .container[data-position="right"] {
   .speaker-name {
-    text-align: right;
+    text-align: end;
     right: 80px;
   }
   img.speaker-image {

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -388,7 +388,7 @@ body[data-theme="plh_kids_kw"] {
       }
 
       .speaker-name {
-        text-align: right;
+        text-align: end;
       }
     }
     .text-bubble-container[data-language-direction~="rtl"] {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the speaker label on the text bubble component would be incorrectly positioned when app language direction is RTL.

## Git Issues

Closes #2619

## Screenshots/Videos

[comp_text_bubble](https://docs.google.com/spreadsheets/d/1Yo8X4TrTW2lzEgusDplAQ-y-JJvQOIqXGNLVON1uvRo/edit?gid=569531329#gid=569531329)

LTR:

<img width="300" alt="Screenshot 2025-01-03 at 16 05 55" src="https://github.com/user-attachments/assets/4bb4dcf0-82ea-4b7d-8c68-dc34d043ddc6" />

RTL:

<img width="300" alt="Screenshot 2025-01-03 at 16 06 16" src="https://github.com/user-attachments/assets/f6e34fb2-9c56-4fdc-bca4-347d96810065" />
