### PR TITLE
fix: ios browser nav-stack height

### DIFF
--- a/src/app/feature/nav-stack/components/nav-stack/nav-stack.component.global.scss
+++ b/src/app/feature/nav-stack/components/nav-stack/nav-stack.component.global.scss
@@ -20,7 +20,7 @@ ion-modal.nav-stack-modal {
   &::part(content) {
     border-radius: var(--border-radius) var(--border-radius) 0 0;
     position: absolute;
-    bottom: 0px;
+    bottom: calc(0px + var(--ion-safe-area-bottom, 0));
   }
 
   ion-toolbar {

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -18,8 +18,10 @@
 
 /** Ionic CSS Variables **/
 :root {
-  // The total height of the central safe area of the device viewport
-  --safe-area-height: calc(100vh - var(--ion-safe-area-top, 0) - var(--ion-safe-area-bottom, 0));
+  // The total height of the central safe area of the device viewport.
+  // Use 100% rather than 100vh to handle browsers with toolbars,
+  // see https://github.com/IDEMSInternational/open-app-builder/issues/2680
+  --safe-area-height: calc(100% - var(--ion-safe-area-top, 0) - var(--ion-safe-area-bottom, 0));
 
   // Margins //
   --row-margin-top: 1em; // used in downstream calculations, e.g. sticky display-group


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the top of a nav-stack could be cut off when accessing the app via Safari on iOS.

## Testing

iOS appetize [link](https://appetize.io/app/ios/international.idems.debug-app?device=iphone14pro&osVersion=16.2).

## Git Issues

Closes #2680 

## Screenshots/Videos

I've included screenshots of the fullscreen pop-up component, as this is the other component that makes use of the CSS property that has been updated in this PR. The behaviour of fullscreen pop-ups is unchanged as shown here.

|   | Native app | Safari |
|---|---|---|
| nav-stack | <img width="200" alt="nav-stack native app" src="https://github.com/user-attachments/assets/8e8eba89-4596-472e-a7f4-2be167bae261" /> | <img width="200" alt="nav-stack safari" src="https://github.com/user-attachments/assets/ee9ff753-67b2-495f-ae8c-5ef33e82db64" /> |
| fullscreen pop-up | <img width="200" alt="fullscreen pop-up native app" src="https://github.com/user-attachments/assets/2a1a7ec8-9241-4856-be53-ea1bc8d49f1f" /> | <img width="200" alt="fullscreen pop-up safari" src="https://github.com/user-attachments/assets/b23c06b2-ded7-47e7-9501-186914655ea4" /> |




