### PR TITLE
fix: button card-portrait styling

### DIFF
--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -51,7 +51,6 @@
     [attr.data-has-children]="_row.rows ? true : null"
     [attr.data-disabled]="params.disabled"
   >
-    {{ _row.rows ? true : false }}
     <img *ngIf="params.image" src="{{ params.image | plhAsset }}" />
     <div *ngIf="_row.value" [class]="'button-text ' + params.textAlign">
       {{ _row.value }}

--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -7,7 +7,7 @@
     (click)="triggerActions('click')"
     [attr.data-param-style]="params.style"
     [attr.data-variant]="params.variant"
-    [attr.data-has-children]="_row.rows ? true : false"
+    [attr.data-has-children]="_row.rows ? true : null"
     [attr.data-language-direction]="templateTranslateService.languageDirection()"
     [attr.data-icon-align]="params.iconAlign"
   >
@@ -48,9 +48,10 @@
     class="button-container"
     (click)="handleClick()"
     [attr.data-variant]="params.variant"
-    [attr.data-has-children]="_row.rows ? true : false"
+    [attr.data-has-children]="_row.rows ? true : null"
     [attr.data-disabled]="params.disabled"
   >
+    {{ _row.rows ? true : false }}
     <img *ngIf="params.image" src="{{ params.image | plhAsset }}" />
     <div *ngIf="_row.value" [class]="'button-text ' + params.textAlign">
       {{ _row.value }}


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue for MX and KW themes where the `button` with `card-portrait` variant would incorrectly apply styling as if child rows were present (regression from #2675)

## Git Issues

Closes #

## Screenshots/Videos

| Before | After |
|---|---|
| <img width="240" alt="Screenshot 2025-01-24 at 18 16 48" src="https://github.com/user-attachments/assets/d6eee192-c2fa-4907-9588-a48b178d1fce" /> | <img width="240" alt="Screenshot 2025-01-24 at 18 36 36" src="https://github.com/user-attachments/assets/83b8b812-e720-49a5-bfc2-08e478d91512" /> |


