### PR TITLE
feat: MX theme button variant 'faq'

### DIFF
--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -289,6 +289,35 @@ body[data-theme="plh_facilitator_mx"] {
         }
       }
     }
+
+    ion-button[data-variant~="faq"] {
+      --border-radius: 0px var(--ion-border-radius-small) var(--ion-border-radius-small) 0px;
+      --background: white;
+      --background-activated: var(--ion-color-gray-light);
+      --padding-top: var(--tiny-padding);
+      --padding-bottom: var(--tiny-padding);
+      color: var(--color-surface-black);
+      min-height: var(--buttons-tall-height);
+
+      border: 1px solid var(--ion-color-gray-light);
+      border-radius: 0px !important;
+      border-start-end-radius: var(--ion-border-radius-small) !important;
+      border-end-end-radius: var(--ion-border-radius-small) !important;
+      border-inline-start: 4px solid var(--ion-color-primary);
+
+      &:hover {
+        --background: var(--ion-color-gray-light);
+      }
+      .text.left.null {
+        text-align: start !important;
+        p {
+          margin-inline-end: auto;
+          text-align: start !important;
+          width: auto !important;
+        }
+      }
+    }
+
     ion-button[data-language-direction~="rtl"] .children {
       position: unset !important;
       align-self: unset !important;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new variant for the button component, only for the `plh_facilitator_mx` theme: `faq`

## Notes

Originally I had thought it might make sense to make this a generally available variant of the button. However, due to the way that the `plh_facilitator_mx` theme level overrides are applied, it is difficult to add new styling from the component level that overrides them.

## Git Issues

Closes https://github.com/ParentingForLifelongHealth/plh-facilitator-app-mx-content/issues/141

## Screenshots/Videos

[comp_button](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit?gid=569531329#gid=569531329)

<img width="680" alt="Screenshot 2025-01-27 at 17 56 22" src="https://github.com/user-attachments/assets/df5ca6b6-2b30-432d-8128-07ee253835fc" />

<img width="260" alt="Screenshot 2025-01-27 at 17 56 38" src="https://github.com/user-attachments/assets/315e5c5a-74af-4a69-a695-960798eedc13" />
