### PR TITLE
server: increase payload size limit

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -14,8 +14,8 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   // Configure body parser with increased payload size limits
-  app.use(json({ limit: "32mb" }));
-  app.use(urlencoded({ extended: true, limit: "32mb" }));
+  app.use(json({ limit: "2mb" }));
+  app.use(urlencoded({ extended: true, limit: "2mb" }));
 
   app.enableCors();
   // Make available on reverse proxy path (e.g. /api)

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -5,12 +5,18 @@ import { AppModule } from "./app.module";
 import { DBInstance } from "./db";
 import { environment } from "./environment";
 import { version } from "../package.json";
+import { json, urlencoded } from "express";
 
 async function bootstrap() {
   // DB Bootstrap (could be managed outside repo)
   await new DBInstance().setup();
   // API Bootstrap (auto connects to DB)
   const app = await NestFactory.create(AppModule);
+
+  // Configure body parser with increased payload size limits
+  app.use(json({ limit: "32mb" }));
+  app.use(urlencoded({ extended: true, limit: "32mb" }));
+
   app.enableCors();
   // Make available on reverse proxy path (e.g. /api)
   // app.setGlobalPrefix(environment.API_BASE_PATH || "");

--- a/packages/server/docker/docker-compose.yml
+++ b/packages/server/docker/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     #   context: ../../api
     #   dockerfile: Dockerfile
     #   target: prod-env
-    image: idems/apps-api:1.6.0
+    image: idems/apps-api:1.6.1
     env_file:
       - ../../api/.env
     environment:


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

increases the size limit on body payloads posted to API server. This is required to resolve an issue where attempting to sync user data would result in a `413 (Payload Too Large)` response to the POST request to the server.

Solution taken from [this answer](https://stackoverflow.com/a/59978098).

The value of 32mb was chosen to match the `client_max_body_size` as specified in `packages/server/docker/config/nginx/templates/server.conf.template`, but could likely be much lower.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
