### PR TITLE
refactor!: template-calc service

### DIFF
--- a/src/app/shared/components/template/services/template-calc.service.mock.spec.ts
+++ b/src/app/shared/components/template/services/template-calc.service.mock.spec.ts
@@ -3,15 +3,21 @@ import { ICalcContext, TemplateCalcService } from "./template-calc.service";
 import { MockDataEvaluationService } from "src/app/shared/services/data/data-evaluation.service.mock.spec";
 
 export class MockTemplateCalcService extends TemplateCalcService {
-  constructor() {
+  constructor(mockCalcContext: Partial<ICalcContext> = {}) {
     super(new MockDataEvaluationService(), new MockLocalStorageService());
-  }
-
-  public getCalcContext(): ICalcContext {
-    return {
-      thisCtxt: {},
-      globalConstants: {},
-      globalFunctions: {},
+    // merge any mock calc context with defaults
+    super["calcContext"] = {
+      thisCtxt: {
+        // ensure default calc included as allows `@calc(...)` to be triggered via `this.calc(...)`
+        calc: (v: any) => v,
+        ...mockCalcContext.thisCtxt,
+      },
+      globalConstants: {
+        ...mockCalcContext.globalConstants,
+      },
+      globalFunctions: {
+        ...mockCalcContext.globalFunctions,
+      },
     };
   }
 }

--- a/src/app/shared/components/template/services/template-calc.service.spec.ts
+++ b/src/app/shared/components/template/services/template-calc.service.spec.ts
@@ -1,3 +1,92 @@
+import { TestBed } from "@angular/core/testing";
+import { TemplateCalcService } from "./template-calc.service";
+import { MockDataEvaluationService } from "src/app/shared/services/data/data-evaluation.service.mock.spec";
+import { MockLocalStorageService } from "src/app/shared/services/local-storage/local-storage.service.mock.spec";
+import { DataEvaluationService } from "src/app/shared/services/data/data-evaluation.service";
+import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
+import { CORE_CALC_FUNCTIONS } from "./template-calc-functions/core-calc-functions";
+import { PLH_CALC_FUNCTIONS } from "./template-calc-functions/plh-calc-functions";
+
+/**
+ * Call standalone tests via:
+ * yarn ng test --include src/app/shared/components/template/services/template-calc.service.spec.ts
+ */
+describe("TemplateCalcService", () => {
+  let service: TemplateCalcService;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DataEvaluationService,
+          useValue: new MockDataEvaluationService(),
+        },
+        {
+          provide: LocalStorageService,
+          useValue: new MockLocalStorageService(),
+        },
+      ],
+    });
+    service = TestBed.inject(TemplateCalcService);
+    await service.ready();
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("[Deprecated] populates window.calc with calc functions", () => {
+    const { calc } = service["windowWithCalc"];
+    expect(Object.keys(calc)).toEqual([
+      ...Object.keys(CORE_CALC_FUNCTIONS),
+      ...Object.keys(PLH_CALC_FUNCTIONS),
+    ]);
+  });
+
+  it("populates window.date_fns with date_fns lib", () => {
+    const { date_fns } = service["windowWithCalc"];
+    expect(date_fns.hoursToMilliseconds(1)).toEqual(3600000);
+  });
+
+  it("Gets calc context", () => {
+    const calcContext = service.getCalcContext();
+    const { globalConstants, globalFunctions, thisCtxt } = calcContext;
+    // global constants and functions are passed by service
+    expect(globalConstants).toEqual({});
+    // global functions should be same as window but without 3rd party
+    expect(Object.keys(globalFunctions)).toEqual([
+      ...Object.keys(CORE_CALC_FUNCTIONS),
+      ...Object.keys(PLH_CALC_FUNCTIONS),
+    ]);
+    // By default a handful of specific app data context fields always populated
+    expect(Object.keys(thisCtxt)).toEqual([
+      "calc",
+      "app_day",
+      "app_first_launch",
+      "app_user_id",
+      "device_info",
+    ]);
+  });
+
+  it("evaluates @calc statements", async () => {
+    const res = await service.evaluate("@calc(2*2)");
+    expect(res).toEqual(4);
+  });
+
+  it("evaluates @calc statements with window functions", async () => {
+    const res = await service.evaluate("@calc(window.date_fns.hoursToMilliseconds(1))", {});
+    expect(res).toEqual(3600000);
+  });
+
+  it("evaluates @calc statements with local context", async () => {
+    // NOTE - `@local` expression should be converted to `this.local` in template-parser
+    const res = await service.evaluate("@calc(this.local.test_string)", {
+      local: { test_string: "hello" },
+    });
+    expect(res).toEqual("hello");
+  });
+});
+
 /**
  * TODO - Add testing data and methods
  * 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)


## Breaking Changes
The `window.calc` accessor has been marked as deprecated, e.g. `@calc(window.calc.pick_random([1,2,3]))`
Any methods available via `window.calc.xxxx` are already available directly, e.g. `@calc(pick_random)`, so use that way instead.

I can't see any examples of this being used in [example_calc](https://docs.google.com/spreadsheets/d/15TccctjzepSPPv9xrLp46fhYldNN0wrho1zA5voTYcg/edit?gid=1595229908#gid=1595229908), so assume this is mostly a legacy behaviour anyways

The only method that should still be accessed via the window is the `date_fns` utility library, e.g. `@calc(window.date_fns.add_days(...))`

## Description
Changes merged from #2772 for easier review, a handful of updates to the `template-calc.service` which handles authored `@calc(...)` statements, specifically

## Author Notes
Beyond the marked deprecation, there shouldn't be any breaking changes or functional testing required.

## Review Notes
The code doesn't introduce changes to how calc statements are evaluated (for follow-up), so more just to confirm test cases behave as expected

## Dev Notes
The changes introduced here should be mostly non-functional (testing, mock and type-safety improvements). The additional method included is designed for future integration in #2772, so in itself shouldn't be breaking. 

Whilst diving into the service I did notice a handful of inconsistencies and clunky areas within the code, however have avoided larger refactor as would be best done through RFC procedures first (beyond marking `window.calc` as deprecated. Goals of a larger refactor would include:

- Improve ways to define deployment-specific calc functions
- Customisable list of 3rd party libs to include in calc (currently just date_fns included for all)
- Improved parser methods to extract globals required by calc statements and only including those when generating calc context

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
