### PR TITLE
Refactor: button disabled dynamic

### DIFF
--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -1,33 +1,33 @@
-<ng-container [ngSwitch]="variantMap.cardPortrait">
+<ng-container [ngSwitch]="variantMap().cardPortrait">
   <!-- Default variant -->
   <ion-button
     *ngSwitchDefault
-    [class]="'full standard medium' + ' ' + params.style + ' ' + params.buttonAlign"
-    [disabled]="disabled()"
+    [class]="'full standard medium' + ' ' + params().style + ' ' + params().buttonAlign"
+    [disabled]="params().disabled"
     (click)="triggerActions('click')"
-    [attr.data-param-style]="params.style"
-    [attr.data-variant]="params.variant"
+    [attr.data-param-style]="params().style"
+    [attr.data-variant]="params().variant"
     [attr.data-has-children]="_row.rows ? true : null"
     [attr.data-language-direction]="templateTranslateService.languageDirection()"
-    [attr.data-icon-align]="params.iconAlign"
+    [attr.data-icon-align]="params().iconAlign"
   >
-    @if (params.icon && params.iconAlign === "left") {
-      <ion-icon slot="start" [src]="params.icon | plhAsset"></ion-icon>
+    @if (params().icon && params().iconAlign === "left") {
+      <ion-icon slot="start" [src]="params().icon | plhAsset"></ion-icon>
     }
-    @if (params.icon && params.iconAlign === "right") {
-      <ion-icon slot="end" [src]="params.icon | plhAsset"></ion-icon>
+    @if (params().icon && params().iconAlign === "right") {
+      <ion-icon slot="end" [src]="params().icon | plhAsset"></ion-icon>
     }
-    @if (params.iconSecondary) {
+    @if (params().iconSecondary) {
       <!-- HACK: support icon being a path to an asset or assume it is the name of an ion-icon (e.g. chevron-forward) -->
-      @if (params.iconSecondary.includes(".")) {
-        <ion-icon slot="end" [src]="params.iconSecondary | plhAsset"></ion-icon>
+      @if (params().iconSecondary.includes(".")) {
+        <ion-icon slot="end" [src]="params().iconSecondary | plhAsset"></ion-icon>
       } @else {
-        <ion-icon slot="end" [name]="params.iconSecondary"></ion-icon>
+        <ion-icon slot="end" [name]="params().iconSecondary"></ion-icon>
       }
     }
     <span
       *ngIf="_row.value"
-      [class]="'left text ' + params.textAlign"
+      [class]="'left text ' + params().textAlign"
       [innerHTML]="_row.value | markdown"
     >
     </span>
@@ -47,12 +47,12 @@
     *ngSwitchCase="true"
     class="button-container"
     (click)="handleClick()"
-    [attr.data-variant]="params.variant"
+    [attr.data-variant]="params().variant"
     [attr.data-has-children]="_row.rows ? true : null"
-    [attr.data-disabled]="disabled()"
+    [attr.data-disabled]="params().disabled"
   >
-    <img *ngIf="params.image" src="{{ params.image | plhAsset }}" />
-    <div *ngIf="_row.value" [class]="'button-text ' + params.textAlign">
+    <img *ngIf="params().image" src="{{ params().image | plhAsset }}" />
+    <div *ngIf="_row.value" [class]="'button-text ' + params().textAlign">
       {{ _row.value }}
     </div>
     <span *ngIf="_row.rows" class="children">

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -70,8 +70,8 @@ export class TmplButtonComponent extends TemplateBaseComponent {
     this.triggerActions("click");
   }
 
-  private getParams(authorParams: FlowTypes.TemplateRow["parameter_list"]) {
-    const buttonParams: IButtonParams = {
+  private getParams(authorParams: FlowTypes.TemplateRow["parameter_list"]): IButtonParams {
+    return {
       disabled: parseBoolean(this.parameterList().disabled),
       style: `${getStringParamFromTemplateRow(this._row, "style", "information")} ${
         this.isTwoColumns() ? "two_columns" : ""
@@ -86,7 +86,6 @@ export class TmplButtonComponent extends TemplateBaseComponent {
       iconSecondary: getStringParamFromTemplateRow(this._row, "icon_secondary_asset", null),
       iconAlign: getStringParamFromTemplateRow(this._row, "icon_align", "left") as any,
     };
-    return buttonParams;
   }
 
   /** Determine if the button is inside a display group with the style "two_columns" */

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -1,14 +1,13 @@
-import { Component, computed, ElementRef, OnInit } from "@angular/core";
-import {
-  getStringParamFromTemplateRow,
-  getBooleanParamFromTemplateRow,
-} from "src/app/shared/utils";
+import { Component, computed, effect, ElementRef } from "@angular/core";
+import { getStringParamFromTemplateRow, parseBoolean } from "src/app/shared/utils";
 import { TemplateBaseComponent } from "../base";
 import { TemplateTranslateService } from "../../services/template-translate.service";
+import { FlowTypes } from "packages/data-models";
 
 interface IButtonParams {
   /** TEMPLATE PARAMETER: "variant" */
   variant:
+    | ""
     | "alternative"
     | "card"
     | "card-portrait"
@@ -41,6 +40,10 @@ interface IButtonParams {
   iconAlign: "left" | "right";
 }
 
+interface IVariantMap {
+  cardPortrait?: boolean;
+}
+
 /**
  * A general-purpose button component
  */
@@ -49,17 +52,10 @@ interface IButtonParams {
   templateUrl: "./button.component.html",
   styleUrls: ["./button.component.scss"],
 })
-export class TmplButtonComponent extends TemplateBaseComponent implements OnInit {
-  params: Partial<IButtonParams> = {};
-  disabled = computed(() => {
-    // TODO: is disabling by row still supported generally?
-    const disabledByRow = this.rowSignal().disabled;
-    if (disabledByRow) return true;
-    const disabledByParam = getBooleanParamFromTemplateRow(this.rowSignal(), "disabled", false);
-    return disabledByParam;
-  });
+export class TmplButtonComponent extends TemplateBaseComponent {
+  params = computed(() => this.getParams(this.parameterList()));
   /** @ignore */
-  variantMap: { cardPortrait: boolean };
+  variantMap = computed(() => this.populateVariantMap(this.params().variant));
 
   /** @ignore */
   constructor(
@@ -69,37 +65,28 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
     super();
   }
 
-  ngOnInit() {
-    this.getParams();
-  }
-
   public handleClick() {
-    if (this.params.disabled) return;
+    if (this.params().disabled) return;
     this.triggerActions("click");
   }
 
-  private getParams() {
-    this.params.style = `${getStringParamFromTemplateRow(this._row, "style", "information")} ${
-      this.isTwoColumns() ? "two_columns" : ""
-    }` as any;
-    this.params.variant = getStringParamFromTemplateRow(this._row, "variant", "")
-      .split(",")
-      .join(" ") as IButtonParams["variant"];
-    this.populateVariantMap();
-    this.params.image = getStringParamFromTemplateRow(this._row, "image_asset", null);
-    this.params.textAlign = getStringParamFromTemplateRow(this._row, "text_align", null) as any;
-    this.params.buttonAlign = getStringParamFromTemplateRow(
-      this._row,
-      "button_align",
-      "center"
-    ) as any;
-    this.params.icon = getStringParamFromTemplateRow(this._row, "icon", null);
-    this.params.iconSecondary = getStringParamFromTemplateRow(
-      this._row,
-      "icon_secondary_asset",
-      null
-    );
-    this.params.iconAlign = getStringParamFromTemplateRow(this._row, "icon_align", "left") as any;
+  private getParams(authorParams: FlowTypes.TemplateRow["parameter_list"]) {
+    const buttonParams: IButtonParams = {
+      disabled: parseBoolean(this.parameterList().disabled),
+      style: `${getStringParamFromTemplateRow(this._row, "style", "information")} ${
+        this.isTwoColumns() ? "two_columns" : ""
+      }` as any,
+      variant: getStringParamFromTemplateRow(this._row, "variant", "")
+        .split(",")
+        .join(" ") as IButtonParams["variant"],
+      image: getStringParamFromTemplateRow(this._row, "image_asset", null),
+      textAlign: getStringParamFromTemplateRow(this._row, "text_align", null) as any,
+      buttonAlign: getStringParamFromTemplateRow(this._row, "button_align", "center") as any,
+      icon: getStringParamFromTemplateRow(this._row, "icon", null),
+      iconSecondary: getStringParamFromTemplateRow(this._row, "icon_secondary_asset", null),
+      iconAlign: getStringParamFromTemplateRow(this._row, "icon_align", "left") as any,
+    };
+    return buttonParams;
   }
 
   /** Determine if the button is inside a display group with the style "two_columns" */
@@ -112,9 +99,9 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
     }
   }
 
-  private populateVariantMap() {
-    const variantArray = this.params.variant.split(" ");
-    this.variantMap = {
+  private populateVariantMap(variant: IButtonParams["variant"] = ""): IVariantMap {
+    const variantArray = variant.split(" ");
+    return {
       cardPortrait: variantArray.includes("card-portrait"),
     };
   }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
Targets branch of #2757

- Update parameter_list handling to update on change (not just init)
- Replace mapped params with signal

## Review Notes
Confirm example/test cases targetted in original PR branch still work

## Dev Notes
Looking through button code and proposed changes I didn't think it fully made sense to make just one single param responsive whilst keeping the others as is. 

I think moving forward it would make sense to move away from `ngOnInit` methods to process parameter_list variables, and instead use signals to compute component params whenever the author `parameter_list()` signal updates. 

This is a little awkward as for whatever reason we have a bunch of utility methods that take the entire row before parsing parameter list values to specific types (e.g. `getStringParameterFromRow`), but I also think these should likely also be deprecated and slowly moved away from. As a shorter term solution I've kept the methods in place and still pass the full row, just using the `parameter_list()` signal as a trigger to evaluate. 

It also may be worth considering whether we want to push for keeping the list of mapped params within a single `params()` signal (and a base method that can be extended to pass a mapping function from template to component params), or whether to leave to individual components and prefer to expose individual values/signals for each of the params used. I'd personally lean towards the latter (e.g. top-level `this.disabled`, `this.variant`, `this.textAlign` etc.) to allow for more performant change detection and minimal re-rendering if we ever get to a stage where parameter list updates don't force entire row re-renders, but short term I don't think it makes much difference.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
