### PR TITLE
Feat: user import dynamic data merge strategy

### DIFF
--- a/src/app/feature/user/pages/user-debug/user-debug.page.html
+++ b/src/app/feature/user/pages/user-debug/user-debug.page.html
@@ -90,6 +90,7 @@
     </table>
   </div>
 
+  <!-- Dynamic Data -->
   <h2>Dynamic Data</h2>
   <ion-select
     #dynamicDataSelect
@@ -124,6 +125,12 @@
       </tbody>
     </table>
   </div>
-
   }
+  <div style="display: flex; align-items: center; gap: 8px; margin-top: 1rem">
+    <span>Reset dynamic data:</span>
+    @if (dynamicDataSelected) {
+    <ion-button (click)="resetSelectedDynamicData()">Reset selected data list</ion-button>
+    }
+    <ion-button (click)="resetAllDynamicData()">Reset all</ion-button>
+  </div>
 </ion-content>

--- a/src/app/feature/user/pages/user-debug/user-debug.page.ts
+++ b/src/app/feature/user/pages/user-debug/user-debug.page.ts
@@ -1,4 +1,5 @@
 import { Component, Injector, OnInit, signal } from "@angular/core";
+import { FlowTypes } from "packages/data-models";
 import { TemplateActionService } from "src/app/shared/components/template/services/instance/template-action.service";
 import { TemplateFieldService } from "src/app/shared/components/template/services/template-field.service";
 import { AuthService } from "src/app/shared/services/auth/auth.service";
