### PR TITLE
chore(map): increase filter precision to 2 decimal places

### DIFF
--- a/src/app/shared/components/template/components/map/map.component.ts
+++ b/src/app/shared/components/template/components/map/map.component.ts
@@ -258,8 +258,8 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
   }
 
   private filterLayerFeatures(vectorLayer: VectorLayer, upperValue: number, lowerValue: number) {
-    lowerValue = this.roundToXDecimalPlace(lowerValue, 1);
-    upperValue = this.roundToXDecimalPlace(upperValue, 1);
+    lowerValue = this.roundToXDecimalPlace(lowerValue, 2);
+    upperValue = this.roundToXDecimalPlace(upperValue, 2);
     const propertyName = vectorLayer.get("propertyToPlot");
     const filterFeatures = (feature: Feature) => {
       const value = feature.get(propertyName);
@@ -334,7 +334,7 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
       translate: (value: number) => {
         return new Intl.NumberFormat("en-GB", {
           minimumFractionDigits: 0,
-          maximumFractionDigits: 1,
+          maximumFractionDigits: 2,
         }).format(value);
       },
       vertical: true,


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

When applying a filter based on changing the slider values, the values used are now rounded to 2 decimal places (previously 1 decimal place). In the future, the precision should be exposed as layer-level property to authors.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
