### PR TITLE
fix: make button text alignment responsive to language direction

### DIFF
--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -112,10 +112,10 @@ ion-button[data-variant~="card"] {
     padding: 1rem 0 0.5rem;
     text-align: center;
     &.right {
-      text-align: right;
+      text-align: end;
     }
     &.left {
-      text-align: left;
+      text-align: start;
     }
     &.center {
       text-align: center;
@@ -173,14 +173,14 @@ ion-button[data-variant~="card"] {
 
 .left ::ng-deep {
   margin: 0 auto 0 2px;
-  text-align: left;
+  text-align: start;
   p {
     margin: 0 0 0 2px;
   }
 }
 .right {
   margin: 0 2px 0 auto;
-  text-align: right;
+  text-align: end;
 }
 .center {
   text-align: center;

--- a/src/theme/deployment/_overrides.scss
+++ b/src/theme/deployment/_overrides.scss
@@ -61,10 +61,10 @@ p {
   font-size: var(--font-size-text-large);
 }
 .right {
-  text-align: right;
+  text-align: end;
 }
 .left {
-  text-align: left;
+  text-align: start;
 }
 .center {
   text-align: center;

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -26,9 +26,9 @@ body[data-theme="plh_kids_kw"] {
       text-align: unset !important;
     }
     .left.text {
-      text-align: left;
+      text-align: start;
       p {
-        text-align: left !important;
+        text-align: start !important;
       }
     }
     // Center align all button text by default
@@ -45,7 +45,7 @@ body[data-theme="plh_kids_kw"] {
     }
     .left.right ::ng-deep {
       p {
-        text-align: right !important;
+        text-align: end !important;
       }
     }
     //Alignment Buttons


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Makes the alignment of text responsive to language direction (LTR/RTL). In particular this applies to text within the button component, but there may be desirable knock-ons for other components that use the same pattern to align text.

Note that this does not fix the `text_align` parameter on the button component (marked by a very old comment as "to be removed" in the [comp_button](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit?gid=569531329#gid=569531329) template)

## Dev notes

The text alignment throughout the app is a bit of a mess, with bits of CSS code in various places overriding each other. For now, I've left everything as it is structurally, but replaced relevant instances of `text-align: left` and `text-align: right` with `text-align: start` and `text-align: end` respectively, which respond appropriately to language direction.

## Git Issues

Closes #2678

## Screenshots/Videos

[comp_button](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit?gid=569531329#gid=569531329)

|   | LTR | RTL |
|---|---|---|
| default theme | <img width="200" alt="Screenshot 2025-01-03 at 18 14 23" src="https://github.com/user-attachments/assets/32d859ee-8efa-4eba-952f-4d0458865ba6" /> | <img width="200" alt="Screenshot 2025-01-03 at 18 14 49" src="https://github.com/user-attachments/assets/0268bcdc-977f-4fcf-8557-620dbc83338a" /> |
| plh_kids_kw theme | <img width="200" alt="Screenshot 2025-01-03 at 18 15 08" src="https://github.com/user-attachments/assets/fcad039a-4143-42e7-8bfb-697c03068253" /> | <img width="200" alt="Screenshot 2025-01-03 at 18 15 17" src="https://github.com/user-attachments/assets/8fc2092a-3ec2-42dd-b586-909f1000744f" /> |