@@ -82,6 +83,7 @@ export class UserDebugPage implements OnInit {
   /** Prepare table data to display for provided dynamic data entry */
   public setDynamicEntryView(entry?: IDynamicDataEntry) {
     if (entry) {
+      console.log("[USER] entry", entry);
       const rows = Object.values(entry.data);
       this.dynamicDataTable = { headers: Object.keys(rows[0]), rows };
     } else {
@@ -90,6 +92,17 @@ export class UserDebugPage implements OnInit {
   }
   public dynamicEntryCompareFn(a: IDynamicDataEntry, b: IDynamicDataEntry) {
     return a.id === b.id;
+  }
+
+  public async resetSelectedDynamicData() {
+    const { flow_type, flow_name } = this.dynamicDataSelected;
+    await this.dynamicDataService.resetFlow(flow_type as FlowTypes.FlowType, flow_name);
+    location.reload();
+  }
+
+  public async resetAllDynamicData() {
+    await this.dynamicDataService.resetAll();
+    location.reload();
   }
 
   /** Retrieve localStorage entries prefixed by field service prefix */

--- a/src/app/shared/services/dynamic-data/actions/index.ts
+++ b/src/app/shared/services/dynamic-data/actions/index.ts
@@ -29,8 +29,13 @@ export class DynamicDataActionFactory {
   };
 
   public reset_data: IActionHandler = async ({ params }: { params?: IActionResetDataParams }) => {
-    const { _list_id } = this.parseActionParams(params);
-    return this.service.resetFlow("data_list", _list_id);
+    if (!params) {
+      // If no list specified, reset all flows
+      return this.service.resetAll();
+    } else {
+      const { _list_id } = this.parseActionParams(params);
+      return this.service.resetFlow("data_list", _list_id);
+    }
   };
 
   public remove_data: IActionHandler = async ({ params }: { params?: IActionRemoveDataParams }) => {

--- a/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
@@ -155,6 +155,11 @@ export class PersistedMemoryAdapter {
     this.persistStateToDB();
   }
 
+  public async deleteAll() {
+    this.state = {};
+    await this.persistStateToDB();
+  }
+
   /** Trigger persist handler. Requests will be debounced and notified when complete */
   public async persistStateToDB() {
     this.statePersist$.next("pending");
@@ -198,7 +203,7 @@ export class PersistedMemoryAdapter {
     const db = await this.mapDBToObject({});
     const idsToDelete = [];
     for (const flow_type of Object.keys(db)) {
-      const { deleted } = compareObjectKeys(db[flow_type], this.state[flow_type]);
+      const { deleted } = compareObjectKeys(db[flow_type], this.state[flow_type] || {});
       for (const flow_name of deleted) {
         const rowHash = db[flow_type][flow_name];
         for (const row_id of Object.keys(rowHash)) {

--- a/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
@@ -167,6 +167,22 @@ export class PersistedMemoryAdapter {
     await firstValueFrom(this.statePersist$.pipe(filter((v) => v === "complete")));
   }
 
+  /** Return list of all flow name and flow type for each saved flow */
+  public async getAllFlowNamesAndTypes(): Promise<{ flow_type: string; flow_name: string }[]> {
+    const allCollections = Object.values(this.db.collections);
+
+    const allResults = await Promise.all(
+      allCollections.map(async (collection) => {
+        const docs: RxDocument[] = await collection.find().exec();
+        // Since each collection relates to a single flow, just take the first
+        const doc = docs[0].toMutableJSON();
+        const { flow_type, flow_name } = doc as any;
+        return { flow_type, flow_name };
+      })
+    );
+
+    return allResults;
+  }
   /**
    * Subscribe to state persist tracker, handling persist operation
    * when requested and with 500ms debounce between operations

--- a/src/app/shared/services/dynamic-data/adapters/reactiveMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/reactiveMemory.ts
@@ -180,6 +180,10 @@ export class ReactiveMemoryAdapter {
     await this.db.collections[collectionName].remove();
   }
 
+  public async removeAll() {
+    this.db.remove();
+  }
+
   /**
    * Iterate over a document's key-value pairs and populate any properties starting with
    * an underscore to a single top-level APP_META property

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
@@ -88,6 +88,22 @@ describe("DynamicDataService", () => {
     // Not easily possible due to clearCache method used (but removing shows it does work)
   });
 
+  it("persists partial updates to cache", async () => {
+    await service.update("data_list", "test_flow", "id1", { number: 1.1 });
+    await service.update("data_list", "test_flow", "id1", { string: "updated" });
+    const cacheState = await service.getState();
+    expect(cacheState).toEqual({
+      data_list: {
+        test_flow: {
+          id1: {
+            number: 1.1,
+            string: "updated",
+          },
+        },
+      },
+    });
+  });
+
   it("provides live querying", async () => {
     // HACK - ensure any previous data cleared before running test
     await service.resetFlow("data_list", "test_flow");

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -139,8 +139,8 @@ export class DynamicDataService extends AsyncServiceBase {
         const mergedUpdate = deepMergeObjects(data, update);
         // update memory db
         await this.db.updateDoc({ collectionName, id: row_id, data: mergedUpdate });
-        // update persisted db
-        this.writeCache.update({ flow_name, flow_type, id: row_id, data: mergedUpdate });
+        // update persisted db - only use partial update as will be merged
+        this.writeCache.update({ flow_name, flow_type, id: row_id, data: update });
       } else {
         throw new Error(
           `[Update Fail] no doc exists for ${flow_type}:${flow_name} with row_id: ${row_id}`

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -192,6 +192,17 @@ export class DynamicDataService extends AsyncServiceBase {
     }
   }
 
+  /** Remove user writes on all flows */
+  public async resetAll() {
+    try {
+      await this.writeCache.deleteAll();
+      await this.db.removeAll();
+      console.log("[Dynamic Data] All data reset successfully");
+    } catch (error) {
+      console.error("[Dynamic Data] Error resetting all data:", error);
+    }
+  }
+
   /** Access full state of all persisted data layers */
   public async getState() {
     // ensure all writes are complete before returning overall state

--- a/src/app/shared/services/userMeta/userMeta.service.ts
+++ b/src/app/shared/services/userMeta/userMeta.service.ts
@@ -121,6 +121,12 @@ export class UserMetaService extends AsyncServiceBase {
   }
 
   private async importUserDynamicData(dynamic_data?: IDynamicDataState) {
+    /**
+     * Reset all user dynamic data before importing new data
+     * TODO: implement a variety of different merge strategies and expose options to template action
+     */
+    this.dynamicDataService.resetAll();
+
     if (!dynamic_data) return;
     for (const [flow_type, entriesByFlowName] of Object.entries(dynamic_data)) {
       for (const [flow_name, entriesByRowId] of Object.entries(entriesByFlowName)) {


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

When restoring user profile info via the `user: import` template action, the user's dynamic data is now reset before the new data is imported. Previously, the imported data would be merged as updates.

The new underlying logic to reset all dynamic data is exposed in these additional ways:
- Via calling the `reset_data` template action without specifying a `_list_id` to reset
- On the `/user` debug page

## Git Issues

Closes #2810

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
