### PR TITLE
fix(map): handle showing new layer with same scale_id

### DIFF
--- a/src/app/shared/components/template/components/map/map.component.ts
+++ b/src/app/shared/components/template/components/map/map.component.ts
@@ -189,6 +189,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
         if (!this.visibleScaleIds().includes(scaleId)) {
           this.visibleScaleIds.set([...this.visibleScaleIds(), scaleId]);
         }
+        this.handleSliderChange(mapLayer);
       } else {
         // Check if any other layer with the same scaleId is still visible
         const allLayers = this.getAllLayers();


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow up to #2782: fixes issue where filter would not be applied when making a layer visible that belongs to a scale ID group with a filter currently active

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
