### PR TITLE
spike: fix component.setValue inside data-items

### DIFF
--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -165,8 +165,23 @@ export class TemplateActionService extends SyncServiceBase {
         const selfField = arg.split(".")[1];
         arg = this.container?.templateRowMap[action._triggeredBy?._nested_name]?.[selfField];
       }
+
       return arg;
     });
+
+    // HACK – If a set_local action targets the row that triggered it, update the template row map to make this row available
+    if (action.action_id === "set_local" && this.container) {
+      const { _triggeredBy: triggerRow } = action;
+      const { _nested_name } = triggerRow;
+      const [setLocalKey] = action.args;
+
+      if (
+        setLocalKey === _nested_name &&
+        !this.container.templateRowMap.hasOwnProperty(_nested_name)
+      ) {
+        this.container.templateRowMap[_nested_name] = triggerRow;
+      }
+    }
     const { action_id, args } = action;
 
     // Call any action registered with global handler


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Investigation around #2704.

Allows a toggle bar inside a data items loop to set its own value.

## Git Issues

Closes #

## Screenshots/Videos

[debug_toggle_bar](https://docs.google.com/spreadsheets/d/1GeClVPEv2Trom59KvVnTXRwNyVbWCzKDl8-M7wmbNlc/edit?gid=1681985300#gid=1681985300)

<img width="600" alt="Screenshot 2025-01-13 at 16 59 16" src="https://github.com/user-attachments/assets/0ec8d764-bda0-45a2-810c-a09a4aec80ab" />

<img width="220" alt="Screenshot 2025-01-13 at 16 59 45" src="https://github.com/user-attachments/assets/2ea6deb6-4ef2-420b-9c41-1c00f5e8bb90" />
