### PR TITLE
chore: expose horizontal and vertical values for app config layout padding; fix display group inline_padding variant 

### DIFF
--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -128,7 +128,10 @@ const APP_FOOTER_DEFAULTS = {
 };
 
 const LAYOUT = {
-  page_padding: "24px",
+  page_padding: {
+    horizontal: "24px",
+    vertical: "24px",
+  },
 };
 
 const APP_SIDEMENU_DEFAULTS = {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -59,7 +59,8 @@ export class AppComponent {
   public routeContainerStyle = computed(() => {
     const { page_padding } = this.layoutConfig();
     return {
-      "--page-padding": page_padding,
+      "--page-padding-horizontal": page_padding.horizontal,
+      "--page-padding-vertical": page_padding.vertical,
     };
   });
 

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -52,8 +52,7 @@
 
 .display-group-wrapper[data-variant~="inline_padding"] {
   width: 100%;
-  padding-left: var(--padding-start);
-  padding-right: var(--padding-end);
+  padding-inline: var(--default-page-padding);
 }
 
 .display-group-wrapper {

--- a/src/theme/deployment/_overrides.scss
+++ b/src/theme/deployment/_overrides.scss
@@ -5,11 +5,11 @@ plh-button > ion-button {
 
 /// Ensure all pages have padding
 ion-content {
-  $default-padding: 24px;
-  --padding-top: var(--page-padding-vertical, #{$default-padding});
-  --padding-bottom: var(--page-padding-vertical, #{$default-padding});
-  --padding-start: var(--page-padding-horizontal, #{$default-padding});
-  --padding-end: var(--page-padding-horizontal, #{$default-padding});
+  --default-page-padding: 24px;
+  --padding-top: var(--page-padding-vertical, var(--default-page-padding));
+  --padding-bottom: var(--page-padding-vertical, var(--default-page-padding));
+  --padding-start: var(--page-padding-horizontal, var(--default-page-padding));
+  --padding-end: var(--page-padding-horizontal, var(--default-page-padding));
 
   // HACK: prevent scrollbar from hiding when interacting with ion-range, for example (this can cause visual glitches).
   // see https://github.com/ionic-team/ionic-framework/issues/25595#issuecomment-1330293954

--- a/src/theme/deployment/_overrides.scss
+++ b/src/theme/deployment/_overrides.scss
@@ -6,10 +6,10 @@ plh-button > ion-button {
 /// Ensure all pages have padding
 ion-content {
   $default-padding: 24px;
-  --padding-top: var(--page-padding, #{$default-padding});
-  --padding-bottom: var(--page-padding, #{$default-padding});
-  --padding-start: var(--page-padding, #{$default-padding});
-  --padding-end: var(--page-padding, #{$default-padding});
+  --padding-top: var(--page-padding-vertical, #{$default-padding});
+  --padding-bottom: var(--page-padding-vertical, #{$default-padding});
+  --padding-start: var(--page-padding-horizontal, #{$default-padding});
+  --padding-end: var(--page-padding-horizontal, #{$default-padding});
 
   // HACK: prevent scrollbar from hiding when interacting with ion-range, for example (this can cause visual glitches).
   // see https://github.com/ionic-team/ionic-framework/issues/25595#issuecomment-1330293954


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- New `app_config` properties: `LAYOUT.page_padding.horizontal` and `LAYOUT.page_padding.vertical`
  - These replace the previous single `LAYOUT.page_padding` property. This was only used in debug and WIP sheets, so I haven't considered this to be a breaking change.
  - Separating out these properties makes it much easier to assign them to ionic's four `--padding-*` css variables. It also makes sense from an authoring perspective, as the main use case for adjusting the padding is to do so for the horizontal axis only.
- Updates `inline_padding` variant of the display group component
  - Previously, the size of the padding was read from the same ionic padding variables that are set from the app config level, meaning that if the page padding was set to 0, the padding applied to the `inline_padding` variant would also be 0. 
  - This variant was originally introduced for convenience when dealing with sticky display groups, which ignore page padding by default (see #2589).
  - In theory, this variant shouldn't be necessary as it should accomplish the same thing as a single line of custom styling (namely `padding-inline: 24px`, for example). However, as well as providing a convenient alternative to adding custom styling, the custom styling approach is currently broken, see #2709.
  - In resolving #2709, it seems difficult to avoid unwanted knock-ons, since there may be production deployments which make use of the styling at both levels. We need a way to style padding-free pages immediately, therefore it seems like an acceptable short-term solution to leverage the existing `inline_padding` variant.
    - An alternative would be to set the custom `padding-inline` to be half the desired value, knowing that it will be applied twice on the rendered component

## Git Issues

Closes #

## Screenshots/Videos

[feat_app_layout_padding](https://docs.google.com/spreadsheets/d/1Z46gTluTPeffqpiAZMapYo0imm59GU03j0sW9UChvPM/edit?gid=2064945031#gid=2064945031):

<img width="680" alt="Screenshot 2025-01-14 at 15 54 48" src="https://github.com/user-attachments/assets/625a850f-5813-4ba8-9579-c12a80db285b" />

<img width="680" alt="Screenshot 2025-01-14 at 15 54 02" src="https://github.com/user-attachments/assets/3149cdfd-0a2c-4c2e-96b7-7eb804c905c6" />

<img width="240" alt="Screenshot 2025-01-14 at 15 33 23" src="https://github.com/user-attachments/assets/827edf62-31b7-4e7d-9888-47fa3396b121" />
