### PR TITLE
fix: auth restore profiles order

### DIFF
--- a/src/app/shared/services/auth/auth.service.ts
+++ b/src/app/shared/services/auth/auth.service.ts
@@ -90,7 +90,7 @@ export class AuthService extends AsyncServiceBase {
     const currentUserId = this.localStorageService.getProtected("APP_USER_ID");
     const restoreProfiles = authEntries
       .filter((v) => v.app_user_id !== currentUserId)
-      .sort((a, b) => (a.updatedAt > b.createdAt ? -1 : 1));
+      .sort((a, b) => (a.updatedAt > b.updatedAt ? -1 : 1));
     this.restoreProfiles.set(restoreProfiles);
   }
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes a minor issue where the list of auth profiles available to be restored were not sorted correctly by the `updatedAt` property.

I'm assuming that the original logic was an error as I don't see the significance of the comparison, although I may well be missing something. It's also worth noting that the author can sort the list themselves, see the example of this in the [settings_login](https://docs.google.com/spreadsheets/d/1hy3nSqXZaLjVFRCQgayZjzSMVCX26P3HNuR_KtKjE3c/edit?gid=56143870#gid=56143870) template on the `plh_kids_kw` deployment:

<img width="880" alt="Screenshot 2025-02-24 at 17 40 45" src="https://github.com/user-attachments/assets/5aea4a5c-d873-40fb-beab-e2fdaf51e9ce" />

## Git Issues

Closes #
