### PR TITLE
fix: text box value bug

### DIFF
--- a/src/app/shared/components/template/components/base.ts
+++ b/src/app/shared/components/template/components/base.ts
@@ -36,7 +36,7 @@ export class TemplateBaseComponent implements ITemplateRowProps {
    **/
   @Input() set row(row: FlowTypes.TemplateRow) {
     this._row = row;
-    this.rowSignal.set(row);
+    this.rowSignal.set({ ...row });
   }
 
   /**

--- a/src/app/shared/components/template/components/base.ts
+++ b/src/app/shared/components/template/components/base.ts
@@ -36,6 +36,7 @@ export class TemplateBaseComponent implements ITemplateRowProps {
    **/
   @Input() set row(row: FlowTypes.TemplateRow) {
     this._row = row;
+    // take shallow clone to still be able to detect changes if this._row directly modified
     this.rowSignal.set({ ...row });
   }
 
@@ -70,6 +71,7 @@ export class TemplateBaseComponent implements ITemplateRowProps {
   async setValue(value: any) {
     // HACK - provide optimistic update so that data_items interceptor also can access updated row value
     this._row.value = value;
+    this.rowSignal.update((v) => ({ ...v, value }));
 
     const action: FlowTypes.TemplateRowAction = {
       action_id: "set_self",


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes a bug where the value of the text-box would sometimes not update as expected.

## Testing

This is quite a difficult issue to create a debug template for, since really we want direct access to the component's `value()` signal to check that it updates correctly, which is how I was debugging as a dev. I think it should suffice to confirm that the issue as observed is now resolved.

## Dev notes

Technically, this PR resolves a general issue with components' `value()` computed property not always being updated as expected via the `setValue()` component method (#2706 is relevant).

In debugging the issue, I observed that the component's `value()` computed property would not update as expected, even though `rowSignal().value`, on which it depends, was updating as expected. I observed that removing the `{ equal: isEqual }` option from the definition of the `rowSignal()` signal appeared to resolve the issue. I believe the issue to be as follows:

- When we update the value in `setValue()` via `this._row.value = value;`, we're mutating the `_row` object directly, but since rowSignal is using `isEqual` for comparison, it ends up comparing the same object reference with itself, returning a false positive, and preventing the changes from propagating.

At first I thought it would make sense to update the `isEqual()` function to handle such cases of self reference, but this proved difficult. I tried updating the first check to be `if (a === b && typeof a !== "object") return true;`, as well as updating the checks on object literals. I couldn't get these to work.

However, after some consideration I think that the change in the current PR are preferable: essentially creating a new object reference when updating the value of `rowSignal()`.

## Git Issues

Closes #2759 

## Screenshots/Videos

`plh_facilitator_mx` [add_parent](https://docs.google.com/spreadsheets/d/14iUeYWUHIly3tyz61Wgz_tlPUVAqkI8aXFnlsrUA1ZY/edit?gid=293189857#gid=293189857) template:

https://github.com/user-attachments/assets/f3da9b3d-d445-47cd-8c7e-a03725dc6b19

