### PR TITLE
feat(map): display 'data loading' overlay; optimise filter calculations

### DIFF
--- a/src/app/shared/components/template/components/map/map.component.html
+++ b/src/app/shared/components/template/components/map/map.component.html
@@ -1,5 +1,10 @@
 <div class="map-container">
   <div class="map-and-legend-container">
+    @if (layerLoading()) {
+      <div class="loading-overlay">
+        <p>Data loading...</p>
+      </div>
+    }
     <div id="mapElement" #mapElement class="map"></div>
     <div class="legend">
       @for (layerGroup of mapLayerGroupsSorted; track $index) {

--- a/src/app/shared/components/template/components/map/map.component.scss
+++ b/src/app/shared/components/template/components/map/map.component.scss
@@ -4,6 +4,22 @@ $map-height: 70vh;
   width: 100%;
 }
 
+.loading-overlay {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  p {
+    text-align: center;
+    font-weight: bold;
+    color: white;
+  }
+}
+
 .map-and-legend-container {
   display: flex;
   flex-direction: column;

--- a/src/app/shared/components/template/components/map/map.component.ts
+++ b/src/app/shared/components/template/components/map/map.component.ts
@@ -255,6 +255,8 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
   }
 
   private filterLayerFeatures(vectorLayer: VectorLayer, upperValue: number, lowerValue: number) {
+    lowerValue = this.roundToXDecimalPlace(lowerValue, 1);
+    upperValue = this.roundToXDecimalPlace(upperValue, 1);
     const propertyName = vectorLayer.get("propertyToPlot");
     const filterFeatures = (feature: Feature) => {
       const value = feature.get(propertyName);
@@ -319,12 +321,17 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
       translate: (value: number) => {
         return new Intl.NumberFormat("en-GB", {
           minimumFractionDigits: 0,
-          maximumFractionDigits: 2,
+          maximumFractionDigits: 1,
         }).format(value);
       },
       vertical: true,
     };
     return sliderOptions;
+  }
+
+  private roundToXDecimalPlace(value: number, decimalPlaces: number = 1) {
+    const factor = 10 ** decimalPlaces;
+    return Math.round(value * factor) / factor;
   }
 
   private async initialiseMap() {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Changes relate to the map component for the `conflict_forecast` deployment.

- Adds an overlay when map data is loading
- Optimises for filter calculations by rounding filter values to one decimal place

## Git Issues

Closes #

## Screenshots/Videos

Demo of `conflict_forecast` deployment. Loading times have been artificially lengthened to demonstrate loading overlay feature.


https://github.com/user-attachments/assets/f0fcc7b2-9d20-4314-9410-78e206eb8f90


