### PR TITLE
Feat!: auth restore data

### DIFF
--- a/src/app/shared/services/auth/auth.service.ts
+++ b/src/app/shared/services/auth/auth.service.ts
@@ -60,6 +60,7 @@ export class AuthService extends AsyncServiceBase {
         const collectionData = profiles.map((p) => ({ ...p, id: p.app_user_id }));
         await this.dynamicDataService.ready();
         await this.dynamicDataService.setInternalCollection("auth_profiles", collectionData);
+        console.log("[Auth] Restore Profiles", profiles);
       }
     });
   }

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
@@ -143,9 +143,9 @@ describe("DynamicDataService", () => {
     ).toBeRejectedWithError();
   });
 
-  it("supports internal `app_` collections", async () => {
+  it("supports internal collections", async () => {
     await service.setInternalCollection("mock", [{ id: "1", string: "hello" }]);
-    const obs = await service.query$<any>("data_list", "app_mock");
+    const obs = await service.query$<any>("data_list", "_mock");
     const data = await firstValueFrom(obs);
     expect(data).toEqual([{ id: "1", string: "hello" }]);
   });

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
@@ -143,6 +143,13 @@ describe("DynamicDataService", () => {
     ).toBeRejectedWithError();
   });
 
+  it("supports internal `app_` collections", async () => {
+    await service.setInternalCollection("mock", [{ id: "1", string: "hello" }]);
+    const obs = await service.query$<any>("data_list", "app_mock");
+    const data = await firstValueFrom(obs);
+    expect(data).toEqual([{ id: "1", string: "hello" }]);
+  });
+
   // QA
   it("prevents query of non-existent data lists", async () => {
     let errMsg: string;

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -212,11 +212,11 @@ export class DynamicDataService extends AsyncServiceBase {
 
   /**
    * Set the data for an internal data collection
-   * All internal collections are prefixed by `app_` and are only stored ephemerally (not persisted)
+   * All internal collections are prefixed by `_app_` and are only stored ephemerally (not persisted)
    * Data that is set will override any pre-existing data
    **/
   public async setInternalCollection(name: string, data: any[]) {
-    const { collectionName } = await this.ensureCollection("data_list", `app_${name}`);
+    const { collectionName } = await this.ensureCollection("data_list", `_${name}`);
     const collection = this.db.getCollection(collectionName);
     const docs = await collection.find().exec();
     await collection.bulkRemove(docs.map((d) => d.id));
@@ -257,8 +257,8 @@ export class DynamicDataService extends AsyncServiceBase {
    * compatible in case of schema changes
    * */
   private async prepareInitialData(flow_type: FlowTypes.FlowType, flow_name: string) {
-    // Internal `app_` tables are in-memory only and do not have preloaded data or schema
-    if (flow_name.startsWith("app_")) {
+    // Internal tables, prefixed by `_` are in-memory read-only and do not have preloaded data or schema
+    if (flow_name.startsWith("_")) {
       return { data: [], schema: { ...REACTIVE_SCHEMA_BASE } };
     }
 

--- a/src/app/shared/services/userMeta/userMeta.service.ts
+++ b/src/app/shared/services/userMeta/userMeta.service.ts
@@ -77,6 +77,9 @@ export class UserMetaService extends AsyncServiceBase {
 
   /** Import existing user contact fields and replace current user */
   private async importUser(id: string) {
+    if (!id) {
+      throw new Error(`[User Import] no id provided`);
+    }
     try {
       // TODO - get type-safe return types using openapi http client
       const profile = await firstValueFrom(
@@ -87,7 +90,7 @@ export class UserMetaService extends AsyncServiceBase {
         return;
       }
       const { contact_fields, dynamic_data } = profile as any;
-      console.log("[User Import]", { contact_fields, dynamic_data });
+      console.log("[User Import]", profile);
       await this.importUserContactFields(contact_fields);
       await this.importUserDynamicData(dynamic_data);
     } catch (error) {


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Breaking Changes
As part of the work on this PR we need a way to create and expose to author data that has been created as part of internal services (in this case the list of auth profiles available for restoration). 

For convenience, I've kept the same `@data` convention for these internal lists, but used the prefix `app_` to mark as internal, so that the auth service populates an `app_auth_profiles` list that authors can read via `@data.app_auth_profiles`. 

This has the breaking knock-on that means any other lists that an author creates named starting `app_` will not be processed correctly (would be assumed internal and not attempt to load initial data from sheets)

## Description
- Add support for data created by internal app services to be exposed to to authors `@data` references (using prefixed `app_` flow names)
- Provide `app_auth_profiles` table for tracking restorable auth profiles
- Update [example_auth](https://docs.google.com/spreadsheets/d/12xo0ewDN0bbeVrs3klWd9J8DkFQLTCYX1zhGWnovqIo/edit?gid=579616705#gid=579616705) to include profile restore example

## Review Notes
See example in [example_auth](https://docs.google.com/spreadsheets/d/12xo0ewDN0bbeVrs3klWd9J8DkFQLTCYX1zhGWnovqIo/edit?gid=579616705#gid=579616705)

Note - should remove `app_auth_profiles` data_items loop condition to display (set to `false` to avoid breaking work in #2791)


<!--EndFragment-->
</body>
</html>

## Author Notes
As an alternative to the `app_` naming convention we could use a different prefix to access auth restore data, e.g. `@app.auth_profiles` or `@auth.restore_profiles`. Each of these would take a bit of extra refactoring to manage data retrieval from the templating system but could be worthwhile if we expect extending in similar ways in the future.

Additionally the `app_auth_profiles` could be renamed to anything else (keen to keep the `auth_` prefix there to identify the service that creates the data.

As a minor bit of tidying I've renamed the `example_google_auth` sheet to `example_auth` and updated examples
https://docs.google.com/spreadsheets/d/12xo0ewDN0bbeVrs3klWd9J8DkFQLTCYX1zhGWnovqIo/edit?gid=579616705#gid=579616705

Due to a quirk with how contact fields are stored only the `_server_sync_lateste` field currently works to retrieve from contact fields, because all the rest are named `@item.contact_fields.rp-contact-field.some_field` which does not parse in the current templating system (the last `"rp-contact-field.some_field"` is actually a single string not nested json). This could be resolved with proposed changes to item parsing in #2772

It might be worth creating a follow-up issue to consider removing these prefixes when storing on the server (and possibly locally as well as I'm not sure what purpose they really serve currently - originally designed to support multiple apps in same localstorage however this is only used when running on localhost as otherwise all apps have their own per-domain localstorage, and we don't actually use currently)

It would also likely be good to create a follow-up issue that allows a user to fully remove their profile from the server (or at least mark for deletion). This will both help in debugging and also GDPR (currently require manual request for data deletion)

## Dev Notes
Would be good to have additional feedback on the notes outlined in author notes above

## Git Issues

Closes #

## Screenshots/Videos

https://github.com/user-attachments/assets/94db4838-b401-4f6b-8ac5-b5faf1ebf06f


