### PR TITLE
style: new display group variant for MX button use case

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -60,7 +60,6 @@
   &[data-variant~="box_primary"],
   &[data-variant~="box_secondary"],
   &[data-variant~="box_secondary_alt"],
-  &[data-variant~="solid_secondary"],
   &[data-variant~="box_white"] {
     margin-top: var(--regular-margin);
     padding: var(--regular-padding);

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -89,3 +89,13 @@
     --border-color: var(--border-color-default, var(--ion-color-primary));
   }
 }
+
+.display-group-wrapper {
+  &[data-variant~="solid_secondary"] {
+    padding: var(--regular-padding);
+    background-color: var(--ion-color-secondary);
+    border-radius: var(--ion-border-radius-secondary);
+    border: var(--border-standard);
+    border-color: var(--ion-color-secondary-200);
+  }
+}

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -59,6 +59,8 @@
   &[data-variant~="box_gray"],
   &[data-variant~="box_primary"],
   &[data-variant~="box_secondary"],
+  &[data-variant~="box_secondary_alt"],
+  &[data-variant~="solid_secondary"],
   &[data-variant~="box_white"] {
     margin-top: var(--regular-margin);
     padding: var(--regular-padding);
@@ -84,18 +86,13 @@
     --border-color: var(--ion-color-secondary-500);
   }
 
+  &[data-variant~="box_secondary_alt"] {
+    --background-color: var(--ion-color-secondary-600);
+    --border-color: var(--ion-color-secondary-200);
+  }
+
   &[data-variant~="box_white"] {
     --background-color: white;
     --border-color: var(--border-color-default, var(--ion-color-primary));
-  }
-}
-
-.display-group-wrapper {
-  &[data-variant~="solid_secondary"] {
-    padding: var(--regular-padding);
-    background-color: var(--ion-color-secondary);
-    border-radius: var(--ion-border-radius-secondary);
-    border: var(--border-standard);
-    border-color: var(--ion-color-secondary-200);
   }
 }

--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -947,6 +947,9 @@ body[data-theme="plh_facilitator_mx"] {
       border: none;
       border-inline-start: 3px solid var(--color-accent-orange-40);
     }
+    &[data-variant~="box_secondary_alt"] {
+      border-radius: var(--ion-border-radius-secondary) !important;
+    }
     &[data-variant~="box_gray"] {
       --background-color: var(--ion-color-gray-100) !important;
       border: none;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new variant to the display group to handle the use case referenced [here](https://github.com/ParentingForLifelongHealth/plh-facilitator-app-mx-content/issues/140#issuecomment-2616147702).

This variant, `box_secondary_alt`, applies a background colour, border and corner radius to the group, in line with the existing `box_*` variants. Additional styling for the use case should be handled through other means, see example below.

Corresponding debug content PR: https://github.com/IDEMSInternational/app-debug-content/pull/142

## Notes

I wasn't sure how best to handle this use case. While defining the styling itself is relatively trivial, there is a decision about how much styling to include in a variant vs relying on additional authored styling, to achieve a balance between reusability and flexibility. I've opted in favour of making the styling very flexible to authors: any content could be authored inside the styled display group in the usual way. Another approach to handling this request, at the other end of the scale, would be to author a new variant of `button` component which took an additional parameter to define the top text (e.g. `title`), and applied all the necessary styling. This would be easier to reuse in other contexts, but more difficult to adapt if, for example, we wanted the same visual component to contain an image and no top title, for example.

Adding a `box_secondary_alt` does not represent a step towards our planned theme-system improvements (#1468), but is a welcome departure from cases such as the display group "styles" below the new one in the [demo sheet](https://docs.google.com/spreadsheets/d/1IlM2fbVYzVdwPBa9UEaKZhGGlLFhRHCo--T6uC-EQiE/edit?gid=7532536#gid=7532536): e.g. `tool_1`, `tool_2` etc., which have deployment specific names and inflexible styling.

## Git Issues

Referenced in https://github.com/ParentingForLifelongHealth/plh-facilitator-app-mx-content/issues/140

## Screenshots/Videos

Design:

![406990546-fa347aae-0305-46bb-9031-760cadd75dbe](https://github.com/user-attachments/assets/4c2d0f62-00ef-4c44-a2c6-cefb82285241)

[comp_display_group](https://docs.google.com/spreadsheets/d/1IlM2fbVYzVdwPBa9UEaKZhGGlLFhRHCo--T6uC-EQiE/edit?gid=7532536#gid=7532536):

<img width="800" alt="Screenshot 2025-02-05 at 11 50 46" src="https://github.com/user-attachments/assets/c1aef3ce-65f9-43a4-8ee7-e41c996616d1" />

`default` theme:

<img width="240" alt="Screenshot 2025-02-05 at 11 52 28" src="https://github.com/user-attachments/assets/1d2cc075-baa1-41bd-8363-90603d06ed1b" />

`plh_facilitator_mx` theme:

<img width="240" alt="Screenshot 2025-02-05 at 11 52 50" src="https://github.com/user-attachments/assets/0c449d22-cbfb-455e-a496-564feb8b5c16" />

