### PR TITLE
feat: combo-box component disabled state

### DIFF
--- a/src/app/shared/components/template/components/combo-box/combo-box.component.html
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.html
@@ -2,9 +2,9 @@
   <button
     class="open-combobox margin-t-regular"
     (click)="openModal()"
-    [class.placeholder-style]="(!_row.value && placeholder) || prioritisePlaceholder"
-    [class.disabled]="disabled()"
     [ngClass]="{
+      disabled: disabled(),
+      'placeholder-style': (!_row.value && placeholder) || prioritisePlaceholder,
       'with-value': _row.value,
       'no-value': !_row.value
     }"

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.html
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.html
@@ -3,22 +3,24 @@
     class="open-combobox margin-t-regular"
     (click)="openModal()"
     [class.placeholder-style]="(!_row.value && placeholder) || prioritisePlaceholder"
+    [class.disabled]="disabled()"
     [ngClass]="{
       'with-value': _row.value,
       'no-value': !_row.value
     }"
-    [disabled]="_row.disabled"
+    [disabled]="disabled()"
   >
-    {{ (text && !prioritisePlaceholder ? text : placeholder) | translate }}
+    {{ displayText() | translate }}
   </button>
 } @else if (variant === "dropdown") {
   <div class="combo-box-container dropdown">
     <ion-select
       [class.hasValue]="!!_row.value"
-      [placeholder]="(text && !prioritisePlaceholder ? text : placeholder) | translate"
+      [placeholder]="displayText() | translate"
       (ionChange)="setValue($event.detail.value)"
       interface="popover"
       labelPlacement="stacked"
+      [disabled]="disabled()"
     >
       @for (answerOption of answerOptions(); track answerOption.name) {
         <ion-select-option [value]="answerOption.name">

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.scss
@@ -26,7 +26,12 @@ $background-with-value: var(
   }
 }
 
-.placeholder-style {
+.disabled {
+  opacity: 0.5;
+}
+
+.placeholder-style,
+.disabled {
   color: $placeholder-text;
 }
 .with-value {

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, OnDestroy, OnInit, signal } from "@angular/core";
+import { Component, computed, effect, OnDestroy, signal } from "@angular/core";
 import { ModalController } from "@ionic/angular";
 import { ComboBoxModalComponent } from "./combo-box-modal/combo-box-modal.component";
 import {
@@ -20,7 +20,7 @@ import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 })
 export class TmplComboBoxComponent
   extends TemplateBaseComponent
-  implements ITemplateRowProps, OnInit, OnDestroy
+  implements ITemplateRowProps, OnDestroy
 {
   public variant: "modal" | "dropdown";
   public placeholder: string;
@@ -58,6 +58,15 @@ export class TmplComboBoxComponent
     return this.answerText() && !this.prioritisePlaceholder ? this.answerText() : this.placeholder;
   });
 
+  public buttonStyle = computed(() => {
+    return {
+      disabled: this.disabled(),
+      "placeholder-style": (!this._row.value && this.placeholder) || this.prioritisePlaceholder,
+      "with-value": this._row.value,
+      "no-value": !this._row.value,
+    };
+  });
+
   constructor(
     private modalController: ModalController,
     private dataItemsService: DataItemsService
@@ -79,10 +88,10 @@ export class TmplComboBoxComponent
       },
       { allowSignalWrites: true }
     );
