### PR TITLE
fix: handle safe area when app header is hidden

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -44,6 +44,12 @@
         <plh-main-header
           [style.display]="headerConfig().hidden ? 'none' : 'block'"
         ></plh-main-header>
+        <!-- Add spacer element when header is hidden to account for safe area (native status bar, notch etc.) -->
+        <div
+          class="safe-area-spacer"
+          [style.display]="headerConfig().hidden ? 'block' : 'none'"
+          [style.height]="'var(--ion-safe-area-top, 0)'"
+        ></div>
         <div class="route-container" [ngStyle]="routeContainerStyle()">
           <ion-router-outlet id="main-content"></ion-router-outlet>
         </div>


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where content would spill out of the "safe area" ("the section [of the display] that is not covered by the device's notch, status bar, or other elements that are part of the device's UI and not the app's" – [docs](https://ionicframework.com/docs/theming/advanced#safe-area-padding)) when the app header is hidden.

These changes should not have an effect on the web app accessed through Safari on iOS, as no safe area is applied in this case (see #2688).

#2631 added functionality to hide the app header and the issue has likely been present since then. Really we should be doing more testing on iOS in general (and multiple iOS devices), but this is time consuming and difficult to prioritise when deadlines are tight. In future, we should at least make sure to do additional testing on iOS for any changes that may affect interactions with the safe area.

## Testing

Test [feat_app_layout_inline_header](https://docs.google.com/spreadsheets/d/1Z46gTluTPeffqpiAZMapYo0imm59GU03j0sW9UChvPM/edit?gid=618720041#gid=618720041), and other linked templates

Appetize links:
- [ios](https://appetize.io/apps/ios/international.idems.debug-app)
- [android](https://appetize.io/apps/android/international.idems.debug_app)

## Dev notes

Ionic handles the device safe area natively, to an extent. For example, padding is applied to certain elements to account for the top and bottom unsafe areas ([docs](https://ionicframework.com/docs/theming/advanced#safe-area-padding)). This includes the `<ion-toolbar>` element that we use in the header and footer, so the header automatically adjusts to fill the unsafe area at the top of the screen on devices with a notch, for example. However, as this padding is only applied to certain elements and not the content as a whole, when we don't render the app header with its included `ion-toolbar`, there is no automatic handling of the safe area.

I've opted to handle this by explicitly adding a spacer element when the header is hidden, taking its height from the exposed `--ion-safe-area-top` CSS variable. An alternative approach would be to configure the app content to be restricted to the safe area at the `CapacitorConfig` level (see [this answer](https://stackoverflow.com/questions/73897759/content-displayed-over-the-safe-area-ios-capcitor-angular/74106265#74106265)):

```ts
  ios: {
    contentInset: "always"
  }
```

Whilst this might be more robust, from some quick testing it seems to be over-active: for example, the footer becomes excessively large, including double the amount of necessary padding. So if we did want to go down this route, we'd need to make changes to how we currently handle the safe area.

## Git Issues




Closes #2692



## Screenshots/Videos

Screen recordings taken using local iOS emulator.

`debug` deployment (including new [feat_app_layout_inline_header](https://docs.google.com/spreadsheets/d/1Z46gTluTPeffqpiAZMapYo0imm59GU03j0sW9UChvPM/edit?gid=618720041#gid=618720041) template:

https://github.com/user-attachments/assets/fb8a915c-52e6-4362-b642-c865db6c6007


`plh_kids_kw` deployment:

https://github.com/user-attachments/assets/23e8d962-7c48-4762-995e-eef6e87b4fba