### PR TITLE
fix: plh_kids_kw activity lock button position on ios

### DIFF
--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -336,6 +336,8 @@ body[data-theme="plh_facilitator_mx"] {
       }
       .children {
         inset-inline-end: -2px !important;
+        // `top` must be unset explicitly to avoid cascade/inheritance issue on webkit browsers
+        top: unset;
         bottom: 2px !important;
         padding: 0px !important;
       }

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -120,6 +120,8 @@ body[data-theme="plh_kids_kw"] {
       }
       .children {
         inset-inline-end: -2px !important;
+        // `top` must be unset explicitly to avoid cascade/inheritance issue on webkit browsers
+        top: unset;
         bottom: 2px !important;
         padding: 0px !important;
       }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue on the `plh_kids_kw` deployment where the lock icon/favourite toggle that displays within the activity button cards within the [activity_library](https://docs.google.com/spreadsheets/d/1V8iYNvVVc0whiZ3p--ulL_93DiOEH_SKwwwSqLX6OE4/edit?gid=0#gid=0) template would not be positioned as expected on iOS.

## Testing

As this is a minor change, I propose we trust my initial testing and merge. I will publish a build to appetize in anticipation of the next `plh_kids_kw` release, and you can test then @esmeetewinkel 

## Dev notes

The issue is seemingly due to the way that webkit browsers (I was able to replicate on my desktop safari browser) handle cascading and inheritance of multiple stylesheets in terms of setting the `top`, `bottom` etc. positioning properties. It seems webkit browsers do not necessarily unset `top`, for example, in one stylesheet when setting `bottom` explicitly in another. I can't find much documentation on this, but as the immediate issue is resolved I don't think it's worth digging much deeper into.

## Git Issues

Closes #2694

## Screenshots/Videos

The issue resolved in my local emulator:

<img width="280" alt="Screenshot 2025-03-04 at 14 46 08" src="https://github.com/user-attachments/assets/3da847ff-3dbb-4931-b8fe-4fd2117bd5dc" />


