### PR TITLE
spike(action_lists)!: evaluation standalone

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -338,7 +338,7 @@ export namespace FlowTypes {
 
   const DYNAMIC_PREFIXES_COMPILER = ["gen", "row", "default"] as const;
 
-  const DYNAMIC_PREFIXES_RUNTIME = [
+  export const DYNAMIC_PREFIXES_RUNTIME = [
     "local",
     "field",
     "fields",
@@ -354,6 +354,8 @@ export namespace FlowTypes {
     ...DYNAMIC_PREFIXES_COMPILER,
     ...DYNAMIC_PREFIXES_RUNTIME,
   ] as const;
+
+  export type IDynamicPrefixRuntime = (typeof DYNAMIC_PREFIXES_RUNTIME)[number];
 
   export type IDynamicPrefix = (typeof DYNAMIC_PREFIXES)[number];
 
@@ -453,6 +455,8 @@ export namespace FlowTypes {
     params?: ParamsType; // additional params also used by args (does not require position argument)
     // TODO - CC 2022-04-29 - ideally args should be included as part of params
     _triggeredBy?: TemplateRow; // tracking the component that triggered the action for logging;
+    /** mapping of dynamic variables referenced in action with current value*/
+    _evalContext?: { [prefix in IDynamicPrefix]?: { [name: string]: any } };
     /**
      * most actions are specified from a parent template (begin_template statement) and are executed
      * within parent context. However actions specified by own update_action_list statement require self handling

--- a/src/app/shared/components/template/components/data-items/data-items.component.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.ts
@@ -70,10 +70,13 @@ export class TmplDataItemsComponent extends TemplateBaseComponent {
    * the author to explicitly use a set_item action. This applies to any component that internally calls `setValue`
    */
   private hackInterceptComponentActions(_nested_name: string) {
-    this.parent.templateActionService.registerActionsInterceptor(_nested_name, (action) => {
-      if (action.action_id === "set_self" && action._triggeredBy._evalContext?.itemContext) {
+    this.parent.templateActionService.registerActionsInterceptor(_nested_name, async (action) => {
+      const itemContext = action._triggeredBy?._evalContext?.itemContext;
+      if (action.action_id === "set_self" && itemContext) {
         return undefined;
       }
+      // Ensure actions also have access to item context for evaluation
+      action._evalContext = { ...action._evalContext, item: itemContext };
       return this.dataItemsService.evaluateComponentAction(action);
     });
   }

--- a/src/app/shared/components/template/components/layout/layout.ts
+++ b/src/app/shared/components/template/components/layout/layout.ts
@@ -22,7 +22,7 @@ import { TemplateContainerComponent } from "../../template-container.component";
  *  <plh-template-component *ngFor="let childRow of _row.rows; trackBy: trackByRow" [row]="childRow" [parent]="parent"></plh-template-component>
  * ```
  */
-export class TemplateLayoutComponent implements ITemplateRowProps, OnInit {
+export class TemplateLayoutComponent implements ITemplateRowProps {
   _row: FlowTypes.TemplateRow;
   /** specific data used in component rendering */
   @Input() set row(row: FlowTypes.TemplateRow) {
@@ -36,10 +36,6 @@ export class TemplateLayoutComponent implements ITemplateRowProps, OnInit {
   /** reference to parent template container - does not have setter as should remain static */
   @Input() parent: TemplateContainerComponent;
   constructor() {}
-
-  ngOnInit() {
-    this.addParentActionsFilter();
-  }
 
   /**
    * As content can be nested within containers or pages, a general
@@ -67,26 +63,6 @@ export class TemplateLayoutComponent implements ITemplateRowProps, OnInit {
     return row;
   }
 
-  /**
-   * Add any additional methods or function calls to actions that would otherwise be handled by
-   * the template container.
-   * @returns `true` or `false` to specify if the action should continue to also
-   * be processed by the template container parent (as it is used as a filter)
-   */
-  public interceptTemplateContainerAction(action: FlowTypes.TemplateRowAction) {
-    return true;
-  }
-
   public trackByRow = (index: number, row: FlowTypes.TemplateRow) =>
     this.parent.trackByRow(index, row);
-
-  private addParentActionsFilter() {
-    this.parent.templateActionService.handleActionsInterceptor = async (actions) => {
-      return actions.filter((action) => {
-        const shouldHandleByParent = this.interceptTemplateContainerAction(action);
-        // continue to process on parent unless specific return says not to
-        return shouldHandleByParent !== false;
-      });
-    };
-  }
 }

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -129,6 +129,7 @@ export class NavGroupComponent extends TemplateLayoutComponent {
     }
   }
 
+  // TODO - register as interceptor
   interceptTemplateContainerAction(action: FlowTypes.TemplateRowAction) {
     const { action_id, args } = action;
     // only allow actions to be processed by parent if last section
@@ -206,13 +207,11 @@ export class NavGroupComponent extends TemplateLayoutComponent {
             action_id: "set_field",
             args: [progressField, "" + currentPercentDone],
             trigger: "completed",
-            _triggeredBy: this._row,
           },
           {
             action_id: "set_field",
             args: [progressFieldMaximum, "" + maximumPercentDone],
             trigger: "completed",
-            _triggeredBy: this._row,
           },
         ],
         this._row

--- a/src/app/shared/components/template/services/instance/template-row.service.ts
+++ b/src/app/shared/components/template/services/instance/template-row.service.ts
@@ -269,7 +269,9 @@ export class TemplateRowService extends SyncServiceBase {
     // Continue processing full row
     const parsedRow: FlowTypes.TemplateRow = await this.templateVariablesService.evaluatePLHData(
       { ...translatedRow },
-      evalContext
+      evalContext,
+      // do not evaluate action_list as this will be evaluated at time of triggering
+      ["action_list"]
     );
 
     const row = parsedRow;

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -85,7 +85,7 @@ export class TemplateNavService extends SyncServiceBase {
     // TODO: Find more elegant way to get current root level template name
     const parentName = location.pathname.replace("/template/", "");
     const [templatename, key, value] = action.args;
-    const nav_parent_triggered_by = action._triggeredBy?.name;
+    const nav_parent_triggered_by = action._triggeredBy._nested_name;
     const queryParams: INavQueryParams = { nav_parent: parentName, nav_parent_triggered_by };
     // handle direct page or template navigation
     const navTarget = templatename.startsWith("/") ? [templatename] : ["template", templatename];
@@ -149,7 +149,7 @@ export class TemplateNavService extends SyncServiceBase {
       if (triggerRow) {
         log("trigger row", triggerRow);
         const triggeredActions = triggerRow.action_list.filter((a) => a.trigger === nav_child_emit);
-        await container.templateActionService.handleActions(triggeredActions, triggerRow);
+        await container.handleActions(triggeredActions, triggerRow);
         // back history will have changed (2 duplicate pages), so nav back to restore correct back button
         history.back();
       } else {
@@ -226,7 +226,7 @@ export class TemplateNavService extends SyncServiceBase {
     const queryParams: INavQueryParams = {
       popup_child: templatename,
       popup_parent: name,
-      popup_parent_triggered_by: action._triggeredBy?.name || null,
+      popup_parent_triggered_by: action._triggeredBy._nested_name || null,
       popup_variant: variant,
     };
     this.router.navigate([], { queryParams, replaceUrl: true, queryParamsHandling: "merge" });
@@ -251,7 +251,7 @@ export class TemplateNavService extends SyncServiceBase {
         // process any completed/uncompleted actions as specified
         const emittedActions = actionsByTrigger[nav_child_emit];
         if (emittedActions) {
-          await container.templateActionService.handleActions(emittedActions, triggerRow);
+          await container.handleActions(emittedActions, triggerRow);
           await this.dismissPopup(popup_child, nav_child_emit);
         }
         // if the popup does not have any actions triggered by the nav_emit, leave open if there

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -9,6 +9,7 @@ import { extractDynamicEvaluators } from "data-models";
 import { TemplateFieldService } from "./template-field.service";
 import { AppDataService } from "src/app/shared/services/data/app-data.service";
 import { AsyncServiceBase } from "src/app/shared/services/asyncService.base";
+import type { ITemplatedDataContextList } from "packages/shared/src/models/templatedData/templatedData";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 const SHOW_DEBUG_LOGS = false;
@@ -85,7 +86,7 @@ export class TemplateVariablesService extends AsyncServiceBase {
       // process arrays as json objects and return
       if (Array.isArray(data)) {
         const objData = _arrayToObject(data);
-        const evaluatedObjData = await this.evaluatePLHData(objData, context);
+        const evaluatedObjData = await this.evaluatePLHData(objData, context, omitFields);
         value = Object.values(evaluatedObjData);
       }
 
@@ -108,7 +109,7 @@ export class TemplateVariablesService extends AsyncServiceBase {
               // evalute each object element with reference to any dynamic specified for it's index (instead of fieldname)
               const nestedContext = { ...context };
               nestedContext.field = nestedContext.field ? `${nestedContext.field}.${k}` : k;
-              const evaluated = await this.evaluatePLHData(data[k], nestedContext);
+              const evaluated = await this.evaluatePLHData(data[k], nestedContext, omitFields);
               value[k] = evaluated;
             }
           }
@@ -362,6 +363,95 @@ export class TemplateVariablesService extends AsyncServiceBase {
   }
 
   /**
+   *
+   *
+   */
+  public async evaluateContextVariables(contextVariables: ITemplatedDataContextList) {
+    const evaluatedVariables: {
+      [prefix in FlowTypes.IDynamicPrefixRuntime]?: { [expression: string]: any };
+    } = {};
+    for (const [context, expressions] of Object.entries(contextVariables)) {
+      evaluatedVariables[context] = {};
+      for (const expression of Object.keys(expressions)) {
+        const evaluator = this.evaluators[context];
+        if (evaluator) {
+          evaluatedVariables[context][expression] = await evaluator(expression);
+        } else {
+          console.warn(`No evaluator exists for context:`, context);
+          // TODO - better to return empty string, expression or undefined?
+          evaluatedVariables[context][expression] = undefined;
+          // context[variable] = `@${context}["${variable}"]`;
+        }
+      }
+    }
+    return evaluatedVariables;
+  }
+
+  /**
+   *
+   * TODO - add method to register handlers
+   */
+  private evaluators: Record<
+    FlowTypes.IDynamicPrefixRuntime,
+    (expression: string, context: any) => Promise<any>
+  > = {
+    calc: async () => {},
+    campaign: async (fieldName) => {
+      // TODO - ideally campaign lookup should be merged into data list lookup with additional query/params
+      // e.g. evaluate conditions, take first etc.
+      await this.campaignService.ready();
+      const rows = await this.campaignService.getNextCampaignRows(fieldName);
+      return rows?.[0];
+    },
+    data: async (fieldName) => {
+      let parsedValue = {};
+      const [flow_name, nested_path] = fieldName.split(".");
+      const sheet = await this.appDataService.getSheet("data_list", flow_name);
+      if (sheet) {
+        parsedValue = sheet.rowsHashmap;
+        if (nested_path) {
+          parsedValue = getNestedProperty(sheet.rowsHashmap, nested_path);
+        }
+      }
+      return parsedValue;
+    },
+    field: async (fieldName) => this.templateFieldService.getField(fieldName),
+    fields: async (fieldName) => this.templateFieldService.getField(fieldName),
+    global: async (fieldName) => this.templateFieldService.getGlobal(fieldName),
+    item: async (v) => v,
+    // Local expressions should be evaluated from within local container context instead of service
+    local: async (v) => v,
+    // Raw expressions
+    raw: async (v) => v,
+  };
+
+  // TODO -
+  public evaluateLocal(fieldName: string, templateRowMap: ITemplateRowMap) {
+    // TODO - assumed 'value' field will be returned but this could be provided instead as an arg
+    const returnField: keyof FlowTypes.TemplateRow = "value";
+
+    // find any rows where nested path corresponds to match path
+    let matchedRows: { row: FlowTypes.TemplateRow; nestedName: string }[] = [];
+    Object.entries(templateRowMap).forEach(([nestedName, row]) => {
+      if (nestedName === fieldName || nestedName.endsWith(`.${fieldName}`)) {
+        matchedRows.push({ row, nestedName });
+      }
+    });
+
+    // match found - return least nested (in case of duplicates)
+    if (matchedRows.length > 0) {
+      matchedRows = matchedRows.sort(
+        (a, b) => a.nestedName.split(".").length - b.nestedName.split(".").length
+      );
+      if (matchedRows.length > 1) {
+        console.warn(`@local.${fieldName} found multiple`, { matchedRows });
+      }
+      return { value: matchedRows[0].row[returnField] };
+    }
+    return { missing: true, value: "" };
+  }
+
+  /**
    * Lookup evaluators from statements such as @local.someVar or @data.anotherVar and return the
    * value depending on the required method
    */
@@ -375,18 +465,10 @@ export class TemplateVariablesService extends AsyncServiceBase {
     const { templateRowMap, field } = context;
     switch (type) {
       case "local":
-        // TODO - assumed 'value' field will be returned but this could be provided instead as an arg
-        const returnField: keyof FlowTypes.TemplateRow = "value";
-
-        // find any rows where nested path corresponds to match path
-        let matchedRows: { row: FlowTypes.TemplateRow; nestedName: string }[] = [];
-        Object.entries(templateRowMap).forEach(([nestedName, row]) => {
-          if (nestedName === fieldName || nestedName.endsWith(`.${fieldName}`)) {
-            matchedRows.push({ row, nestedName });
-          }
-        });
+        const { missing, value } = this.evaluateLocal(fieldName, templateRowMap);
+        parsedValue = value;
         // no match found. If condition assume this is fine, otherwise authoring error
-        if (matchedRows.length === 0) {
+        if (missing) {
           if (field === "condition") {
             parsedValue = false;
           } else {
@@ -397,47 +479,8 @@ export class TemplateVariablesService extends AsyncServiceBase {
             });
           }
         }
-        // match found - return least nested (in case of duplicates)
-        else {
-          matchedRows = matchedRows.sort(
-            (a, b) => a.nestedName.split(".").length - b.nestedName.split(".").length
-          );
-          if (matchedRows.length > 1) {
-            console.warn(`@local.${fieldName} found multiple`, { matchedRows });
-          }
-          parsedValue = matchedRows[0].row[returnField];
-        }
+        break;
 
-        break;
-      case "field":
-        // console.warn("To keep consistency with rapidpro, @fields should be used instead of @field");
-        parsedValue = this.templateFieldService.getField(fieldName);
-        break;
-      case "fields":
-        parsedValue = this.templateFieldService.getField(fieldName);
-        break;
-      case "global":
-        parsedValue = this.templateFieldService.getGlobal(fieldName);
-        break;
-      case "data":
-        const [flow_name, nested_path] = fieldName.split(".");
-        const sheet = await this.appDataService.getSheet("data_list", flow_name);
-        if (sheet) {
-          parsedValue = sheet.rowsHashmap;
-          if (nested_path) {
-            parsedValue = getNestedProperty(sheet.rowsHashmap, nested_path);
-          }
-        } else {
-          // if sheet not found return as empty object
-          parsedValue = {};
-        }
-        break;
-      // TODO - ideally campaign lookup should be merged into data list lookup with additional query/params
-      // e.g. evaluate conditions, take first etc.
-      case "campaign":
-        await this.campaignService.ready();
-        parsedValue = (await this.campaignService.getNextCampaignRows(fieldName))?.[0];
-        break;
       case "calc":
         const expression = fieldName.replace(/@/gi, "this.");
         const { thisCtxt, globalFunctions, globalConstants } = context.calcContext;
@@ -445,6 +488,7 @@ export class TemplateVariablesService extends AsyncServiceBase {
         // TODO - merge string replacements with above methods
         parsedValue = evaluateJSExpression(expression, thisCtxt, globalFunctions, globalConstants);
         break;
+      // TODO - all item evaluators should be intercepted by data-items/item components instead of here
       case "item":
         // only attempt to evaluate items if context passed, otherwise leave as original unparsed string
         if (context?.itemContext) {
@@ -454,12 +498,18 @@ export class TemplateVariablesService extends AsyncServiceBase {
         }
         break;
       default:
-        parseSuccess = false;
-        console.error("No evaluator for dynamic field:", evaluator.matchedExpression);
-        // By default return an empty string if could not be evaluated successfully
-        // NOTE - any value is fine to return EXCEPT a dynamic expression (e.g. same @local.some_var)
-        // This will be checked a second time and could cause an infinite loop
-        parsedValue = "";
+        // HACK - Only some evaluators have been migrated to new format
+        // TODO - migrate all global evaluators and provide alternate handling for specific
+        if (this.evaluators[type]) {
+          parsedValue = await this.evaluators[type](fieldName);
+        } else {
+          parseSuccess = false;
+          console.error("No evaluator for dynamic field:", evaluator.matchedExpression);
+          // By default return an empty string if could not be evaluated successfully
+          // NOTE - any value is fine to return EXCEPT a dynamic expression (e.g. same @local.some_var)
+          // This will be checked a second time and could cause an infinite loop
+          parsedValue = "";
+        }
     }
     parsedValue = this.ensureValueTranslated(parsedValue);
     return { parsedValue, parseSuccess };
@@ -491,10 +541,4 @@ function _arrayToObject(arr: any[]) {
   const obj = {};
   arr.forEach((el, i) => (obj[i] = el));
   return obj;
-}
-
-function mapToJson(map: Map<string, any>) {
-  const json = {};
-  map.forEach((value, key) => (json[key] = value));
-  return json;
 }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Breaking Changes
 **action_list evaluates using newer templated data system** 
This may lead to some unexpected behaviour if any action_lists include complex statements that mix variable references, e.g. `click | set_field : some_field : hello this.value`. I think these types of patterns had always been discouraged/not worked anyways (with preference of setting intermediate local variables instead), but just to be aware of some small potential for knock-on. Unfortunately we don't have many tests for action_list edge cases so might be good to check against existing debug sheets. 

**action_list values references now auto-update**
Previous workaround to specify `this.value` in action_lists to handle receiving updated value for triggered actions are no longer required. The syntax is still supported and not marked as deprecated (no plans to remove), but any documentation that refers to this could likely be updated.

## Description
Action lists are currently evaluated as part of main template container processing, meaning that all row action params and args are evaluated prior to the row that triggers them from rendering. There are 2 main drawbacks to this:

1) Actions need to be parsed even if they are never actually triggered. This isn't too expensive an operation, just lacking a bit in optimisation.

2) Actions can become stale if data changes between render and trigger. This typically happens if an is triggered by a component change (parsed action will have value before change), or if multiple actions are triggered in series where the first action manipulates data required for the second action.

This PR aims to detach action_list processing from the main templating system and instead only evaluate at the time of being triggered. This should address both issues 

Additionally it evaluates actions using the new app data templating system, which has better support for 




**TODO**
- [ ] Tests (requires previous pr)
- [ ] Resolve potential conflicts with outstanding PR

**Follow-up**
- [ ] Consider refactoring all dynamic evaluation to similar format and remove from runtime
- [ ] Dynamic evaluator registry
- [ ] Handle `this.` workarounds

## Dev Notes
parser vs runtime

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
