### PR TITLE
fix: iOS fullscreen popups

### DIFF
--- a/src/app/feature/nav-stack/components/nav-stack/nav-stack.component.global.scss
+++ b/src/app/feature/nav-stack/components/nav-stack/nav-stack.component.global.scss
@@ -20,7 +20,8 @@ ion-modal.nav-stack-modal {
   &::part(content) {
     border-radius: var(--border-radius) var(--border-radius) 0 0;
     position: absolute;
-    bottom: calc(0px + var(--ion-safe-area-bottom, 0));
+    bottom: 0px;
+    padding-bottom: calc(0px + var(--ion-safe-area-bottom, 0));
   }
 
   ion-toolbar {

--- a/src/app/shared/components/template/components/layout/popup/popup.component.scss
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.scss
@@ -1,5 +1,9 @@
 .popup-backdrop {
-  height: 100vh;
+  // Ensure some padding applied even when --ion-safe-area-* is 0px
+  --pop-up-top-padding: max(var(--ion-safe-area-top), 24px);
+  --pop-up-bottom-padding: max(var(--ion-safe-area-bottom), 24px);
+
+  height: 100%;
   width: 100%;
   background: rgba(0, 0, 0, 0.6);
   display: flex;
@@ -7,25 +11,28 @@
   justify-content: center;
   .popup-container {
     position: relative;
+    height: fit-content;
+    max-height: var(--safe-area-height);
     width: var(--content-max-width);
     padding: 0 2rem;
     margin: auto;
-    margin-top: var(--ion-safe-area-top, 0);
-    margin-bottom: var(--ion-safe-area-bottom, 0);
+    padding-top: var(--pop-up-top-padding);
+    padding-bottom: var(--pop-up-bottom-padding);
   }
   &[data-fullscreen] {
     background: white;
     .popup-container {
-      height: var(--safe-area-height);
-    }
-    .close-button {
-      top: 10px;
-      inset-inline-end: 10px;
+      height: 100%;
+      max-height: unset;
+      .close-button {
+        top: calc(var(--ion-safe-area-top, 0) + 10px);
+        inset-inline-end: 10px;
+      }
     }
   }
   .popup-content {
-    margin: 30px auto;
-    max-height: calc(var(--safe-area-height) - 60px);
+    height: fit-content;
+    max-height: 100%;
     background: white;
     border-radius: 20px;
     padding: 20px;
@@ -43,7 +50,7 @@
   }
   .close-button {
     position: absolute;
-    top: 18px;
+    top: calc(var(--pop-up-top-padding) - 10px);
     background: white;
     width: 40px;
     height: 40px;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the content of fullscreen pop-ups may not all be visible when accessing the web app via Safari on iOS. Whilst I haven't been able to recreate this issue more generally, it's possible that it was also occurring when accessing the native iOS app, which should also be fixed by these changes.

## Testing

As these changes refactor some of the styling for pop-ups in general, we should test every pop-up type for every platform. I have attempted this in the videos embedded below. In each case, we should be ensuring that all the content is visible (particularly relevant for scrolling content) and that all the spacing looks correct – e.g. the space around the non-fullscreen pop-up element; the positioning of the close button.

Pop-up types:
- Available via [example_pop_ups](https://docs.google.com/spreadsheets/d/1K9JZ9Glnj73CFJmpfGIRa5dRA2TBxSsJmaguV6GL8Pc/edit?gid=402992224#gid=402992224):
  - pop-up with short content
  - pop-up with long, scrollable content
  - fullscreen pop-up with short content
  - fullscreen pop-up with long, scrollable content
- Available on initial app launch (after reset)
  - Fullscreen pop-up launched as part of launch actions

Platforms:
- Desktop browser
- iOS (in theory should test different device types with different notches/cut-outs etc.) - [appetize](https://appetize.io/app/ios/international.idems.debug-app?device=iphone14pro&osVersion=16.2)
  - native app
  - web app via Safari
- Android - [appetize](https://appetize.io/app/android/international.idems.debug_app?device=pixel7&osVersion=13.0)
  - native app
  - web app via Chrome

## Dev notes

Even with live reloading, the developer experience of developing a web app for iOS is very frustrating. There appear to be differences in how CSS is interpreted depending on whether the app is accessed through Safari or the bundled Capacitor app. This includes the fact that the safe area does not get set correctly in Safari (see #2680), but extends to more general issues too. Sometimes, some elements would display incorrectly, but would be fixed when I enabled and disabled a CSS rule via the desktop Safari developer panel linked to the app in my emulator. Sometimes, the safe area would be incorrect until I quit and relaunched the emulator.

Hopefully these issues are related to the emulator itself, and would not be present for an end user.

## Git Issues

Closes #2687

## Screenshots/Videos

### Desktop browser


https://github.com/user-attachments/assets/360fe484-1975-4302-bc58-0f84dfcf1604


### iOS (local emulator)
These recordings are from my local emulator, but uploaded to appetize [here](https://appetize.io/app/ios/international.idems.debug-app?device=iphone14pro&osVersion=16.2).

Native app:


https://github.com/user-attachments/assets/e5ed1837-500b-4722-b572-7e2edcedcb58


Web app via Safari:


https://github.com/user-attachments/assets/67455a2a-86b4-4132-a617-976c35a13504


### Android ([appetize](https://appetize.io/app/android/international.idems.debug_app?device=pixel7&osVersion=13.0&scale=50))

Native app:

https://github.com/user-attachments/assets/e052f751-6362-41d3-bff0-f779898614cb

