### PR TITLE
fix: app config page padding property is properly interpreted as shorthand

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -43,6 +43,7 @@ import { LocalStorageService } from "./shared/services/local-storage/local-stora
 import { DeploymentService } from "./shared/services/deployment/deployment.service";
 import { ScreenOrientationService } from "./shared/services/screen-orientation/screen-orientation.service";
 import { TemplateMetadataService } from "./shared/components/template/services/template-metadata.service";
+import { getPaddingValuesFromShorthand } from "./shared/components/template/utils";
 
 @Component({
   selector: "app-root",
@@ -58,8 +59,12 @@ export class AppComponent {
 
   public routeContainerStyle = computed(() => {
     const { page_padding } = this.layoutConfig();
+    const { top, right, bottom, left } = getPaddingValuesFromShorthand(page_padding);
     return {
-      "--page-padding": page_padding,
+      "--page-padding-top": top,
+      "--page-padding-start": left,
+      "--page-padding-bottom": bottom,
+      "--page-padding-end": right,
     };
   });
 

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -52,8 +52,7 @@
 
 .display-group-wrapper[data-variant~="inline_padding"] {
   width: 100%;
-  padding-left: var(--padding-start);
-  padding-right: var(--padding-end);
+  padding-inline: var(--default-page-padding);
 }
 
 .display-group-wrapper {

--- a/src/app/shared/components/template/utils/render-utils.spec.ts
+++ b/src/app/shared/components/template/utils/render-utils.spec.ts
@@ -1,0 +1,34 @@
+import { getPaddingValuesFromShorthand } from "./render-utils";
+
+/**
+ * Call standalone tests via:
+ * yarn ng test --include src/app/shared/components/template/utils/render-utils.spec.ts
+ */
+describe("Data Items Utils", () => {
+  it("getPaddingValuesFromShorthand extracts correct values", () => {
+    expect(getPaddingValuesFromShorthand("10px")).toEqual({
+      top: "10px",
+      right: "10px",
+      bottom: "10px",
+      left: "10px",
+    });
+    expect(getPaddingValuesFromShorthand("10px 20px")).toEqual({
+      top: "10px",
+      right: "20px",
+      bottom: "10px",
+      left: "20px",
+    });
+    expect(getPaddingValuesFromShorthand("10px 20px 30px")).toEqual({
+      top: "10px",
+      right: "20px",
+      bottom: "30px",
+      left: "20px",
+    });
+    expect(getPaddingValuesFromShorthand("10px 20px 30px 40px")).toEqual({
+      top: "10px",
+      right: "20px",
+      bottom: "30px",
+      left: "40px",
+    });
+  });
+});

--- a/src/app/shared/components/template/utils/render-utils.ts
+++ b/src/app/shared/components/template/utils/render-utils.ts
@@ -70,3 +70,10 @@ export function setElStyleAnimated(
     return;
   });
 }
+
+/** Extract constituent directional values from shorthand padding CSS value */
+export function getPaddingValuesFromShorthand(padding: string) {
+  const paddingArray = padding.split(" ");
+  const [top, right = top, bottom = top, left = right] = paddingArray;
+  return { top, right, bottom, left };
+}

--- a/src/theme/deployment/_overrides.scss
+++ b/src/theme/deployment/_overrides.scss
@@ -5,11 +5,11 @@ plh-button > ion-button {
 
 /// Ensure all pages have padding
 ion-content {
-  $default-padding: 24px;
-  --padding-top: var(--page-padding, #{$default-padding});
-  --padding-bottom: var(--page-padding, #{$default-padding});
-  --padding-start: var(--page-padding, #{$default-padding});
-  --padding-end: var(--page-padding, #{$default-padding});
+  --default-page-padding: 24px;
+  --padding-top: var(--page-padding-top, var(--default-page-padding));
+  --padding-bottom: var(--page-padding-bottom, var(--default-page-padding));
+  --padding-start: var(--page-padding-start, var(--default-page-padding));
+  --padding-end: var(--page-padding-end, var(--default-page-padding));
 
   // HACK: prevent scrollbar from hiding when interacting with ion-range, for example (this can cause visual glitches).
   // see https://github.com/ionic-team/ionic-framework/issues/25595#issuecomment-1330293954


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Fixes an issue where the `app_config` property `LAYOUT.page_padding` would not be correctly interpreted as a shorthand CSS property for setting the padding on multiple sides, e.g. `24px 0` or `24px 32px 10px 24px`
- Updates `inline_padding` variant of the display group component
  - Previously, the size of the padding was read from the same ionic padding variables that are set from the app config level, meaning that if the page padding was set to 0, the padding applied to the `inline_padding` variant would also be 0. 
  - This variant was originally introduced for convenience when dealing with sticky display groups, which ignore page padding by default (see #2589).
  - In theory, this variant shouldn't be necessary as it should accomplish the same thing as a single line of custom styling (namely `padding-inline: 24px`, for example). However, as well as providing a convenient alternative to adding custom styling, the custom styling approach is currently broken, see #2709.
  - In resolving #2709, it seems difficult to avoid unwanted knock-ons, since there may be production deployments which make use of the styling at both levels. We need a way to style padding-free pages immediately, therefore it seems like an acceptable short-term solution to leverage the existing `inline_padding` variant.
    - An alternative would be to set the custom `padding-inline` to be half the desired value, knowing that it will be applied twice on the rendered component

## Dev notes

Because ionic components use the shadow dom, we must rely on the exposed CSS variables to customise the styling. In the case of padding, the shadow element `.inner-scroll` gets padding applied through 4 exposed CSS variables: `--padding-top`, `--padding-bottom`, `--padding-start` and `--padding-end`, see screenshot below. In order to set these variables from our authored `page_padding` value, which defines all 4 via in shorthand syntax, we must manually extract the different values.

<img width="1000" alt="Screenshot 2025-01-16 at 17 47 08" src="https://github.com/user-attachments/assets/7a8fe1dd-d7a2-4b0e-9777-394e659e6297" />


## Git Issues

Closes #2710 

## Screenshots/Videos

[feat_app_layout_padding](https://docs.google.com/spreadsheets/d/1Z46gTluTPeffqpiAZMapYo0imm59GU03j0sW9UChvPM/edit?gid=2064945031#gid=2064945031):

<img width="800" alt="Screenshot 2025-01-16 at 19 11 36" src="https://github.com/user-attachments/assets/da01a520-b4fd-4d54-a24b-fe2fafe6ad4a" />


<img width="680" alt="Screenshot 2025-01-14 at 15 54 02" src="https://github.com/user-attachments/assets/3149cdfd-0a2c-4c2e-96b7-7eb804c905c6" />

<img width="240" alt="Screenshot 2025-01-16 at 19 16 30" src="https://github.com/user-attachments/assets/a6405372-d298-4f8b-bd80-884ecfe900ce" />

<img width="240" alt="Screenshot 2025-01-16 at 19 16 39" src="https://github.com/user-attachments/assets/c5ee8089-aacf-4a7d-9bb5-efe988be52c1" />
