### PR TITLE
fix: display group handles RTL language direction

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.html
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.html
@@ -23,6 +23,7 @@
     [attr.data-param-style]="params.style"
     [attr.data-rowname]="_row.name"
     [attr.data-variant]="params.variant"
+    [attr.data-has-background-image]="params.backgroundImageAsset ? true : false"
     [style.marginBottom.px]="params.offset"
     [ngSwitch]="type"
     [style]="_row.style_list | styleList"

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -28,6 +28,19 @@
   background-color: var(--ion-background-color);
 }
 
+// HACK: Flip background image (but not child content) when language direction is RTL
+:dir(rtl) {
+  .display-group-wrapper {
+    justify-content: flex-end;
+    &[data-has-background-image] {
+      transform: scaleX(-1);
+      > * {
+        transform: scaleX(-1);
+      }
+    }
+  }
+}
+
 // Default spacing within display groups. Adapted from `template-component.scss`
 .display-group-wrapper[data-param-style~="row"] > plh-template-component:not([data-hidden="true"]) {
   margin: 0;

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
@@ -70,11 +70,15 @@ export class TmplDisplayGroupComponent extends TemplateBaseComponent implements 
 
   private getBackgroundImageStyles() {
     // only generate background image styles if asset included
-    const backgroundImageAsset = getStringParamFromTemplateRow(this._row, "background_image_asset");
-    if (!backgroundImageAsset) return {};
+    this.params.backgroundImageAsset = getStringParamFromTemplateRow(
+      this._row,
+      "background_image_asset",
+      ""
+    );
+    if (!this.params.backgroundImageAsset) return {};
     // retrieve the image asset url in the same way plh_asset pipe does
     // assign background position and size styles and return
-    const url = this.templateAssetService.getTranslatedAssetPath(backgroundImageAsset);
+    const url = this.templateAssetService.getTranslatedAssetPath(this.params.backgroundImageAsset);
     const backgroundImage = `url(${url})`;
     const backgroundPosition = getStringParamFromTemplateRow(
       this._row,


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow-up to #2589 
- Now, when a display group has a background image set, the image will be flipped horizontally when the language direction is RTL (as requested in [this comment](https://github.com/IDEMSInternational/open-app-builder/pull/2589#pullrequestreview-2511570773)).
  - We may want to expose a parameter to handle this behaviour, as some images may not be intended to be mirrored
- Additionally, fixes an undocumented RTL issue where the contents of a display group would be aligned to the left of the screen when the language was RTL.

## Git Issues

Closes #

## Screenshots/Videos

[feature_display_group](https://docs.google.com/spreadsheets/d/1ARbNRGDer5vj9qSpRMZFrMkYifGkH3TLtDVp72YbaqU/edit?gid=1231713195#gid=1231713195):

LTR:

<img width="220" alt="Screenshot 2025-01-03 at 16 57 27" src="https://github.com/user-attachments/assets/5439de97-53a6-4ece-ab75-e071ce6e6571" />

RTL: 

<img width="220" alt="Screenshot 2025-01-03 at 16 57 06" src="https://github.com/user-attachments/assets/a1a6de20-b05b-496b-8b27-e59087ab840c" />