-  }
-
-  ngOnInit(): void {
-    this.getParams();
+    effect(() => {
+      this.parameterList();
+      this.getParams();
+    });
   }
 
   getParams() {

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -63,6 +63,9 @@ export class TmplComboBoxComponent
     private dataItemsService: DataItemsService
   ) {
     super();
+    // If an initial value is authored, check if this corresponds to an answer option entry.
+    // Handle in effect as answer options may not be available on init
+    // TODO: Refactor base component to use value() signal and use this to compute displayText
     effect(
       () => {
         if (this.answerOptions().length > 0 && this._row.value) {

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, OnDestroy, OnInit, signal } from "@angular/core";
+import { Component, computed, effect, OnDestroy, OnInit, signal } from "@angular/core";
 import { ModalController } from "@ionic/angular";
 import { ComboBoxModalComponent } from "./combo-box-modal/combo-box-modal.component";
 import {
@@ -27,9 +27,9 @@ export class TmplComboBoxComponent
   public prioritisePlaceholder: boolean;
   public disabledText: string;
   private style: string;
-  public text = signal("");
+  public answerText = signal("");
   private authorDisabled = false;
-  private customAnswerSelected: boolean = false;
+  private customAnswerSelected = signal(false);
   private customAnswerText: string;
   private componentDestroyed$ = new ReplaySubject(1);
 
@@ -53,11 +53,9 @@ export class TmplComboBoxComponent
   public disabled = computed(() => this.authorDisabled || this.answerOptions().length === 0);
 
   public displayText = computed(() => {
-    return this.disabled()
-      ? this.disabledText
-      : this.text() && !this.prioritisePlaceholder
-        ? this.text()
-        : this.placeholder;
+    if (this.disabled()) return this.disabledText;
+    if (this.customAnswerSelected()) return this.customAnswerText;
+    return this.answerText() && !this.prioritisePlaceholder ? this.answerText() : this.placeholder;
   });
 
   constructor(
@@ -65,25 +63,23 @@ export class TmplComboBoxComponent
     private dataItemsService: DataItemsService
   ) {
     super();
+    effect(
+      () => {
+        if (this.answerOptions().length > 0 && this._row.value) {
+          const selectedAnswer = this.answerOptions().find((x) => x.name === this._row.value);
+          if (!selectedAnswer) {
+            this.customAnswerSelected.set(true);
+          } else {
+            this.answerText.set(selectedAnswer?.text || "");
+          }
+        }
+      },
+      { allowSignalWrites: true }
+    );
   }
 
   ngOnInit(): void {
     this.getParams();
-
-    this.customAnswerSelected =
-      this.answerOptions().length > 0 && this._row.value
-        ? !this.answerOptions().find((x) => x.name === this._row.value)
-        : false;
-
-    this.text.set("");
-    if (this._row.value) {
-      this.text.set(
-        this.customAnswerSelected
-          ? this.customAnswerText
-          : this.answerOptions().find((answerListItem) => answerListItem.name === this._row.value)
-              ?.text
-      );
-    }
   }
 
   getParams() {
@@ -108,17 +104,17 @@ export class TmplComboBoxComponent
       componentProps: {
         answerOptions: this.answerOptions,
         row: this._row,
-        selectedValue: this.customAnswerSelected ? this.text() : this._row.value,
-        customAnswerSelected: this.customAnswerSelected,
+        selectedValue: this.customAnswerSelected() ? this.answerText() : this._row.value,
+        customAnswerSelected: this.customAnswerSelected(),
         style: this.style,
       },
     });
 
     modal.onDidDismiss().then(async (data) => {
       this.prioritisePlaceholder = false;
-      this.text.set(data?.data?.answer?.text);
-      this.customAnswerSelected = data?.data?.customAnswerSelected;
-      this.customAnswerText = this.customAnswerSelected ? this.text() : "";
+      this.answerText.set(data?.data?.answer?.text);
+      this.customAnswerSelected.set(data?.data?.customAnswerSelected);
+      this.customAnswerText = this.customAnswerSelected() ? data?.data?.answer?.text : "";
       await this.setValue(data?.data?.answer?.name);
       await this.triggerActions("changed");
     });


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new disabled state for the combo-box component. 
- The combo-box is disabled if manually set to disabled via a new `disabled` parameter (i.e. `disabled = true`
- Else the combo-box is automatically disabled if no answer list is provided, or if the answer list is empty.
- When the combo-box is disabled, it will display any text provided to a new parameter, `disabled_text`

Also fixes an issue where the displayed text in the combo box may not update correctly to reflect the value.

## Testing

Every configuration of the combo-box should be tested to ensure no functionality is broken. The [comp_combo_box](https://docs.google.com/spreadsheets/d/1uIkaMlDjoDN7uTpHkSeEQ6Yp-4ehX9IrBQMrolpfjQc/edit?gid=569531329#gid=569531329) component was quite confusing, I've updated it and am satisfied that each configuration seems to be functioning as expected.

## Git Issues

closes https://github.com/ParentingForLifelongHealth/plh-facilitator-app-mx-content/issues/111 (alongside content change already made to [menu_task_flow_base](https://docs.google.com/spreadsheets/d/1qG_NlXNGEhXg6y2nJ2UdnfnsGcoazAtURkCIesOLnzA/edit?gid=482991517#gid=482991517) template.

## Screenshots/Videos

[comp_combo_box](https://docs.google.com/spreadsheets/d/1uIkaMlDjoDN7uTpHkSeEQ6Yp-4ehX9IrBQMrolpfjQc/edit?gid=569531329#gid=569531329):

<img width="720" alt="Screenshot 2025-01-20 at 13 34 33" src="https://github.com/user-attachments/assets/84eb5aff-14b8-4e0d-93d5-81f970552ce8" />


<img width="260" alt="Screenshot 2025-01-20 at 13 34 05" src="https://github.com/user-attachments/assets/e568f7f0-6f5c-4694-bf17-04a712fbc625" />

