### PR TITLE
Chore: ng test ci and mock updates

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -164,7 +164,7 @@ jobs:
       
       - name: Test
         if: ${{inputs.include-tests}}
-        run: yarn test:workspaces
+        run: yarn test:workspaces && yarn ng test
 
       - name: Build
         run: yarn build ${{inputs.build-flags}}

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Test - Src
         if: ${{inputs.include-tests}}
-        run: yarn ng test --sourceMap=false --browsers=ChromeHeadless --watch=false
+        run: yarn ng test --source-map=false --browsers=ChromeHeadless --watch=false
         
       #############################################################################
       #         Build

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -148,9 +148,8 @@ jobs:
         run: yarn workflow deployment set ${{env.DEPLOYMENT_NAME}}
 
       #############################################################################
-      #         Build
-      # Run optional tests before building and uploading final build as artifact
-      # for use in other actions
+      #         Test
+      # Run optional tests before building
       #############################################################################
 
       - name: Lint
@@ -162,9 +161,22 @@ jobs:
         if: ${{ inputs.include-tests && !inputs.lfs }}
         run: git lfs pull --include "packages/scripts/test/data/input/*"
       
-      - name: Test
+      - name: Test - Shared
         if: ${{inputs.include-tests}}
-        run: yarn test:workspaces && yarn ng test
+        run: yarn workspace shared test
+
+      - name: Test - Scripts
+        if: ${{inputs.include-tests}}
+        run: yarn workspace scripts test
+
+      - name: Test - Src
+        if: ${{inputs.include-tests}}
+        run: yarn ng test --sourceMap=false --browsers=ChromeHeadless --watch=false
+        
+      #############################################################################
+      #         Build
+      # Build and upload as artifact for use in other actions
+      #############################################################################
 
       - name: Build
         run: yarn build ${{inputs.build-flags}}

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-promise": "^6.1.1",
+    "fake-indexeddb": "^6.0.0",
     "firebase-tools": "^13.6.0",
     "husky": "^8.0.3",
     "jasmine-core": "~4.5.0",

--- a/src/app/feature/theme/services/theme.service.mock.spec.ts
+++ b/src/app/feature/theme/services/theme.service.mock.spec.ts
@@ -1,14 +1,13 @@
 import { BehaviorSubject } from "rxjs";
 import { ThemeService } from "./theme.service";
-import { MockLocalStorageService } from "src/app/shared/services/local-storage/local-storage.service.spec";
+import { MockLocalStorageService } from "src/app/shared/services/local-storage/local-storage.service.mock.spec";
 import { MockAppConfigService } from "src/app/shared/services/app-config/app-config.service.mock.spec";
