### PR TITLE
chore(ci): make deployment private key secret explicit in second-order workflows

### DIFF
--- a/.github/workflows/reusable-android-release.yml
+++ b/.github/workflows/reusable-android-release.yml
@@ -33,6 +33,8 @@ on:
       required: true
     KEY_PASSWORD: 
       required: true
+    DEPLOYMENT_PRIVATE_KEY:
+      description: Provide private key if deployment uses encrypted config
   
 jobs:
     build:

--- a/.github/workflows/reusable-appetize.yml
+++ b/.github/workflows/reusable-appetize.yml
@@ -22,7 +22,10 @@ env:
 
 
 on:
- workflow_call:
+  workflow_call:
+    secrets:
+      DEPLOYMENT_PRIVATE_KEY:
+        description: Provide private key if deployment uses encrypted config
 
 jobs:
 

--- a/.github/workflows/reusable-content-sync.yml
+++ b/.github/workflows/reusable-content-sync.yml
@@ -44,6 +44,8 @@ on:
           required: true
         PAT:
           required: true
+        DEPLOYMENT_PRIVATE_KEY:
+          description: Provide private key if deployment uses encrypted config
    
 jobs:
    build:


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow-up to #2722. Covers three additional workflows that were missed in that PR that don't directly call the the `reusable-app-build` workflow but make use of the `DEPLOYMENT_PRIVATE_KEY` secret.


## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
