### PR TITLE
style: round icon button icon colour

### DIFF
--- a/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.scss
+++ b/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.scss
@@ -158,6 +158,7 @@ ion-tab-button {
 
   &[data-variant~="no-background"],
   &.no-background {
+    color: unset;
     background: transparent;
     box-shadow: none;
     ion-icon {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

For the `round_button` component with `style: no-background`, the colour of the source icon is not altered. Previously, the icon would be recoloured to contrast with colour of the background of the button – as there is no background colour in this case, the colour of the icon should not be altered.

## Git Issues

Closes #

## Screenshots/Videos

Updated [comp_round_button](https://docs.google.com/spreadsheets/d/161GZue4jkQNJzyfYvMWesMp2vwvbkJgpNqkDlVIGJDw/edit?gid=569531329#gid=569531329):

<img width="800" alt="Screenshot 2025-01-07 at 10 43 40" src="https://github.com/user-attachments/assets/1e5e4f62-161a-4028-a177-ee47efee1811" />

<img width="360" alt="Screenshot 2025-01-07 at 10 43 59" src="https://github.com/user-attachments/assets/b807716e-8a79-4a6f-8aa1-238fd53c637f" />
