### PR TITLE
hotfix: data-items local variables

### DIFF
--- a/src/app/shared/components/template/components/data-items/data-items.service.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.service.ts
@@ -165,6 +165,11 @@ export class DataItemsService {
     } as any);
     // HACK - still want to be able to use localContext from parent rows so copy to child processor
     processor.templateRowMap = JSON.parse(JSON.stringify(templateRowMap));
+    const templateRowMapValues = Object.fromEntries(
+      Object.entries(templateRowMap).map(([key, { value }]) => [key, value])
+    );
+    processor.templateRowMapValues = templateRowMapValues;
+
     await processor.processContainerTemplateRows();
     return processor.renderedRows();
   }

--- a/src/app/shared/components/template/services/instance/template-action.service.spec.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.spec.ts
@@ -40,6 +40,10 @@ class MockTemplateRowService implements Partial<TemplateRowService> {
 
 class MockContainer implements Partial<TemplateContainerComponent> {
   templateRowService = new MockTemplateRowService() as any as TemplateRowService;
+
+  get templateRowMap() {
+    return this.templateRowService.templateRowMap;
+  }
 }
 
 /**
@@ -101,7 +105,7 @@ describe("TemplateActionService", () => {
       _triggeredBy
     );
     expect(service.container.templateRowService.templateRowMap.mock_row_2.value).toEqual("updated");
-    expect(service.container.templateRowService.templateRowMapValues.mock_row_1).toEqual("updated");
+    expect(service.container.templateRowService.templateRowMapValues.mock_row_2).toEqual("updated");
     // also include test case of concatenated expression
     await service.handleActions(
       [

--- a/src/app/shared/components/template/services/instance/template-action.service.spec.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.spec.ts
@@ -31,14 +31,15 @@ class MockTemplateRowService implements Partial<TemplateRowService> {
     mock_row_1: { value: "", _nested_name: "mock_row_1", name: "mock_row_1", type: "" },
     mock_row_2: { value: "", _nested_name: "mock_row_2", name: "mock_row_2", type: "" },
   };
+  templateRowMapValues = {
+    mock_row_1: "",
+    mock_row_2: "",
+  };
   processRowUpdates = async () => null;
 }
 
 class MockContainer implements Partial<TemplateContainerComponent> {
   templateRowService = new MockTemplateRowService() as any as TemplateRowService;
-  get templateRowMap() {
-    return this.templateRowService.templateRowMap;
-  }
 }
 
 /**
@@ -74,14 +75,16 @@ describe("TemplateActionService", () => {
     await service.handleActions([
       { trigger: "click", action_id: "set_local", args: ["mock_row_1", "updated"] },
     ]);
-    expect(service.container.templateRowMap.mock_row_1.value).toEqual("updated");
+    expect(service.container.templateRowService.templateRowMap.mock_row_1.value).toEqual("updated");
+    expect(service.container.templateRowService.templateRowMapValues.mock_row_1).toEqual("updated");
   });
 
   it("set_self action", async () => {
     await service.handleActions([
       { trigger: "click", action_id: "set_self", args: ["mock_row_1", "updated"] },
     ]);
-    expect(service.container.templateRowMap.mock_row_1.value).toEqual("updated");
+    expect(service.container.templateRowService.templateRowMap.mock_row_1.value).toEqual("updated");
+    expect(service.container.templateRowService.templateRowMapValues.mock_row_1).toEqual("updated");
   });
 
   it("Uses latest value for `this.value` arg", async () => {
@@ -97,7 +100,8 @@ describe("TemplateActionService", () => {
       ],
       _triggeredBy
     );
-    expect(service.container.templateRowMap.mock_row_2.value).toEqual("updated");
+    expect(service.container.templateRowService.templateRowMap.mock_row_2.value).toEqual("updated");
+    expect(service.container.templateRowService.templateRowMapValues.mock_row_1).toEqual("updated");
     // also include test case of concatenated expression
     await service.handleActions(
       [
@@ -109,7 +113,9 @@ describe("TemplateActionService", () => {
       ],
       _triggeredBy
     );
-    expect(service.container.templateRowMap.mock_row_2.value).toEqual("prefix_updated");
+    expect(service.container.templateRowService.templateRowMap.mock_row_2.value).toEqual(
+      "prefix_updated"
+    );
   });
 
   it("Uses latest value for `this.value` param", async () => {

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -382,6 +382,8 @@ export class TemplateActionService extends SyncServiceBase {
       }
       rowEntry.value = value;
       this.container.templateRowService.templateRowMap[rowEntry._nested_name] = rowEntry;
+      this.container.templateRowService.templateRowMapValues[rowEntry._nested_name] =
+        rowEntry.value;
     } else {
       // TODO
       console.warn("Setting local variable which does not exist", { key, value }, "TODO");

--- a/src/app/shared/components/template/services/instance/template-process.service.ts
+++ b/src/app/shared/components/template/services/instance/template-process.service.ts
@@ -64,6 +64,7 @@ export class TemplateProcessService extends SyncServiceBase {
     this.container.template = template;
     // reset any existing templateRowMap data
     this.container.templateRowService.templateRowMap = {};
+    this.container.templateRowService.templateRowMapValues = {};
     // process the template as if it were rendered
     // TODO - should filter out template rows to only include those used programatically (e.g. set_variable, set_field etc.)
     await this.container.templateRowService.processContainerTemplateRows();

--- a/src/app/shared/components/template/services/instance/template-row.service.ts
+++ b/src/app/shared/components/template/services/instance/template-row.service.ts
@@ -37,7 +37,7 @@ export class TemplateRowService extends SyncServiceBase {
   public templateRowMap: ITemplateRowMap = {};
 
   /** Modified templateRowMap to only include row values, for use in local evalContext */
-  private templateRowMapValues: { [row_nested_name: string]: FlowTypes.TemplateRow["value"] } = {};
+  public templateRowMapValues: { [row_nested_name: string]: FlowTypes.TemplateRow["value"] } = {};
 
   public renderedRows = signal<FlowTypes.TemplateRow[]>([], { equal: isEqual }); // rows processed and filtered by condition
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
Fix regression introduced by #2767 where data_items no longer passed outer local variables to inner items

## Review Notes
Minimal reproduction of issue available at [comp_data_items_debug_2](https://docs.google.com/spreadsheets/d/1khGTrDekzqDQyW1r2x0ADqknanrlkmhOz1RRzhP6-7c/edit?gid=1510685976#gid=1510685976)

Should be broken on master but fixed in branch. Should also confirm original issue resolved

## Dev Notes
I should have been a bit more careful when adding the additional variable that is meant to stay in sync with the templateRowMap, not realising that the rowMap was updated in multiple places not just the main processor. As part of this fix I checked the codebase for anywhere the `templateRowMap` was updated and tried to ensure the related `templateRowMapValues` was also.

A better solution might have been to only allow the `templateRowMap` to be set/updated from a method (not directly), and just using that method to ensure both values updated, however that would have been a larger refactor so not included at this moment. Alternatively the values could be created through some sort of getter/function, however it would require a level of memoizing or using computed signal in service to prevent repeated recalculation as it is accessed by every row processor. 

I tried adding tests to capture the behaviour, however the code change is within the `hackProcessRows` method which is stubbed for testing so not easy to do. However the behaviour is captured within [comp_data_items](https://docs.google.com/spreadsheets/d/1khGTrDekzqDQyW1r2x0ADqknanrlkmhOz1RRzhP6-7c/edit?gid=845703892#gid=845703892) Example 3 (accessing completed_counter inside of items), so now that visual tests are back working the component sheet should pick up any future regression if visually tested. 

I have also added some minor test updates to the `template-action.service.spec` that check the general case of the templateRowMapValues being updated (wouldn't have caught this specific issue but good to have for future ref)

## Git Issues

Closes #2777 

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
