### PR TITLE
Fix: data items translations

### DIFF
--- a/src/app/shared/components/template/components/data-items/data-items.service.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.service.ts
@@ -10,13 +10,15 @@ import { updateItemMeta } from "./data-items.utils";
 import { isEqual } from "packages/shared/src/utils/object-utils";
 import { AppDataEvaluator } from "packages/shared/src/models/appDataEvaluator/appDataEvaluator";
 import { JSEvaluator } from "packages/shared/src/models/jsEvaluator/jsEvaluator";
+import { TemplateTranslateService } from "../../services/template-translate.service";
 
 @Injectable({ providedIn: "root" })
 export class DataItemsService {
   constructor(
     private dynamicDataService: DynamicDataService,
     private injector: Injector,
-    private templateVariablesService: TemplateVariablesService
+    private templateVariablesService: TemplateVariablesService,
+    private templateTranslateService: TemplateTranslateService
   ) {}
 
   /** Process an template data_items row and generate an observable of generated child item rows */
@@ -41,7 +43,7 @@ export class DataItemsService {
         .pipe(
           switchMap((query) =>
             query.pipe(
-              switchMap((data) =>
+              switchMap((data: FlowTypes.Data_listRow[]) =>
                 defer(async () => {
                   // Parse the retrieved data_list. Use item processor to loop over item data
                   // and templated rows to generate item rows
@@ -122,25 +124,28 @@ export class DataItemsService {
 
   /**
    * Similar method as templateRowService to partially evaluate any string expressions in data_lists,
-   * except uses arrays instead of hashmaps
+   * except uses arrays instead of hashmaps and includes translation
+   * (default template processor uses `ensureValueTranslated` method from `template-variables.service`)
    *
    * TODO - this isn't an efficient method for parsing. Data lists should be evaluated in parser
    * and list of variables to replace identified as metadata in similar way to templating
    *
-   * TODO - is this even required if the templated rows are also parsed?
    */
-  private async hackParseDataList(dataListHashmap: FlowTypes.Data_listRow[]) {
-    const parsedHashmap: Record<string, FlowTypes.Data_listRow> = {};
-    for (const [listKey, listValue] of Object.entries(dataListHashmap)) {
-      parsedHashmap[listKey] = listValue;
-      for (const [itemKey, itemValue] of Object.entries(listValue)) {
-        if (typeof itemValue === "string") {
-          parsedHashmap[listKey][itemKey] =
-            await this.templateVariablesService.evaluateConditionString(itemValue);
+  private async hackParseDataList(dataListRows: FlowTypes.Data_listRow[]) {
+    // Ensure data list rows translated before processing template items
+    const translatedListRows = this.templateTranslateService.translateDataListRows(dataListRows);
+    const evaluatedRows: FlowTypes.Data_listRow[] = [];
+    for (const row of translatedListRows) {
+      for (const [key, value] of Object.entries(row)) {
+        if (typeof value === "string") {
+          const evaluated = await this.templateVariablesService.evaluateConditionString(value);
+          row[key] = evaluated;
         }
       }
+      evaluatedRows.push(row);
     }
-    return Object.values(parsedHashmap);
+
+    return evaluatedRows;
   }
 
   /**

--- a/src/app/shared/components/template/components/data-items/data-items.service.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.service.ts
@@ -128,11 +128,12 @@ export class DataItemsService {
    * (default template processor uses `ensureValueTranslated` method from `template-variables.service`)
    *
    * TODO - this isn't an efficient method for parsing. Data lists should be evaluated in parser
-   * and list of variables to replace identified as metadata in similar way to templating
-   *
+   * and list of variables to replace identified as metadata in similar way to templating.
    */
   private async hackParseDataList(dataListRows: FlowTypes.Data_listRow[]) {
     // Ensure data list rows translated before processing template items
+    // It might be possible to avoid repeated translation effort if including translated data_list in query,
+    // but would also need better tracking of language change and data updates so not currently optimized.
     const translatedListRows = this.templateTranslateService.translateDataListRows(dataListRows);
     const evaluatedRows: FlowTypes.Data_listRow[] = [];
     for (const row of translatedListRows) {

--- a/src/app/shared/components/template/services/template-translate.service.spec.ts
+++ b/src/app/shared/components/template/services/template-translate.service.spec.ts
@@ -1,5 +1,28 @@
 import { TestBed } from "@angular/core/testing";
 import { TemplateTranslateService } from "./template-translate.service";
+import { AppDataService } from "src/app/shared/services/data/app-data.service";
+import { MockAppDataService } from "src/app/shared/services/data/app-data.service.mock.spec";
+import { AppConfigService } from "src/app/shared/services/app-config/app-config.service";
+import { MockAppConfigService } from "src/app/shared/services/app-config/app-config.service.spec";
+
+const MOCK_DATA_LIST_ROWS = [
+  {
+    id: "id_1",
+    text: "Hello",
+    non_translated_text: "world",
+    row_index: 0,
+    _translations: {
+      text: {
+        es_sp: true,
+      },
+    },
+    _translatedFields: {
+      text: {
+        eng: "Hello",
+      },
+    },
+  },
+];
 
 /** Mock calls for field values from the template field service to return test data */
 export class MockTemplateTranslateService implements Partial<TemplateTranslateService> {
@@ -12,15 +35,49 @@ export class MockTemplateTranslateService implements Partial<TemplateTranslateSe
   }
 }
 
+/**
+ * Call standalone tests via:
+ * yarn ng test --include src/app/shared/components/template/services/template-translate.service.spec.ts
+ */
 describe("TemplateTranslateService", () => {
   let service: TemplateTranslateService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: AppDataService,
+          useValue: new MockAppDataService(
+            { data_list: {} },
+            {
+              es_sp: {
+                Hello: "hola",
+              },
+            }
+          ),
+        },
+        {
+          provide: AppConfigService,
+          useValue: new MockAppConfigService({ APP_LANGUAGES: { default: "en_mock" } }),
+        },
+      ],
+    });
     service = TestBed.inject(TemplateTranslateService);
   });
 
   it("should be created", () => {
     expect(service).toBeTruthy();
+  });
+
+  it("Updates translation_strings on language set", async () => {
+    await service.setLanguage("es_sp");
+    expect(service.translation_strings).toEqual({ Hello: "hola" });
+  });
+
+  it("translateDataListRows", async () => {
+    await service.setLanguage("es_sp");
+    const [row_0] = service.translateDataListRows(MOCK_DATA_LIST_ROWS);
+    expect(row_0.text).toEqual("hola");
+    expect(row_0.non_translated_text).toEqual("world");
   });
 });

--- a/src/app/shared/components/template/services/template-translate.service.ts
+++ b/src/app/shared/components/template/services/template-translate.service.ts
@@ -140,7 +140,6 @@ export class TemplateTranslateService extends AsyncServiceBase {
     const [{ _translatedFields }] = rows;
     if (!_translatedFields) return rows;
     const translateKeys = Object.keys(_translatedFields);
-    console.log("translate list rows", JSON.parse(JSON.stringify(rows)));
     // translate rows
     return rows.map((row) => {
       for (const key of translateKeys) {
@@ -187,7 +186,7 @@ export class TemplateTranslateService extends AsyncServiceBase {
     return translated;
   }
 
-  subscribeToAppConfigChanges() {
+  private subscribeToAppConfigChanges() {
     this.appConfigService.appConfig$.subscribe((appConfig: IAppConfig) => {
       this.appLanguages = appConfig.APP_LANGUAGES;
       this.appLanguagesMeta = appConfig.APP_LANGUAGES_META;

--- a/src/app/shared/components/template/services/template-translate.service.ts
+++ b/src/app/shared/components/template/services/template-translate.service.ts
@@ -134,7 +134,7 @@ export class TemplateTranslateService extends AsyncServiceBase {
    * NOTE - this method is currently only used by data-items as regular processor translates after parsing
    * into template, where translateRow method can be used
    */
-  translateDataListRows(rows: FlowTypes.Data_listRow[] = []) {
+  public translateDataListRows(rows: FlowTypes.Data_listRow[] = []) {
     if (rows.length === 0) return rows;
     // use first row to identify list of fields for translation
     const [{ _translatedFields }] = rows;

--- a/src/app/shared/components/template/services/template-translate.service.ts
+++ b/src/app/shared/components/template/services/template-translate.service.ts
@@ -128,6 +128,33 @@ export class TemplateTranslateService extends AsyncServiceBase {
   }
 
   /**
+   * Translate all rows from a data_list. Uses `_translatedFields` metadata to determine which columns
+   * require translation, extracted from names with suffix `::eng`
+   *
+   * NOTE - this method is currently only used by data-items as regular processor translates after parsing
+   * into template, where translateRow method can be used
+   */
+  translateDataListRows(rows: FlowTypes.Data_listRow[] = []) {
+    if (rows.length === 0) return rows;
+    // use first row to identify list of fields for translation
+    const [{ _translatedFields }] = rows;
+    if (!_translatedFields) return rows;
+    const translateKeys = Object.keys(_translatedFields);
+    console.log("translate list rows", JSON.parse(JSON.stringify(rows)));
+    // translate rows
+    return rows.map((row) => {
+      for (const key of translateKeys) {
+        const sourceText = row[key];
+        // TODO - confirm whether potential cases that list includes non-text entries
+        if (typeof sourceText === "string" && sourceText in this.translation_strings) {
+          row[key] = this.translation_strings[sourceText];
+        }
+      }
+      return row;
+    });
+  }
+
+  /**
    * As dynamic fields keep reference to initial full expressions that are used as part of evaluation,
    * also replace these references with translated ones
    */

--- a/src/app/shared/services/data/app-data.service.mock.spec.ts
+++ b/src/app/shared/services/data/app-data.service.mock.spec.ts
@@ -18,7 +18,11 @@ export class MockAppDataService implements Partial<AppDataService> {
   public appDataCache: IAppDataCache;
 
   // allow additional specs implementing service to provide their own data if required
-  constructor(mockData: Partial<IAppDataCache> = {}) {
+  constructor(
+    mockData: Partial<IAppDataCache> = {},
+    /** Bypass methods to load translations from http by providing combined language_codes and strings */
+    private translationStrings: { [language_code: string]: { [source_text: string]: string } } = {}
+  ) {
     this.appDataCache = { ...DATA_CACHE_CLEAN, ...mockData };
   }
 
@@ -34,6 +38,7 @@ export class MockAppDataService implements Partial<AppDataService> {
     return this.appDataCache[flow_type]?.[flow_name] as T;
   }
   public async getTranslationStrings(language_code: string) {
-    return {};
+    await _wait(50);
+    return this.translationStrings[language_code];
   }
 }

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -12,6 +12,7 @@ import { ReactiveMemoryAdapter, REACTIVE_SCHEMA_BASE } from "./adapters/reactive
 import { TemplateActionRegistry } from "../../components/template/services/instance/template-action.registry";
 import { DynamicDataActionFactory } from "./actions";
 import { DeploymentService } from "../deployment/deployment.service";
+import type { Observable } from "rxjs/internal/Observable";
 
 @Injectable({ providedIn: "root" })
 /**
@@ -111,8 +112,8 @@ export class DynamicDataService extends AsyncServiceBase {
     queryObj = { ...defaultQueryObj, ...queryObj };
     // use a live query to return all documents in the collection, converting
     // from reactive documents to json data instead
-    let query = this.db.query(collectionName, queryObj);
-    return query;
+    let query = this.db.query<T>(collectionName, queryObj);
+    return query as Observable<T[]>;
   }
 
   /** Take a snapshot of the current state of a table */


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
- Fix issue where data_items loops do not translate text from source data_lists
- Update tests

## Author Notes
The default template parser has various fallback methods that would attempt to translate data_list columns regardless of whether they had been marked for translation or not. This PR does not change default/legacy behaviour, but does add specific method for use within data_items loops that expects any data_list to include `my_column::eng` syntax for any translatable columns in the data_list 

## Review Notes
See video below for [debug_translation_data_items](https://docs.google.com/spreadsheets/d/1Bwh8eb2B43AAlDND4q0b4E-EXgnd6IRjmIFIf1Jbk1c/edit?gid=650194570#gid=650194570) sheet

Have also manually checked `comp_data_items` still behaving as expected, but would also be good to check any deployments where issue first detected.

## Dev Notes
The added tests for the translation system are not comprehensive, more just to test the specific data_list functionality added.

I opted to add an entirely new method to the `templateTranslateService` instead of using existing, as the existing methods are all setup to translate rows after data_list converted to item rows (looking at child row `value` column), instead of the initial list. For the case of data-items loops this is undesirable as it would mean re-translating every generated item row where values are included from the data_list (current behaviour for items loops, although at least these don't reprocess as often as data-items might). 

I found myself tidying up the `hackParseDataList` function a little, as when it was first copy-pasted the data used was a hashmap, and on refactor to use arrays a lot of the names/methods hadn't been updated in a very clear way. I didn't notice any knock-ons from this (but might be good to quickly sense-check)

## Git Issues

Closes #2725

## Screenshots/Videos

[Screenity video - Jan 21, 2025.webm](https://github.com/user-attachments/assets/0fa69329-813a-4cb0-a1be-1f5d403a8f10)
