### PR TITLE
feat(map): scale increments; change scale slider library

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "private": true,
   "dependencies": {
+    "@angular-slider/ngx-slider": "^18.0.0",
     "@angular/animations": "^17.2.2",
     "@angular/common": "~17.2.2",
     "@angular/core": "~17.2.2",

--- a/src/app/shared/components/template/components/map/map.component.html
+++ b/src/app/shared/components/template/components/map/map.component.html
@@ -10,34 +10,16 @@
                 {{ mapLayer.get("scaleTitle") }}
               </div>
               <div class="scale-container">
-                @if (mapLayer.get("scaleSlider")) {
-                  <ngx-slider
-                    [value]="mapLayer.get('scaleMin')"
-                    [highValue]="mapLayer.get('scaleMax')"
-                    [options]="{
-                      floor: mapLayer.get('scaleMin'),
-                      ceil: mapLayer.get('scaleMax'),
-                      step: mapLayer.get('scaleIncrement') || mapLayer.get('scaleMax') / 10,
-                      showTicks: !!mapLayer.get('scaleIncrement'),
-                      showTicksValues: !!mapLayer.get('scaleIncrement')
-                    }"
-                    (userChangeEnd)="handleSliderChange($event, mapLayer)"
-                    [ngStyle]="{ '--bar-background': mapLayer.get('gradientFill') }"
-                  ></ngx-slider>
-                } @else {
-                  <div
-                    class="colour-scale"
-                    [ngStyle]="{ 'background-image': mapLayer.get('gradientFill') }"
-                  ></div>
-                  <div class="scale-labels">
-                    <div class="scale-label max">
-                      {{ mapLayer.get("scaleMax") }}
-                    </div>
-                    <div class="scale-label min">
-                      {{ mapLayer.get("scaleMin") }}
-                    </div>
-                  </div>
-                }
+                <ngx-slider
+                  [class.disabled]="!mapLayer.get('scaleSlider')"
+                  [value]="mapLayer.get('scaleSlider') ? mapLayer.get('scaleMin') : null"
+                  [highValue]="mapLayer.get('scaleSlider') ? mapLayer.get('scaleMax') : null"
+                  [options]="getSliderOptions(mapLayer)"
+                  (userChangeEnd)="
+                    mapLayer.get('scaleSlider') ? handleSliderChange($event, mapLayer) : null
+                  "
+                  [ngStyle]="{ '--bar-background': mapLayer.get('gradientFill') }"
+                ></ngx-slider>
               </div>
             </div>
           }

--- a/src/app/shared/components/template/components/map/map.component.html
+++ b/src/app/shared/components/template/components/map/map.component.html
@@ -11,26 +11,33 @@
               </div>
               <div class="scale-container">
                 @if (mapLayer.get("scaleSlider")) {
-                  <ion-range
-                    [dualKnobs]="true"
-                    [value]="{ lower: 0, upper: 100 }"
+                  <ngx-slider
+                    [value]="mapLayer.get('scaleMin')"
+                    [highValue]="mapLayer.get('scaleMax')"
+                    [options]="{
+                      floor: mapLayer.get('scaleMin'),
+                      ceil: mapLayer.get('scaleMax'),
+                      step: mapLayer.get('scaleIncrement') || mapLayer.get('scaleMax') / 10,
+                      showTicks: !!mapLayer.get('scaleIncrement'),
+                      showTicksValues: !!mapLayer.get('scaleIncrement')
+                    }"
+                    (userChangeEnd)="handleSliderChange($event, mapLayer)"
                     [ngStyle]="{ '--bar-background': mapLayer.get('gradientFill') }"
-                    (ionChange)="handleSliderChange($event, mapLayer)"
-                  ></ion-range>
+                  ></ngx-slider>
                 } @else {
                   <div
                     class="colour-scale"
                     [ngStyle]="{ 'background-image': mapLayer.get('gradientFill') }"
                   ></div>
+                  <div class="scale-labels">
+                    <div class="scale-label max">
+                      {{ mapLayer.get("scaleMax") }}
+                    </div>
+                    <div class="scale-label min">
+                      {{ mapLayer.get("scaleMin") }}
+                    </div>
+                  </div>
                 }