-import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
 import { AppConfigService } from "src/app/shared/services/app-config/app-config.service";
 
 export class MockThemeService extends ThemeService {
   constructor() {
     super(
-      new MockLocalStorageService() as unknown as LocalStorageService,
+      new MockLocalStorageService(),
       new MockAppConfigService({
         APP_THEMES: { available: ["mock_theme"], defaultThemeName: "mock_theme" },
       }) as unknown as AppConfigService

--- a/src/app/feature/theme/services/theme.service.spec.ts
+++ b/src/app/feature/theme/services/theme.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from "@angular/core/testing";
 
 import { ThemeService } from "./theme.service";
 import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
-import { MockLocalStorageService } from "src/app/shared/services/local-storage/local-storage.service.spec";
+import { MockLocalStorageService } from "src/app/shared/services/local-storage/local-storage.service.mock.spec";
 import { AppConfigService } from "src/app/shared/services/app-config/app-config.service";
 import { MockAppConfigService } from "src/app/shared/services/app-config/app-config.service.mock.spec";
 import { IAppConfig } from "packages/data-models";

--- a/src/app/shared/components/template/components/data-items/data-items.service.spec.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.service.spec.ts
@@ -9,6 +9,8 @@ import { firstValueFrom } from "rxjs";
 import { Injector } from "@angular/core";
 import { TemplateVariablesService } from "../../services/template-variables.service";
 import { TemplateTranslateService } from "../../services/template-translate.service";
+import { TemplateCalcService } from "../../services/template-calc.service";
+import { MockTemplateCalcService } from "../../services/template-calc.service.mock.spec";
 
 /***************************************************************************************
  * Test Setup
@@ -95,6 +97,7 @@ describe("DataItemsService", () => {
         { provide: Injector, useValue: {} },
         { provide: TemplateVariablesService, useValue: { evaluateConditionString: (v) => v } },
         { provide: TemplateTranslateService, useValue: {} },
+        { provide: TemplateCalcService, useValue: new MockTemplateCalcService() },
       ],
     });
     service = TestBed.inject(DataItemsService);
@@ -150,6 +153,8 @@ describe("DataItemsService", () => {
     console.log({ evaluated });
     expect(evaluated.args).toEqual(["my_local_var", 3]);
   });
+
+  it("...", async () => {});
   // TODO - fix case where items context refers to generated loop items and not list items
   xit("evaluates data actions rows with items context", async () => {
     const obs = service.getItemsObservable(MOCK_DATA_ITEMS_ROW, {});

--- a/src/app/shared/components/template/components/data-items/data-items.service.spec.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.service.spec.ts
@@ -154,7 +154,6 @@ describe("DataItemsService", () => {
     expect(evaluated.args).toEqual(["my_local_var", 3]);
   });
 
-  it("...", async () => {});
   // TODO - fix case where items context refers to generated loop items and not list items
   xit("evaluates data actions rows with items context", async () => {
     const obs = service.getItemsObservable(MOCK_DATA_ITEMS_ROW, {});

--- a/src/app/shared/components/template/services/template-calc.service.mock.spec.ts
+++ b/src/app/shared/components/template/services/template-calc.service.mock.spec.ts
@@ -1,0 +1,17 @@
+import { MockLocalStorageService } from "src/app/shared/services/local-storage/local-storage.service.mock.spec";
+import { ICalcContext, TemplateCalcService } from "./template-calc.service";
+import { MockDataEvaluationService } from "src/app/shared/services/data/data-evaluation.service.mock.spec";
+
+export class MockTemplateCalcService extends TemplateCalcService {
+  constructor() {
+    super(new MockDataEvaluationService(), new MockLocalStorageService());
+  }
+
+  public getCalcContext(): ICalcContext {
+    return {
+      thisCtxt: {},
+      globalConstants: {},
+      globalFunctions: {},
+    };
+  }
+}

--- a/src/app/shared/components/template/services/template-calc.service.spec.ts
+++ b/src/app/shared/components/template/services/template-calc.service.spec.ts
@@ -1,19 +1,3 @@
-import { ICalcContext, TemplateCalcService } from "./template-calc.service";
-
-export class MockTemplateCalcService implements Partial<TemplateCalcService> {
-  public async ready(): Promise<boolean> {
-    return true;
-  }
-
-  public getCalcContext(): ICalcContext {
-    return {
-      thisCtxt: {},
-      globalConstants: {},
-      globalFunctions: {},
-    };
-  }
-}
-
 /**
  * TODO - Add testing data and methods
  * 

--- a/src/app/shared/components/template/services/template-calc.service.ts
+++ b/src/app/shared/components/template/services/template-calc.service.ts
@@ -2,12 +2,10 @@ import { IFunctionHashmap, IConstantHashmap } from "src/app/shared/utils";
 import { Injectable } from "@angular/core";
 import { Device, DeviceInfo } from "@capacitor/device";
 import * as date_fns from "date-fns";
-import { ServerService } from "src/app/shared/services/server/server.service";
 import { DataEvaluationService } from "src/app/shared/services/data/data-evaluation.service";
 import { AsyncServiceBase } from "src/app/shared/services/asyncService.base";
 import { PLH_CALC_FUNCTIONS } from "./template-calc-functions/plh-calc-functions";
 import { CORE_CALC_FUNCTIONS } from "./template-calc-functions/core-calc-functions";
-import { UserMetaService } from "src/app/shared/services/userMeta/userMeta.service";
 import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
 
 @Injectable({ providedIn: "root" })
@@ -23,17 +21,15 @@ export class TemplateCalcService extends AsyncServiceBase {
   };
 
   constructor(
-    private serverService: ServerService,
     private dataEvaluationService: DataEvaluationService,
-    private localStorageService: LocalStorageService,
-    private userMetaService: UserMetaService
+    private localStorageService: LocalStorageService
   ) {
     super("TemplateCalc");
     this.registerInitFunction(this.initialise);
   }
   private async initialise() {
-    this.ensureSyncServicesReady([this.serverService, this.localStorageService]);
-    await this.ensureAsyncServicesReady([this.dataEvaluationService, this.userMetaService]);
+    this.ensureSyncServicesReady([this.localStorageService]);
+    await this.ensureAsyncServicesReady([this.dataEvaluationService]);
     await this.setUserMetaData();
     this.getCalcContext();
   }

--- a/src/app/shared/components/template/services/template-variables.service.spec.ts
+++ b/src/app/shared/components/template/services/template-variables.service.spec.ts
@@ -7,7 +7,7 @@ import { AppDataService } from "src/app/shared/services/data/app-data.service";
 import { CampaignService } from "src/app/feature/campaign/campaign.service";
 import { MockAppDataService } from "src/app/shared/services/data/app-data.service.mock.spec";
 import { TemplateCalcService } from "./template-calc.service";
-import { MockTemplateCalcService } from "./template-calc.service.spec";
+import { MockTemplateCalcService } from "./template-calc.service.mock.spec";
 import { TemplateTranslateService } from "./template-translate.service";
 import { FlowTypes } from "packages/data-models";
 

--- a/src/app/shared/services/app-events/app-events.service.mock.spec.ts
+++ b/src/app/shared/services/app-events/app-events.service.mock.spec.ts
@@ -1,0 +1,15 @@
+import { AppConfigService } from "../app-config/app-config.service";
+import { MockAppConfigService } from "../app-config/app-config.service.mock.spec";
+import { MockDbService } from "../db/db.service.mock.spec";
+import { MockLocalStorageService } from "../local-storage/local-storage.service.mock.spec";
+import { AppEventService } from "./app-events.service";
+
+export class MockAppEventService extends AppEventService {
+  constructor() {
+    super(
+      new MockDbService(),
+      new MockLocalStorageService(),
+      new MockAppConfigService() as any as AppConfigService
+    );
+  }
+}

--- a/src/app/shared/services/data/app-data-variable.service.spec.ts
+++ b/src/app/shared/services/data/app-data-variable.service.spec.ts
@@ -4,8 +4,8 @@ import { AppDataVariableService, IVariableContext } from "./app-data-variable.se
 import { DbService } from "../db/db.service";
 import { LocalStorageService } from "../local-storage/local-storage.service";
 import { AppDataHandlerBase } from "./variable-handlers";
-import { MockDbService } from "../db/db.service.spec";
-import { MockLocalStorageService } from "../local-storage/local-storage.service.spec";
+import { MockDbService } from "../db/db.service.mock.spec";
+import { MockLocalStorageService } from "../local-storage/local-storage.service.mock.spec";
 
 function getMockHandlers() {
   /** Mock handler inherits base handler which stores all get/set in-memory */

--- a/src/app/shared/services/data/app-data.service.spec.ts
+++ b/src/app/shared/services/data/app-data.service.spec.ts
@@ -8,7 +8,7 @@ import { MockAppDataVariableService } from "./app-data-variable.service.spec";
 import { ErrorHandlerService } from "../error-handler/error-handler.service";
 import { MockErrorHandlerService } from "../error-handler/error-handler.service.mock.spec";
 import { DbService } from "../db/db.service";
-import { MockDbService } from "../db/db.service.spec";
+import { MockDbService } from "../db/db.service.mock.spec";
 import { Injectable } from "@angular/core";
 import { ISheetContents } from "src/app/data";
 import { _wait } from "packages/shared/src/utils/async-utils";

--- a/src/app/shared/services/data/data-evaluation.service.mock.spec.ts
+++ b/src/app/shared/services/data/data-evaluation.service.mock.spec.ts
@@ -1,0 +1,18 @@
+import { MockAppEventService } from "../app-events/app-events.service.mock.spec";
+import { MockDbService } from "../db/db.service.mock.spec";
+import { DataEvaluationService, IDataEvaluationCache } from "./data-evaluation.service";
+
+export class MockDataEvaluationService extends DataEvaluationService {
+  constructor(private mockData: Partial<IDataEvaluationCache> = {}) {
+    super(new MockDbService(), new MockAppEventService(), null as any);
+  }
+  public override async refreshDBCache(): Promise<IDataEvaluationCache> {
+    this.data = {
+      app_day: 5,
+      dbCache: {},
+      first_app_launch: "2024-12-22T18:15:20",
+      ...this.mockData,
+    };
+    return this.data;
+  }
+}

--- a/src/app/shared/services/db/db.service.mock.spec.ts
+++ b/src/app/shared/services/db/db.service.mock.spec.ts
@@ -1,0 +1,13 @@
+import Dexie from "dexie";
+import { indexedDB, IDBKeyRange } from "fake-indexeddb";
+import { DbService } from "./db.service";
+import { EventService } from "../event/event.service";
+
+export class MockDbService extends DbService {
+  constructor() {
+    super(new EventService());
+    // Use a mock indexeddb with Dexie bindings
+    // https://github.com/dumbmatter/fakeIndexedDB?tab=readme-ov-file#dexie-and-other-indexeddb-api-wrappers
+    super["db"] = new Dexie("MockDB", { indexedDB, IDBKeyRange });
+  }
+}

--- a/src/app/shared/services/db/db.service.spec.ts
+++ b/src/app/shared/services/db/db.service.spec.ts
@@ -1,22 +1,6 @@
 import { TestBed } from "@angular/core/testing";
-import { IDBMeta } from "packages/data-models/db.model";
-import { generateTimestamp } from "../../utils";
 
 import { DbService } from "./db.service";
-
-/**
- * Minimal set of methods for use in mocking other tests
- * TODO - add own test suite
- */
-export class MockDbService implements Partial<DbService> {
-  async ready() {
-    await new Promise((resolve) => setTimeout(() => resolve(true), 200));
-    return true;
-  }
-  public generateDBMeta(syncable?: boolean): IDBMeta {
-    return { _created: generateTimestamp(), _sync_status: syncable ? "ignored" : "pending" };
-  }
-}
 
 describe("DbService", () => {
   beforeEach(() => TestBed.configureTestingModule({}));

--- a/src/app/shared/services/local-storage/local-storage.service.mock.spec.ts
+++ b/src/app/shared/services/local-storage/local-storage.service.mock.spec.ts
@@ -1,0 +1,16 @@
+import { LocalStorageService } from "./local-storage.service";
+
+/**
+ * Mock calls to localStorage service
+ * The mock still requires window localstorage, but passes custom prefix to store mock values
+ *
+ * TODO - would be better to override window.localstorage methods however difficult to restore
+ * after use (needs to be implemented in individual specs and not mock service)
+ * */
+export class MockLocalStorageService extends LocalStorageService {
+  constructor(prefix = "mock") {
+    super();
+    this.prefix = prefix;
+    this.clear();
+  }
+}

--- a/src/app/shared/services/local-storage/local-storage.service.spec.ts
+++ b/src/app/shared/services/local-storage/local-storage.service.spec.ts
@@ -1,27 +1,6 @@
 import { TestBed } from "@angular/core/testing";
 
 import { LocalStorageService } from "./local-storage.service";
-import { IProtectedFieldName } from "packages/data-models";
-
-/** Mock calls to localstorage to store values in-memory */
-export class MockLocalStorageService implements Partial<LocalStorageService> {
-  private values: Record<string, string> = {};
-  public getString(key: string): string {
-    return this.values[key];
-  }
-  public setString(key: string, value: string): void {
-    this.values[key] = value;
-  }
-  public ready(): boolean {
-    return true;
-  }
-  public getProtected(field: IProtectedFieldName): string {
-    return this.getString(`_${field}`);
-  }
-  public setProtected(field: IProtectedFieldName, value: string) {
-    return this.setString(`_${field}`, value);
-  }
-}
 
 /**
  * Call standalone tests via:

--- a/src/app/shared/services/local-storage/local-storage.service.ts
+++ b/src/app/shared/services/local-storage/local-storage.service.ts
@@ -2,20 +2,21 @@ import { Injectable } from "@angular/core";
 import { IProtectedFieldName, getProtectedFieldName } from "data-models";
 import { SyncServiceBase } from "../syncService.base";
 
-export const LOCAL_STORAGE_PREFIX = "rp-contact-field";
-
 @Injectable({
   providedIn: "root",
 })
 export class LocalStorageService extends SyncServiceBase {
+  /** Prefix applied to all localStorage entries */
+  public prefix = "rp-contact-field";
+
   constructor() {
     super("LocalStorage");
   }
 
   private get(key: string): string | null {
     if (!key) return null;
-    if (!key.startsWith(LOCAL_STORAGE_PREFIX)) {
-      key = `${LOCAL_STORAGE_PREFIX}.${key}`;
+    if (!key.startsWith(this.prefix)) {
+      key = `${this.prefix}.${key}`;
     }
     return localStorage.getItem(key);
   }
@@ -25,16 +26,16 @@ export class LocalStorageService extends SyncServiceBase {
     if (!allowProtected && this.isProtected(key)) {
       console.warn(`[DEPRECATED] - set local-storage with protected name: ${key}`);
     }
-    if (!key.startsWith(LOCAL_STORAGE_PREFIX)) {
-      key = `${LOCAL_STORAGE_PREFIX}.${key}`;
+    if (!key.startsWith(this.prefix)) {
+      key = `${this.prefix}.${key}`;
     }
     return localStorage.setItem(key, value);
   }
 
   private remove(key: string) {
     if (!key) return;
-    if (!key.startsWith(LOCAL_STORAGE_PREFIX)) {
-      key = `${LOCAL_STORAGE_PREFIX}.${key}`;
+    if (!key.startsWith(this.prefix)) {
+      key = `${this.prefix}.${key}`;
     }
     return localStorage.removeItem(key);
   }
@@ -69,7 +70,7 @@ export class LocalStorageService extends SyncServiceBase {
   getAll() {
     const values = {};
     Object.keys(localStorage)
-      .filter((k) => k.startsWith(LOCAL_STORAGE_PREFIX))
+      .filter((k) => k.startsWith(this.prefix))
       .forEach((k) => (values[k] = localStorage.getItem(k)));
     return values;
   }
@@ -92,8 +93,8 @@ export class LocalStorageService extends SyncServiceBase {
   }
   /** Check if a field name is protected (starts with underscore prefixed or non-prefixed) */
   isProtected(key: string) {
-    if (key.startsWith(LOCAL_STORAGE_PREFIX)) {
-      key = key.replace(`${LOCAL_STORAGE_PREFIX}.`, "");
+    if (key.startsWith(this.prefix)) {
+      key = key.replace(`${this.prefix}.`, "");
     }
     return key.startsWith("_");
   }

--- a/src/app/shared/services/skin/skin.service.spec.ts
+++ b/src/app/shared/services/skin/skin.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from "@angular/core/testing";
 
 import { SkinService } from "./skin.service";
 import { LocalStorageService } from "../local-storage/local-storage.service";
-import { MockLocalStorageService } from "../local-storage/local-storage.service.spec";
+import { MockLocalStorageService } from "../local-storage/local-storage.service.mock.spec";
 import { AppConfigService } from "../app-config/app-config.service";
 import { MockAppConfigService } from "../app-config/app-config.service.mock.spec";
 import { TemplateService } from "../../components/template/services/template.service";

--- a/src/app/shared/services/userMeta/userMeta.service.ts
+++ b/src/app/shared/services/userMeta/userMeta.service.ts
@@ -7,7 +7,7 @@ import { AsyncServiceBase } from "../asyncService.base";
 import { DbService } from "../db/db.service";
 import { TemplateActionRegistry } from "../../components/template/services/instance/template-action.registry";
 import { TemplateFieldService } from "../../components/template/services/template-field.service";
-import { LOCAL_STORAGE_PREFIX, LocalStorageService } from "../local-storage/local-storage.service";
+import { LocalStorageService } from "../local-storage/local-storage.service";
 import { DynamicDataService } from "../dynamic-data/dynamic-data.service";
 import { getProtectedFieldName, IProtectedFieldName } from "packages/data-models";
 
@@ -99,8 +99,9 @@ export class UserMetaService extends AsyncServiceBase {
     // create a reverse mapping of protected fields that are allowed to be imported
     // to allow setting protected fields such as rp-contact-field._app_skin
     const protectedFieldMapping: Record<string, string> = {};
+    const { prefix } = this.localStorageService;
     for (const fieldName of IMPORTABLE_PROTECTED_FIELD_NAMES) {
-      const mappedName = `${LOCAL_STORAGE_PREFIX}.${getProtectedFieldName(fieldName)}`;
+      const mappedName = `${prefix}.${getProtectedFieldName(fieldName)}`;
       protectedFieldMapping[mappedName] = fieldName;
     }
     for (const [key, value] of Object.entries(contact_fields)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14957,6 +14957,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fake-indexeddb@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "fake-indexeddb@npm:6.0.0"
+  checksum: c55bb1f54c1c910a6ca9e18b376ebecc51a29eceb829550d415aa34c2e246730a76dd35dc4fd6d8ae5c5790b9b4f180859e9457bcb73f2d167cc87aa04b6201e
+  languageName: node
+  linkType: hard
+
 "fancy-log@npm:^2.0.0":
   version: 2.0.0
   resolution: "fancy-log@npm:2.0.0"
@@ -15688,6 +15695,7 @@ __metadata:
     eslint-plugin-prefer-arrow: 1.2.3
     eslint-plugin-promise: ^6.1.1
     extract-math: ^1.2.3
+    fake-indexeddb: ^6.0.0
     file-saver: ^2.0.5
     firebase: ^10.9.0
     firebase-tools: ^13.6.0


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

- Add `ng test` to ci test workflow to ensure all ng tests are passing before merge
- Change mock db to use dexie with `fake-indexeddb` instead of stubbing methods
- Alter various mock test suites to extend base instead of implementing partial

## Review Notes
Can see code changes in files ending `.ts` (but not `.spec.ts`) - I've never found a good way to filter these out but there's not too many changed files to quickly look through and check

The spec test code updates are non-breaking (full set of spec tests included in PR testing)

## Dev Notes
I've slowly been migrating most mock services to extend original services instead of partially implementing methods as I feel like in the long term this will be less prone to breakage and better at catching knock-on issues when core methods changed on underlying services (tests will break instead of just potentially showing type errors depending on how implemented)

This shouldn't result in many core code changes at all, just a few minor bits of refactoring in places to make it easier to override some service methods/variables when called from mocks

The CI tests have been separated into separate steps and `ng test` included so that the entire set of spec tests will be evaluated on any PR. If we wanted to be more optimal it would be possible to setup the src, shared, and scripts workspace tests to only [execute when files changed](https://www.meziantou.net/executing-github-actions-jobs-or-steps-only-when-specific-files-change.htm) within corresponding folders, however this isn't a high priority for now (could save a few minutes on each PR test run depending on what files change)

## Git Issues

Closes #

## Screenshots/Videos

**Example Passing Action - with `Test - src` step**
https://github.com/IDEMSInternational/open-app-builder/actions/runs/13144318569/job/36678739564?pr=2775

![image](https://github.com/user-attachments/assets/29d6f6ae-ea7d-43a5-8a82-605698bbbb4b)

