### PR TITLE
fix(map): handle single selection layer dropdown

### DIFF
--- a/src/app/shared/components/template/components/map/map.component.html
+++ b/src/app/shared/components/template/components/map/map.component.html
@@ -43,7 +43,7 @@
               fill="outline"
               placeholder="Select map layers to view"
               [multiple]="!layerGroup.single_selection"
-              (ionChange)="handleDropdownChange($event, layerGroup.id)"
+              (ionChange)="handleDropdownChange($event.detail.value, layerGroup.id)"
               [value]="getVisibleLayerNames(layerGroup.id)"
             >
               @for (mapLayer of layerGroup.layers; track $index) {

--- a/src/app/shared/components/template/components/map/map.component.ts
+++ b/src/app/shared/components/template/components/map/map.component.ts
@@ -304,21 +304,23 @@ export class TmplMapComponent extends TemplateBaseComponent implements AfterView
     }
   }
 
-  public handleDropdownChange(event: any, layerGroupId?: string) {
-    this.makeLayersVisible(event.detail.value, layerGroupId);
+  public handleDropdownChange(value: string | string[], layerGroupId?: string) {
+    // Value may be a single name string, or an array of name strings
+    const layerNames = Array.isArray(value) ? value : [value];
+    this.makeLayersVisible(layerNames, layerGroupId);
   }
 
-  private makeLayersVisible(layers: string[], layerGroupId?: string) {
+  private makeLayersVisible(layerNames: string[], layerGroupId?: string) {
     if (layerGroupId) {
       const layerGroup = this.mapLayerGroups.find((group) => group.id === layerGroupId);
       layerGroup.layers.forEach((layer) => {
-        this.setLayerVisibility(layer, layers.includes(layer.get("name")));
+        this.setLayerVisibility(layer, layerNames.includes(layer.get("name")));
       });
       return;
     } else {
       for (const layerGroup of this.mapLayerGroups) {
         layerGroup.layers.forEach((layer) => {
-          this.setLayerVisibility(layer, layers.includes(layer.get("name")));
+          this.setLayerVisibility(layer, layerNames.includes(layer.get("name")));
         });
       }
     }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the dropdown for a layer group with a single selection would select multiple layers in the case that one layer name was a substring of another.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
