### PR TITLE
chore(ci): make deployment private key secret explicit in all relevant reusable workflows

### DIFF
--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -39,6 +39,9 @@ on:
           type: string
           description: "Specify branch for deployment"
           default: ""
+      secrets:
+        DEPLOYMENT_PRIVATE_KEY:
+          description: Provide private key if deployment uses encrypted config
   
 jobs:
   

--- a/.github/workflows/reusable-deploy-web-gh-pages.yml
+++ b/.github/workflows/reusable-deploy-web-gh-pages.yml
@@ -40,6 +40,9 @@ on:
         default: ${{vars.GH_PAGES_BASE || ''}}
         required: false
         type: string
+    secrets:
+      DEPLOYMENT_PRIVATE_KEY:
+        description: Provide private key if deployment uses encrypted config
       
 
 jobs:

--- a/.github/workflows/reusable-deploy-web-preview.yml
+++ b/.github/workflows/reusable-deploy-web-preview.yml
@@ -39,6 +39,8 @@ on:
     secrets:  # Declare secrets you expect to receive
       FIREBASE_SERVICE_ACCOUNT:
         required: true
+      DEPLOYMENT_PRIVATE_KEY:
+        description: Provide private key if deployment uses encrypted config
 
 jobs:
   build_action:


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow up to #2721, see that PR for a full explanation.

Makes the `DEPLOYMENT_PRIVATE_KEY` secret explicit for all workflows that call the `reusable-app-build` workflow.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
