### PR TITLE
Review: app config sync properties

### DIFF
--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -62,14 +62,6 @@ const NOTIFICATION_DEFAULTS = {
 /** How often to attempt to re-evaluate scheduled notifications - currently every minutes */
 const NOTIFICATIONS_SYNC_FREQUENCY_MS = 1000 * 60 * 3;
 
-const SERVER = {
-  sync: {
-    enabled: true,
-    /** How often to attempt sync - currently every 5mins */
-    frequency: 1000 * 60 * 5,
-  },
-};
-
 const APP_ROUTE_DEFAULTS = {
   /** Default redirect form landing '/' route */
   home_route: "/template/home_screen",
@@ -228,7 +220,6 @@ const APP_CONFIG = {
   LAYOUT,
   NOTIFICATIONS_SYNC_FREQUENCY_MS,
   NOTIFICATION_DEFAULTS,
-  SERVER,
   TASKS,
 };
 

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -3,7 +3,7 @@ import type { IGdriveEntry } from "../@idemsInternational/gdrive-tools";
 import type { IAppConfig, IAppConfigOverride } from "./appConfig";
 
 /** Update version to force recompile next time deployment set (e.g. after default config update) */
-export const DEPLOYMENT_CONFIG_VERSION = 20250202.0;
+export const DEPLOYMENT_CONFIG_VERSION = 20250303.0;
 
 /** Configuration settings available to runtime application */
 export interface IDeploymentRuntimeConfig {
@@ -22,6 +22,8 @@ export interface IDeploymentRuntimeConfig {
      * Will be replaced when running locally as per `src\app\shared\services\server\interceptors.ts`
      * */
     endpoint?: string;
+    /** Frequency (in ms) to attempt syncing data to server. Default 1000 * 60 * 5 (5 mins) */
+    sync_frequency?: number;
   };
   analytics: {
     enabled: boolean;
@@ -195,6 +197,7 @@ export const DEPLOYMENT_RUNTIME_CONFIG_DEFAULTS: IDeploymentRuntimeConfig = {
     enabled: true,
     db_name: "plh",
     endpoint: "https://apps-server.idems.international/api",
+    sync_frequency: 1000 * 60 * 5,
   },
   analytics: {
     enabled: true,

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -301,7 +301,6 @@ export class TemplateActionService extends SyncServiceBase {
         }
         if (emit_value === "server_sync") {
           await this.serverService.syncUserData();
-          await this.dbSyncService.syncToServer();
         }
         if (parent) {
           const msg = ` from ${row?.name || "(no row)"} to parent ${parent?.name || "(no parent)"}`;

--- a/src/app/shared/services/db/db-sync.service.ts
+++ b/src/app/shared/services/db/db-sync.service.ts
@@ -16,6 +16,10 @@ import { DeploymentService } from "../deployment/deployment.service";
 
 @Injectable({ providedIn: "root" })
 /**
+ * Handle syncing local tables to specific server endpoints, such as `feedback` and
+ * `local_notification_interaction`
+ *
+ * NOTE - user profile data is managed separately via the `ServerSyncService`
  *
  * TODOs
  * - Batch update (requires api changes)
@@ -23,12 +27,6 @@ import { DeploymentService } from "../deployment/deployment.service";
  * - 2-way sync (possibly via sync protocol)
  */
 export class DBSyncService extends AsyncServiceBase {
-  syncSchedule;
-  /**
-   * Track whether server sync should be attempted. E.g. can be temporarily disabled on
-   * a given template via template level app config
-   */
-  syncEnabled: boolean;
   constructor(
     private dbService: DbService,
     private http: HttpClient,
@@ -37,10 +35,10 @@ export class DBSyncService extends AsyncServiceBase {
     private deploymentService: DeploymentService
   ) {
     super("DB Sync");
-    this.registerInitFunction(this.inititialise);
+    this.registerInitFunction(this.initialise);
   }
 
-  private async inititialise() {
+  private async initialise() {
     await this.ensureAsyncServicesReady([this.dbService, this.userMetaService]);
     this.ensureSyncServicesReady([this.appConfigService]);
   }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Targets branch of #2822
Refactor server sync frequency to deployment-level API config

## Dev Notes
The main change here is to move the server sync configuration to deployment-level config instead of runtime, as it makes more sense for this to be a fixed value instead of template-dependent. As mentioned in the target issue, if wanting to block syncing for whatever reason I think we should probably build on top of this with a public method and/or authoring action that can disable sync.

I've also refactored the `db-sync.service` a little to share sync schedule with the `server.service`. I was initially confused why there were two services performing similar tasks, but then remembered the original server service was designed for syncing to the `app_users` table and the db-sync any other table (currently `feedback` and `app_notification_interaction`). That being said I think it makes sense to merge these together over time (or provider cleaner separation) as it feels a bit confusing, so for now I've moved all sync scheduling tasks to the server service

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
