### PR TITLE
fix: combo-box dropdown variant emits 'changed' as expected

### DIFF
--- a/src/app/shared/components/template/components/base.ts
+++ b/src/app/shared/components/template/components/base.ts
@@ -67,7 +67,7 @@ export class TemplateBaseComponent implements ITemplateRowProps {
    * Update the current value of the row by setting a local variable that matches
    * @ignore
    **/
-  setValue(value: any) {
+  async setValue(value: any) {
     // HACK - provide optimistic update so that data_items interceptor also can access updated row value
     this._row.value = value;
 

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.html
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.html
@@ -17,7 +17,7 @@
     <ion-select
       [class.hasValue]="!!_row.value"
       [placeholder]="displayText() | translate"
-      (ionChange)="setValue($event.detail.value)"
+      (ionChange)="handleDropdownChange($event.detail.value)"
       interface="popover"
       labelPlacement="stacked"
       [disabled]="disabled()"

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -58,15 +58,6 @@ export class TmplComboBoxComponent
     return this.answerText() && !this.prioritisePlaceholder ? this.answerText() : this.placeholder;
   });
 
-  public buttonStyle = computed(() => {
-    return {
-      disabled: this.disabled(),
-      "placeholder-style": (!this._row.value && this.placeholder) || this.prioritisePlaceholder,
-      "with-value": this._row.value,
-      "no-value": !this._row.value,
-    };
-  });
-
   constructor(
     private modalController: ModalController,
     private dataItemsService: DataItemsService
@@ -107,6 +98,11 @@ export class TmplComboBoxComponent
       | "modal"
       | "dropdown";
     this.authorDisabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
+  }
+
+  public handleDropdownChange(value) {
+    this.setValue(value);
+    this.triggerActions("changed");
   }
 
   async openModal() {

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -100,9 +100,9 @@ export class TmplComboBoxComponent
     this.authorDisabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
   }
 
-  public handleDropdownChange(value) {
-    this.setValue(value);
-    this.triggerActions("changed");
+  public async handleDropdownChange(value) {
+    await this.setValue(value);
+    await this.triggerActions("changed");
   }
 
   async openModal() {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow-up to #2733, which I merged too hastily.
- Ensures the dropdown variant of the combo-box component emits "changed" as expected
- Removes some unused code

## Testing

@ChrisMarsh82 could you test that this works with your MX use-case?

@esmeetewinkel could you test the general combo box functionality for all variations included in [comp_combo_box](https://docs.google.com/spreadsheets/d/1uIkaMlDjoDN7uTpHkSeEQ6Yp-4ehX9IrBQMrolpfjQc/edit?gid=569531329#gid=569531329), to ensure I've not missed anything in testing the changes across this PR and #2733)

## Git Issues

Closes #

## Screenshots/Videos

Updated [comp_combo_box](https://docs.google.com/spreadsheets/d/1uIkaMlDjoDN7uTpHkSeEQ6Yp-4ehX9IrBQMrolpfjQc/edit?gid=569531329#gid=569531329):

<img width="280" alt="Screenshot 2025-01-23 at 17 55 28" src="https://github.com/user-attachments/assets/9f44a8cb-8eb1-413d-963d-ae4f59923507" />

