### PR TITLE
Fix: MX accordion markdown styling

### DIFF
--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -478,20 +478,24 @@ body[data-theme="plh_facilitator_mx"] {
 
       plh-tmpl-text {
         width: 100%;
-        p {
+        .standard {
           color: var(--color-surface-white) !important;
-          font-size: var(--font-size-text-medium) !important;
-          line-height: var(--line-height-text-medium) !important;
-          font-weight: var(--font-weight-standard) !important;
-          margin-top: 8px;
+          p,
+          ul,
+          ol {
+            font-size: var(--font-size-text-medium) !important;
+            line-height: var(--line-height-text-medium) !important;
+            font-weight: var(--font-weight-standard) !important;
+            margin-top: 8px;
+            a {
+              color: var(--color-surface-white-variant) !important;
+              text-decoration: underline !important;
+            }
+          }
           a {
             color: var(--color-surface-white-variant) !important;
             text-decoration: underline !important;
           }
-        }
-        a {
-          color: var(--color-surface-white-variant) !important;
-          text-decoration: underline !important;
         }
       }
     }

--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -690,7 +690,7 @@ body[data-theme="plh_facilitator_mx"] {
       padding: 0;
       border-radius: 12px !important;
       .text {
-        border: 1px solid var(--color-accent-yellow-80);
+        border: 1px solid var(--color-accent-orange-80);
         border-top-left-radius: 12px;
         border-bottom-left-radius: 12px;
 
@@ -716,7 +716,7 @@ body[data-theme="plh_facilitator_mx"] {
         border-top-right-radius: 12px;
         border-bottom-right-radius: 12px;
 
-        background-color: var(--color-accent-yellow-40);
+        background-color: var(--color-accent-orange-40);
         color: var(--color-surface-white);
         font-size: var(--font-size-text-small) !important;
         font-weight: var(--font-weight-bold);
@@ -728,7 +728,7 @@ body[data-theme="plh_facilitator_mx"] {
         max-width: 32px !important;
       }
       &[data-toggled="true"] {
-        background-color: var(--color-accent-yellow-95) !important;
+        background-color: var(--color-accent-orange-95) !important;
       }
     }
     .box-wrapper[data-language-direction~="rtl"] {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

PR branch accidentally builds on the PR branch of #2740, so that PR should be merged first. 

Fixes styling of markdown inside accordion component for `plh_facilitator_mx` theme, in line with #2699.

## Git Issues

Closes #

## Screenshots/Videos

[comp_accordion](https://docs.google.com/spreadsheets/d/1He3nS_qWno-_kJrzizhcUdC1vONKWaluPzC1rr-RfSw/edit?gid=569531329#gid=569531329):

| Before | After |
|---|---|
| <img width="220" alt="Screenshot 2025-01-22 at 11 10 27" src="https://github.com/user-attachments/assets/a2454154-84dd-4976-a381-57ab8515959f" /> | <img width="220" alt="Screenshot 2025-01-22 at 11 10 07" src="https://github.com/user-attachments/assets/83f64074-f89e-457d-a069-d907097df193" /> |

