### PR TITLE
feat: make 'disabled' parameter of button component dynamic

### DIFF
--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -3,7 +3,7 @@
   <ion-button
     *ngSwitchDefault
     [class]="'full standard medium' + ' ' + params.style + ' ' + params.buttonAlign"
-    [disabled]="params.disabled"
+    [disabled]="disabled()"
     (click)="triggerActions('click')"
     [attr.data-param-style]="params.style"
     [attr.data-variant]="params.variant"
@@ -49,7 +49,7 @@
     (click)="handleClick()"
     [attr.data-variant]="params.variant"
     [attr.data-has-children]="_row.rows ? true : null"
-    [attr.data-disabled]="params.disabled"
+    [attr.data-disabled]="disabled()"
   >
     <img *ngIf="params.image" src="{{ params.image | plhAsset }}" />
     <div *ngIf="_row.value" [class]="'button-text ' + params.textAlign">

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -51,11 +51,13 @@ interface IButtonParams {
 })
 export class TmplButtonComponent extends TemplateBaseComponent implements OnInit {
   params: Partial<IButtonParams> = {};
-  disabled = computed(
-    () =>
-      getBooleanParamFromTemplateRow(this.rowSignal(), "disabled", false) ||
-      this.rowSignal().disabled
-  );
+  disabled = computed(() => {
+    // TODO: is disabling by row still supported generally?
+    const disabledByRow = this.rowSignal().disabled;
+    if (disabledByRow) return true;
+    const disabledByParam = getBooleanParamFromTemplateRow(this.rowSignal(), "disabled", false);
+    return disabledByParam;
+  });
   /** @ignore */
   variantMap: { cardPortrait: boolean };
 

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit } from "@angular/core";
+import { Component, computed, ElementRef, OnInit } from "@angular/core";
 import {
   getStringParamFromTemplateRow,
   getBooleanParamFromTemplateRow,
@@ -51,6 +51,11 @@ interface IButtonParams {
 })
 export class TmplButtonComponent extends TemplateBaseComponent implements OnInit {
   params: Partial<IButtonParams> = {};
+  disabled = computed(
+    () =>
+      getBooleanParamFromTemplateRow(this.rowSignal(), "disabled", false) ||
+      this.rowSignal().disabled
+  );
   /** @ignore */
   variantMap: { cardPortrait: boolean };
 
@@ -79,11 +84,7 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
       .split(",")
       .join(" ") as IButtonParams["variant"];
     this.populateVariantMap();
-    this.params.disabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
     this.params.image = getStringParamFromTemplateRow(this._row, "image_asset", null);
-    if (this._row.disabled) {
-      this.params.disabled = true;
-    }
     this.params.textAlign = getStringParamFromTemplateRow(this._row, "text_align", null) as any;
     this.params.buttonAlign = getStringParamFromTemplateRow(
       this._row,

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -51,13 +51,7 @@ interface IButtonParams {
 })
 export class TmplButtonComponent extends TemplateBaseComponent implements OnInit {
   params: Partial<IButtonParams> = {};
-  disabled = computed(() => {
-    // TODO: is disabling by row still supported generally?
-    const disabledByRow = this.rowSignal().disabled;
-    if (disabledByRow) return true;
-    const disabledByParam = getBooleanParamFromTemplateRow(this.rowSignal(), "disabled", false);
-    return disabledByParam;
-  });
+  disabled = computed(() => getBooleanParamFromTemplateRow(this.rowSignal(), "disabled", false));
   /** @ignore */
   variantMap: { cardPortrait: boolean };
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Enables the button component’s disabled/enabled state to dynamically reflect updates to the `disabled` parameter.

Additionally, this PR removes support within the button component for the row-level `disabled` property, which is considered deprecated. See follow-up #2761 to roll out this change to other components.

## Dev notes

As we've discussed previously (for example, [this comment thread](https://github.com/IDEMSInternational/open-app-builder/pull/2493#issuecomment-2446930347) on #2493), it would make sense to embrace angular signals more fundamentally in how we handle component parameters. This PR doesn't make any progress towards achieving this more generally, but ultimately it would likely make sense for all our authorable parameters to be parsed to computed/signal values that react to updates.

## Git Issues

Closes #

## Screenshots/Videos

Updated [comp_button](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit?gid=569531329#gid=569531329):

<img width="600" alt="Screenshot 2025-01-28 at 12 37 24" src="https://github.com/user-attachments/assets/2fb75733-5865-4dec-ada3-18b33ad254cb" />


https://github.com/user-attachments/assets/b2a7f582-85c1-4827-b7ae-e74a4700bfcb


