### PR TITLE
feat(map): support multiple layers sharing the same scale

### DIFF
--- a/src/app/shared/components/template/components/map/map.component.html
+++ b/src/app/shared/components/template/components/map/map.component.html
@@ -12,11 +12,11 @@
               <div class="scale-container">
                 <ngx-slider
                   [class.disabled]="!mapLayer.get('scaleSlider')"
-                  [value]="mapLayer.get('scaleSlider') ? mapLayer.get('scaleMin') : null"
-                  [highValue]="mapLayer.get('scaleSlider') ? mapLayer.get('scaleMax') : null"
+                  [(value)]="sliderValues[mapLayer.get('scaleId') || mapLayer.get('id')].min"
+                  [(highValue)]="sliderValues[mapLayer.get('scaleId') || mapLayer.get('id')].max"
                   [options]="getSliderOptions(mapLayer)"
                   (userChangeEnd)="
-                    mapLayer.get('scaleSlider') ? handleSliderChange($event, mapLayer) : null
+                    mapLayer.get('scaleSlider') ? handleSliderChange(mapLayer, $event) : null
                   "
                   [ngStyle]="{ '--bar-background': mapLayer.get('gradientFill') }"
                 ></ngx-slider>
@@ -30,7 +30,7 @@
   <div class="map-controls">
     @for (layerGroup of mapLayerGroupsSorted; track $index) {
       @if (!layerGroup.controls_style || layerGroup.controls_style === "dropdown") {
-        @if (layerGroup.layers.length > 0) {
+        @if (layerGroup.layers?.length > 0) {
           <div class="map-control-container">
             <p>{{ (layerGroup.name || "Visible layers") + ":" }}</p>
             <ion-select

--- a/src/app/shared/components/template/components/map/map.component.html
+++ b/src/app/shared/components/template/components/map/map.component.html
@@ -4,7 +4,7 @@
     <div class="legend">
       @for (layerGroup of mapLayerGroupsSorted; track $index) {
         @for (mapLayer of layerGroup.layers; track $index) {
-          @if (mapLayer.getVisible() && mapLayer.get("gradientFill")) {
+          @if (mapLayer.getVisible() && mapLayer.get("showScale")) {
             <div class="legend-item">
               <div class="title">
                 <p>{{ mapLayer.get("scaleTitle") }}</p>

--- a/src/app/shared/components/template/components/map/map.component.scss
+++ b/src/app/shared/components/template/components/map/map.component.scss
@@ -137,6 +137,9 @@ $map-height: 70vh;
         .ngx-slider-bubble {
           display: none;
         }
+        .ngx-slider-selection {
+          background: transparent;
+        }
       }
     }
   }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new layer property, `scale_id`, used to identify layers which should share the same scale.

If no scale ID is provided, the layer functions as before, and any associated scale is rendered for that layer when it is visible. If multiple layers share a `scale_id`, then only one scale associated to these layers will ever be shown, and filters applied using that scale slider will apply to all such layers with that scale ID. Authors should ensure that each layer with a given scale ID has the same configuration for its scale (e.g. `scale_max`, `scale_min`, `scale_increment`, `scale_title` etc.)

## Dev Notes

The implementation is quite hacky. Currently, different scales are shown for different layers with the same `scale_id` (up to a maximum of 1) depending on which layers are visible, but these scales are assumed to be identical and kept in sync. 

Instead, it would be better to handle the scale configuration at a different level, only specifying a single scale that relates to multiple layers. This could be at the `layer_group` level, however in that case layers that are in different layer groups could not be identified as belonging to the same slider group. Alternatively, a single slider could be defined for each `property_to_plot` referenced by layers, although this would require such properties to be uniquely named across different data sources where necessary.

## Git Issues

Closes #

## Screenshots/Videos

Demo of [comp_map](https://docs.google.com/spreadsheets/d/1KgLTrFhqZdGhcSk6Zt0KQoy2mYf7NCqhCJz_zS0KEYw/edit?gid=569531329#gid=569531329).

See updates to [comp_map_layer_group_2](https://docs.google.com/spreadsheets/d/1KgLTrFhqZdGhcSk6Zt0KQoy2mYf7NCqhCJz_zS0KEYw/edit?gid=1396735088#gid=1396735088)

<img width="140" alt="Screenshot 2025-02-07 at 12 06 03" src="https://github.com/user-attachments/assets/c8d6640f-933e-4a37-932d-ffc7433b0500" />


https://github.com/user-attachments/assets/9504b54e-f737-452e-b4f3-636f7557dc38


