### PR TITLE
style: MX theme: reduce size of round-button component; further reduce size of navigation button

### DIFF
--- a/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.scss
+++ b/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.scss
@@ -159,7 +159,7 @@ ion-tab-button {
   &[data-variant~="no-background"],
   &.no-background {
     color: unset;
-    background: transparent;
+    background: transparent !important;
     box-shadow: none;
     ion-icon {
       height: 32px;

--- a/src/theme/themes/plh_facilitator_mx/_index.scss
+++ b/src/theme/themes/plh_facilitator_mx/_index.scss
@@ -44,6 +44,8 @@
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),
       round-button-background-secondary-light: var(--ion-color-yellow),
+      round-button-min-height: 48px,
+      round-button-width: 48px,
       tile-button-background-primary: var(--ion-color-primary-500),
       tile-button-background-primary-light: var(--ion-color-primary-300),
       tile-button-background-secondary: var(--ion-color-secondary),

--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -951,11 +951,16 @@ body[data-theme="plh_facilitator_mx"] {
   // Round Button
   ion-tab-button {
     box-shadow: none;
-    background: var(--ion-color-primary-600);
+    background: var(--ion-color-primary-600) !important;
     &[data-variant~="navigation"] {
       background: var(--ion-color-primary-700) !important;
-      border-radius: var(--ion-border-radius-standard);
+      border-radius: var(--ion-border-radius-small);
       box-shadow: none !important;
+      min-height: 32px;
+      width: 36px;
+      ion-icon {
+        font-size: 18px;
+      }
     }
     &[data-variant~="module"] {
       background: var(--color-secondary-blue-40) !important;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Reduces size of `round_button` component to closer resemble figma designs
- Further reduces size of `navigation` variant of `round_button` component to closer resemble figma designs

## Git Issues

Closes https://github.com/ParentingForLifelongHealth/plh-facilitator-app-mx-content/issues/114

In combination with authoring changes (no specific content PR to point to as multiple changes are being worked on simultaneously):
- Makes `group_add.svg` icon white rather than dark
  - (Renamed existing asset -> "group_add_dark.svg" but didn't remove, updated `group_add.svg` to be white)
- Added custom 12px margin-bottom to dg on [edit_parent_group](https://docs.google.com/spreadsheets/d/14iUeYWUHIly3tyz61Wgz_tlPUVAqkI8aXFnlsrUA1ZY/edit?gid=1081278670#gid=1081278670) and [add_parent_group](https://docs.google.com/spreadsheets/d/14iUeYWUHIly3tyz61Wgz_tlPUVAqkI8aXFnlsrUA1ZY/edit?gid=380857207#gid=380857207) to improve spacing

## Screenshots/Videos

[add_parent_group](https://docs.google.com/spreadsheets/d/14iUeYWUHIly3tyz61Wgz_tlPUVAqkI8aXFnlsrUA1ZY/edit?gid=380857207#gid=380857207) template:

| Figma design | Current master | PR branch |
|---|---|---|
| <img width="220" alt="404395655-163b2489-d373-4319-8b16-8e633c074d4b" src="https://github.com/user-attachments/assets/23cf9e1a-1e96-40f3-8cd4-cfdee0129c73" /> | <img width="220" alt="Screenshot 2025-01-19 at 14 18 04" src="https://github.com/user-attachments/assets/2dc9425e-e9c4-40c1-8c84-c0f29da8cca5" /> | <img width="220" alt="Screenshot 2025-01-19 at 14 54 03" src="https://github.com/user-attachments/assets/b2afa18b-86e1-4896-a673-c2f6607786d2" /> |


