### PR TITLE
fix: completion modal

### DIFF
--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -1148,7 +1148,7 @@ body[data-theme="plh_kids_kw"] {
         .close-button {
           border: 0.8px solid var(--color-secondary-blue-80);
           color: var(--color-secondary-blue-50);
-          top: 0px !important;
+          top: 0px;
         }
       }
     }

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -1112,7 +1112,6 @@ body[data-theme="plh_kids_kw"] {
       .popup-container {
         min-height: 70vh;
         padding: 0 1.4rem;
-        margin-top: -28px;
         .popup-content {
           background: linear-gradient(
             310deg,
@@ -1149,6 +1148,7 @@ body[data-theme="plh_kids_kw"] {
         .close-button {
           border: 0.8px solid var(--color-secondary-blue-80);
           color: var(--color-secondary-blue-50);
+          top: 0px !important;
         }
       }
     }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes #2690 (a regression issue following #2688). The changes in #2688 caused the `plh_kids_kw`-specific "completion modal" component to display off the top of the screen. 

## Git Issues

Closes #2690

## Screenshots/Videos

Completion modal launched from [example_pop_ups](https://docs.google.com/spreadsheets/d/1K9JZ9Glnj73CFJmpfGIRa5dRA2TBxSsJmaguV6GL8Pc/edit?gid=402992224#gid=402992224).

Desktop browser:

<img width="280" alt="Screenshot 2025-01-07 at 17 00 13" src="https://github.com/user-attachments/assets/f038c065-7599-4dd8-93b7-cfec67087474" />

iOS native:

<img width="220" alt="Screenshot 2025-01-07 at 17 04 58" src="https://github.com/user-attachments/assets/0b3c0280-25a1-41fc-8f1f-3046f26f419b" />

iOS Safari:

<img width="220" alt="Screenshot 2025-01-07 at 17 07 02" src="https://github.com/user-attachments/assets/30aa8c87-7398-48e5-b5d6-b518eae0c0c6" />