-                <div class="scale-labels">
-                  <div class="scale-label max">
-                    {{ mapLayer.get("scaleMax") }}
-                  </div>
-                  <div class="scale-label min">
-                    {{ mapLayer.get("scaleMin") }}
-                  </div>
-                </div>
               </div>
             </div>
           }

--- a/src/app/shared/components/template/components/map/map.component.scss
+++ b/src/app/shared/components/template/components/map/map.component.scss
@@ -101,6 +101,13 @@ $map-height: 70vh;
       .ngx-slider-tick.ngx-slider-selected {
         background: white;
       }
+
+      &.disabled {
+        .ngx-slider-pointer {
+          // Hide element but preserve styling
+          visibility: hidden !important;
+        }
+      }
     }
   }
 }

--- a/src/app/shared/components/template/components/map/map.component.scss
+++ b/src/app/shared/components/template/components/map/map.component.scss
@@ -61,16 +61,46 @@ $map-height: 70vh;
       height: 12px;
       margin-bottom: 4px;
     }
+  }
+}
 
-    ion-range {
-      width: 100%;
-      bottom: 0px;
-      --bar-background: none;
-      --bar-background-active: none;
-      --bar-height: 12px;
-      --knob-background: var(--ion-color-primary);
-      --knob-size: 28px;
-      --height: 18px;
+/** Styling of scale slider, see example at https://angular-slider.github.io/ngx-slider/demos#styled-slider */
+::ng-deep {
+  .scale-container {
+    .ngx-slider {
+      --bar-height: 14px;
+
+      .ngx-slider-bar {
+        background: var(--bar-background);
+        height: var(--bar-height);
+      }
+      .ngx-slider-selection {
+        background: rgba(255, 255, 255, 0.1);
+      }
+
+      .ngx-slider-pointer {
+        top: calc(-1 * var(--bar-height) / 2);
+        background-color: var(--ion-color-primary);
+      }
+
+      .ngx-slider-pointer:after {
+        background-color: white;
+      }
+      .ngx-slider-pointer.ngx-slider-active:after {
+        background-color: black;
+      }
+
+      .ngx-slider-tick {
+        width: 2px;
+        height: var(--bar-height);
+        border-radius: 0;
+        background: black;
+        top: 3px;
+      }
+
+      .ngx-slider-tick.ngx-slider-selected {
+        background: white;
+      }
     }
   }
 }

--- a/src/app/shared/components/template/components/map/map.component.ts
+++ b/src/app/shared/components/template/components/map/map.component.ts
@@ -19,6 +19,7 @@ import chroma from "chroma-js";
 import BaseLayer from "ol/layer/Base";
 import { RangeCustomEvent } from "@ionic/angular";
 import { Feature } from "ol";
+import { ChangeContext } from "@angular-slider/ngx-slider";
 
 interface IMapLayer {
   id: string;
@@ -37,6 +38,8 @@ interface IMapLayer {
   gradient_palette: string[];
   scale_max: number;
   scale_min: number;
+  /** The size of the steps on the scale */
+  scale_increment: number;
   scale_bins: number[];
   scale_slider: boolean;
   /** Colour to set those features outside of slider range. Default is to set them to be hidden */
@@ -147,28 +150,15 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
    */
   public handleSliderChange(event: any, mapLayer: BaseLayer) {
     // Only works on vector layers
-    const { lower, upper } = (event as RangeCustomEvent).detail.value as {
-      lower: number;
-      upper: number;
-    };
+    const { value: lower, highValue: upper } = event as ChangeContext;
     const vectorLayer = mapLayer as VectorLayer;
     const propertyName = vectorLayer.get("propertyToPlot");
 
-    const scaleMax = vectorLayer.get("scaleMax");
-    const scaleMin = vectorLayer.get("scaleMin");
-    const excludedFeaturesColour = vectorLayer.get("excludedFeaturesColour");
-
-    const normaliseValue = (value: number) => {
-      return scaleMin + (value / 100) * (scaleMax - scaleMin);
-    };
-
-    const lowerNormalised = normaliseValue(lower);
-    const upperNormalised = normaliseValue(upper);
-
     const filterFeatures = (feature: Feature) => {
       const value = feature.get(propertyName);
-      return value >= lowerNormalised && value <= upperNormalised;
+      return value >= lower && value <= upper;
     };
+    const excludedFeaturesColour = vectorLayer.get("excludedFeaturesColour");
     vectorLayer.getSource().forEachFeature((feature: Feature) => {
       if (excludedFeaturesColour) {
         feature.set("overrideColour", !filterFeatures(feature));
@@ -316,6 +306,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
       gradient_palette,
       scale_max,
       scale_min,
+      scale_increment,
       scale_bins,
       scale_title,
       source_asset,
@@ -350,6 +341,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
       propertyToPlot,
       scaleMax: scale_max,
       scaleMin: scale_min,
+      scaleIncrement: scale_increment,
       scaleTitle: scale_title,
       scaleColours: gradient_palette,
     });
@@ -366,6 +358,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
       gradient_palette,
       scale_max,
       scale_min,
+      scale_increment,
       scale_title,
       source_asset,
       stroke,
@@ -488,6 +481,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
       description,
       scaleMax: scale_max,
       scaleMin: scale_min,
+      scaleIncrement: scale_increment,
       scaleTitle: scale_title,
       scaleColours,
       scaleSlider: scale_slider,
@@ -531,6 +525,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
       visible?: boolean;
       name: string;
       description?: string;
+      scaleIncrement?: number;
       scaleMax?: number;
       scaleMin?: number;
       scaleTitle?: string;
@@ -545,6 +540,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
       visible,
       name,
       description,
+      scaleIncrement,
       scaleMax,
       scaleMin,
       scaleTitle,
@@ -563,6 +559,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
     layer.set("name", name);
     layer.set("description", description);
     layer.set("gradientFill", cssGradientFill);
+    layer.set("scaleIncrement", scaleIncrement);
     layer.set("scaleMax", scaleMax);
     layer.set("scaleMin", scaleMin);
     layer.set("scaleTitle", scaleTitle);

--- a/src/app/shared/components/template/components/map/map.component.ts
+++ b/src/app/shared/components/template/components/map/map.component.ts
@@ -188,6 +188,18 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
     }
   }
 
+  public getSliderOptions(mapLayer: any) {
+    const scaleIncrement = mapLayer.get("scaleIncrement") || mapLayer.get("scaleMax") / 10;
+    return {
+      disabled: !mapLayer.get("scaleSlider"),
+      floor: mapLayer.get("scaleMin"),
+      ceil: mapLayer.get("scaleMax"),
+      step: scaleIncrement,
+      showTicks: !mapLayer.get("scaleSlider") || !!mapLayer.get("scaleIncrement"),
+      showTicksValues: !mapLayer.get("scaleSlider") || !!mapLayer.get("scaleIncrement"),
+    };
+  }
+
   private async initialiseMap() {
     this.map = new Map({
       layers: [

--- a/src/app/shared/components/template/template.module.ts
+++ b/src/app/shared/components/template/template.module.ts
@@ -7,6 +7,7 @@ import { NouisliderModule } from "ng2-nouislider";
 import { RouterModule } from "@angular/router";
 import { SwiperModule } from "swiper/angular";
 import { NgxExtendedPdfViewerModule } from "ngx-extended-pdf-viewer";
+import { NgxSliderModule } from "@angular-slider/ngx-slider";
 
 import { SharedPipesModule } from "../../pipes";
 import { TooltipDirective } from "../common/directives/tooltip.directive";
@@ -34,6 +35,7 @@ import { DEMO_COMPONENTS } from "packages/components/demo";
     RouterModule,
     SwiperModule,
     NgxExtendedPdfViewerModule,
+    NgxSliderModule,
     TemplatePipesModule,
   ],
   exports: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,6 +431,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@angular-slider/ngx-slider@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "@angular-slider/ngx-slider@npm:18.0.0"
+  dependencies:
+    detect-passive-events: ^2.0.3
+    rxjs: ^7.8.1
+    tslib: ^2.3.0
+  peerDependencies:
+    "@angular/common": ^18.0.0
+    "@angular/core": ^18.0.0
+    "@angular/forms": ^18.0.0
+  checksum: 7000b1f8265d29b41c573e726cd12103a45bd10c900787cead2c98a69a95fe508abf465fc046404245085df1d8d64f78de9585e476956d10026176f331ead531
+  languageName: node
+  linkType: hard
+
 "@angular/animations@npm:^17.2.2":
   version: 17.2.2
   resolution: "@angular/animations@npm:17.2.2"
@@ -12509,6 +12524,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-it@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "detect-it@npm:4.0.1"
+  checksum: 013981eae87c0265169e11e09efcc1c78fb2fc3e956b0001eb8d741ce03784a3e8e6d60e1445105f510c52be2ccffbd1c31c1bc094d01ad77f11df9830822a9c
+  languageName: node
+  linkType: hard
+
 "detect-libc@npm:^1.0.3":
   version: 1.0.3
   resolution: "detect-libc@npm:1.0.3"
@@ -12536,6 +12558,15 @@ __metadata:
   version: 2.1.0
   resolution: "detect-node@npm:2.1.0"
   checksum: 832184ec458353e41533ac9c622f16c19f7c02d8b10c303dfd3a756f56be93e903616c0bb2d4226183c9351c15fc0b3dba41a17a2308262afabcfa3776e6ae6e
+  languageName: node
+  linkType: hard
+
+"detect-passive-events@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "detect-passive-events@npm:2.0.3"
+  dependencies:
+    detect-it: ^4.0.1
+  checksum: 2fb48474e340a1add096735427433578c571e2fed0c44af86ac116c50b9b7d70662a2e3bf1539d9dff4e2a43459c874b20876270afe7beeb5d4bef08ff9d4a5c
   languageName: node
   linkType: hard
 
@@ -15164,6 +15195,7 @@ __metadata:
     "@angular-eslint/eslint-plugin-template": 17.2.1
     "@angular-eslint/schematics": 17.2.1
     "@angular-eslint/template-parser": 17.2.1
+    "@angular-slider/ngx-slider": ^18.0.0
     "@angular/animations": ^17.2.2
     "@angular/cli": ~17.2.1
     "@angular/common": ~17.2.2


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- The scale in the legend now displays labelled "steps"/"ticks"/"increments"
  - Configurable via the new layer property, `scale_increment`
    - Should be a number representing the size of each increment. E.g. if `scale_min = 0` and `scale_max = 100`, then setting `scale_increment = 5` will divide the scale into 20 different sections, with gaps of 5 between each
    - If no value is provided, the default is to divide the total by 10 to render 10 increments
  - New layer property: `scale_slider_snap`
    - Default `false`
    - if `true`, the slider will snap to the increment markers
- Refactors to use a different library to handle the interactive slider functionality
  - Previously this used the ionic [ion-range](https://ionicframework.com/docs/api/range) component, however this does not support vertical sliders (a requested feature to be implemented), so I've used [@angular-slider/ngx-slider](https://www.npmjs.com/package/@angular-slider/ngx-slider) instead (on the advice of [this comment](https://stackoverflow.com/a/64952298)).

## Git Issues

Closes #

## Screenshots/Videos

See updated [comp_map_layer_group_1](https://docs.google.com/spreadsheets/d/1KgLTrFhqZdGhcSk6Zt0KQoy2mYf7NCqhCJz_zS0KEYw/edit?gid=764093794#gid=764093794) to include `scale_increment` column.


https://github.com/user-attachments/assets/f5ef0bed-4b76-4e58-90f8-05c5f0118bf2

