### PR TITLE
feat: reusable-ios-build action

### DIFF
--- a/.github/workflows/reusable-app-build.yml
+++ b/.github/workflows/reusable-app-build.yml
@@ -52,19 +52,21 @@ on:
           description: Optional folder name to upload as additional artifact (e.g. ios/android folders)
           type: string
           default: ""
-  
+        workflow-runner:
+          description: Optionally specify github runner to use for build action
+          type: string
+          default: ubuntu-latest
       outputs:
         GIT_SHA:
           description: "Git SHA of build head"
           value: ${{ jobs.build.outputs.GIT_SHA }}
-  
 jobs:
     build:
       outputs:
         GIT_SHA: ${{ steps.populate.outputs.GIT_SHA }}
       env:
         ARTIFACT: test
-      runs-on: ubuntu-latest
+      runs-on: ${{inputs.workflow-runner}}
 
       steps:
         - name: Check out app code

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -116,14 +116,11 @@ jobs:
       # https://blog.richardszalay.com/2016/08/22/ios-deploy-pipeline-3-setup-and-build-test-phase/
       # https://stackoverflow.com/a/66278353
       - name: Build IOS
-        env:
-          # Supported configurations in IOS project are Debug and Release
-          configuration: Debug
         working-directory: ios/App
         # Call fastlane build_ios_app track
         # https://docs.fastlane.tools/actions/build_ios_app/
         run: |
-          bundle exec fastlane build_ios_app --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true --build_path "./build"
+          bundle exec fastlane build_ios_app --configuration "Release" --scheme "App" --skip_codesigning true --skip_package_ipa true --skip_archive true --build_path "./build" --output_directory "./build"
 
       #############################################################################
       #         Upload
@@ -133,7 +130,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ios_build
-          path: /ios/App/build
+          path: ios
           # you can also archive the entire directory
           retention-days: 30
 

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -47,16 +47,16 @@ jobs:
   #         Build Deployment Web
   #############################################################################
 
-  # build_web:
-  #   uses: ./.github/workflows/reusable-app-build.yml
-  #   with:
-  #     branch: ${{ inputs.branch }}
-  #     post-build-cmd: yarn workflow ios configure && npx cap sync ios
+  build_web:
+    uses: ./.github/workflows/reusable-app-build.yml
+    with:
+      branch: ${{ inputs.branch }}
+      post-build-cmd: yarn workflow ios configure && npx cap sync ios
 
-  #     additional-artifact: ios
-  #     # Ensure build also run on macos to allow npx cap sync to configure ios pods
-  #     workflow-runner: macos-latest
-  #   secrets: inherit
+      additional-artifact: ios
+      # Ensure build also run on macos to allow npx cap sync to configure ios pods
+      workflow-runner: macos-latest
+    secrets: inherit
 
   #############################################################################
   #         Build IOS
@@ -64,7 +64,7 @@ jobs:
 
   build_ios:
     runs-on: macos-latest
-    # needs: build_web
+    needs: build_web
     steps:
       # Checkout builder repo and install node_modules so that they can be used in ios build
       # (e.g. capacitor plugins store podfiles in node_modules)
@@ -77,11 +77,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ios
-          # TODO - revert after debugging
-          #   NOTE - need to explicitly include token to download from a different workflow run
+          # Debug - use fixed build artifact (can skip build_web). Needs explicit token set
           # https://github.com/actions/download-artifact/issues/320
-          github-token: ${{ github.token }}
-          run-id: 13732579493
+          # github-token: ${{ github.token }}
+          # run-id: 13732579493
 
       # Remove default ios folder and replace with artifact generated
       - name: Setup IOS folder

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -80,7 +80,7 @@ jobs:
           # Use build artifact generated either as part of this run or from previous run (if debug run id set)
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          run-id: 13744145866
+          run-id: 13743953801
 
       # Remove default ios folder and replace with artifact generated
       - name: Setup IOS folder

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -80,32 +80,32 @@ jobs:
           tar -xf artifact.tar --directory ios
           ls ios
 
+      # Create a ruby gemfile declaring fastlane dep for install. This will be auto-installed
+      # via the setup-ruby command. This file could also be created and comitted to core repo is required
+      - name: Add fastlane gem
+        run: |
+          touch Gemfile
+          echo 'source "https://rubygems.org"' > Gemfile
+          echo 'gem "fastlane"' > Gemfile
+
       # Setup ruby. This will also default install the Gemfile in the ios folder which includes fastlane
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.0"
           bundler-cache: true
-        env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
-          BUNDLE_GEMFILE: ${{ github.workspace }}/ios/Gemfile
 
-          # Could not determine gemfile path, skipping "bundle install" and caching
-          # TODO - likely needs gemfile lock
-
+      # Call fastlane build_ios_app track
       # https://docs.fastlane.tools/actions/build_ios_app/
       - name: Build IOS
         env:
-          workspace: App/App.xcworkspace
           configuration: debug
-          scheme: "App"
-          output_name: "app.ipa"
           sdk: "iOS 11.1"
-        working-directory: ios
+        working-directory: ios/App
         run: |
           bundle exec fastlane run build_ios_app 
-          --workspace "${{env.workspace}}"
           --configuration "${{env.configuration}}"
-          --scheme "${{env.scheme}}"
-          --output_name "${{env.output_name}}"
+          --scheme "App"
+          --output_name "app.ipa"
           --sdk "${{env.sdk}}"
 
     # TODO - google plist

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           node-version: 20.17.0
           cache: yarn
-      - run: yarn install
+      - run: yarn workspaces focus --production
 
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
@@ -81,10 +81,14 @@ jobs:
           github-token: ${{ github.token }}
           run-id: 13732579493
 
+      # Merge built ios artifact with repo default
+      # NOTE - this is handled manually instead of via npx cap sync to ensure deployment-specific
+      # capacitor.config.json included
       - name: Extract Build folder
         run: |
-          mkdir ios
-          tar -xf artifact.tar --directory ios
+          mkdir tmp
+          tar -xf artifact.tar --directory tmp
+          cp -R tmp/* ios/*
           ls ios
 
       # Create a ruby gemfile declaring fastlane dep for install. This will be auto-installed

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -123,6 +123,7 @@ jobs:
           --scheme "App"
           --sdk "${{env.sdk}}"
           --skip_codesigning true
+          --skip_package_ipa true
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,17 +52,17 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  build_web:
-    uses: ./.github/workflows/reusable-app-build.yml
-    with:
-      branch: ${{ inputs.branch }}
-      post-build-cmd: npx cap sync ios
-      additional-artifact: ios
-    secrets: inherit
+  # build_web:
+  #   uses: ./.github/workflows/reusable-app-build.yml
+  #   with:
+  #     branch: ${{ inputs.branch }}
+  #     post-build-cmd: npx cap sync ios
+  #     additional-artifact: ios
+  #   secrets: inherit
 
   debug:
     runs-on: macos-latest
-    needs: build_web
+    # needs: build_web
     steps:
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
@@ -72,7 +72,7 @@ jobs:
           #   NOTE - need to explicitly include token to download from a different workflow run
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          # run-id: 13729563778
+          run-id: 13731332844
 
       - name: Extract Build folder
         run: |
@@ -85,7 +85,8 @@ jobs:
         with:
           ruby-version: "3.0"
           bundler-cache: true
-          working-directory: ios
+        env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
+          BUNDLE_GEMFILE: ${{ github.workspace }}/ios/Gemfile
 
           # Could not determine gemfile path, skipping "bundle install" and caching
           # TODO - likely needs gemfile lock

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -68,10 +68,6 @@ jobs:
         with:
           repository: "IDEMSInternational/open-app-builder.git"
           ref: ${{env.APP_CODE_BRANCH}}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20.17.0
-          cache: yarn
 
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
@@ -122,6 +118,10 @@ jobs:
       #     bundle exec fastlane run disable_automatic_code_signing
 
       # Install node_module dependencies (includes capacitor plugin pods required for build)
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+          cache: yarn
       - run: yarn workspaces focus --production
 
       # Call fastlane build_ios_app track

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -60,6 +60,17 @@ jobs:
     runs-on: macos-latest
     # needs: build_web
     steps:
+      # TODO - still need to install node_modules for use in build
+      - uses: actions/checkout@v4
+        with:
+          repository: "IDEMSInternational/open-app-builder.git"
+          ref: ${{env.APP_CODE_BRANCH}}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+          cache: yarn
+      - run: yarn install
+
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
         with:
@@ -95,6 +106,7 @@ jobs:
         # https://docs.fastlane.tools/codesigning/getting-started/
 
       # TODO - still need to use app store connect to manage
+      # TODO - when passing commands via fastlane run needs formatting differently (should test without run)
       # - name: Setup development certificates
       #   working-directory: ios/App
       #   env:

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           node-version: 20.17.0
           cache: yarn
-      - run: yarn workspaces focus --production
+      - run: yarn workspaces focus frontend --production
 
       # Attempt to create an unsigned build for local testing
       # https://blog.richardszalay.com/2016/08/22/ios-deploy-pipeline-3-setup-and-build-test-phase/
@@ -123,7 +123,7 @@ jobs:
         # Call fastlane build_ios_app track
         # https://docs.fastlane.tools/actions/build_ios_app/
         run: |
-          bundle exec fastlane build_ios_app --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true --output_directory "build"
+          bundle exec fastlane build_ios_app --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true
 
       #############################################################################
       #         Upload
@@ -132,8 +132,8 @@ jobs:
       - name: Upload application
         uses: actions/upload-artifact@v4
         with:
-          name: app
-          path: ios/App/build
+          name: xcode_archive
+          path: /Users/runner/Library/Developer/Xcode/Archives
           # you can also archive the entire directory
           retention-days: 30
 

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -20,6 +20,10 @@ env:
   GOOGLE_SERVICES_JSON: ${{secrets.GOOGLE_SERVICES_JSON}}
   GOOGLE_SERVICES_PLIST: ${{secrets.GOOGLE_SERVICES_PLIST}}
 
+  # If debugging can use build from previous run and skip build_web step
+  # Build artifacts expire after 24h so will need updating
+  DEBUG_RUN_ID: 13744145866
+
   ##################################################################################
   #         Main Code
   ##################################################################################
@@ -48,6 +52,7 @@ jobs:
   #############################################################################
 
   build_web:
+    if: ${{!github.env.DEBUG_RUN_ID}}
     uses: ./.github/workflows/reusable-app-build.yml
     with:
       branch: ${{ inputs.branch }}
@@ -77,10 +82,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ios
-          # Debug - use fixed build artifact (can skip build_web). Needs explicit token set
+          # Use build artifact generated either as part of this run or from previous run (if debug run id set)
           # https://github.com/actions/download-artifact/issues/320
-          # github-token: ${{ github.token }}
-          # run-id: 13732579493
+          github-token: ${{ github.token }}
+          run-id: ${{env.DEBUG_RUN_ID || github.run_id}}
 
       # Remove default ios folder and replace with artifact generated
       - name: Setup IOS folder
@@ -123,7 +128,7 @@ jobs:
         # Call fastlane build_ios_app track
         # https://docs.fastlane.tools/actions/build_ios_app/
         run: |
-          bundle exec fastlane build_ios_app --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true
+          bundle exec fastlane build_ios_app --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true --build_path "./build"
 
       #############################################################################
       #         Upload
@@ -132,8 +137,8 @@ jobs:
       - name: Upload application
         uses: actions/upload-artifact@v4
         with:
-          name: xcode_archive
-          path: /Users/runner/Library/Developer/Xcode/Archives
+          name: ios_build
+          path: /ios/App/build
           # you can also archive the entire directory
           retention-days: 30
 

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -116,68 +116,82 @@ jobs:
       # https://github.com/fastlane/fastlane/discussions/21996
       # https://blog.richardszalay.com/2016/08/22/ios-deploy-pipeline-3-setup-and-build-test-phase/
       # https://stackoverflow.com/a/66278353
-      - name: Build IOS
+      - name: Build IOS (simulator)
         working-directory: ios/App
+        env:
+          # Common args used to create unsigned builds (simulator or xcarchive)
+          CODE_SIGNING_ARGS: --skip_codesigning true --skip_package_ipa true
+          # Args to create simulator build. Output format will be .app
+          SIMULATOR_BUILD_ARGS: --destination "generic/platform=iOS Simulator" --derived_data_path "./output/data" --skip_archive true
+
         # Call fastlane build_ios_app track
         # https://docs.fastlane.tools/actions/build_ios_app/
         run: |
-          bundle exec fastlane build_ios_app --configuration "Release" --scheme "App" --destination "generic/platform=iOS Simulator" --skip_codesigning true --skip_package_ipa true --skip_archive true --build_path "./build" --output_directory "./build/output" --derived_data_path "./build/data"
+          bundle exec fastlane build_ios_app --configuration "Release" --scheme "App" ${{env.CODE_SIGNING_ARGS}} ${{env.SIMULATOR_BUILD_ARGS}}
 
       #############################################################################
       #         Upload
+      # This will export an xcarchive that can be signed manually
       #############################################################################
 
-      - name: Upload application
+      - name: Upload build
         uses: actions/upload-artifact@v4
         with:
-          name: ios_build
-          path: ios/App/build
+          name: simulator_app
+          path: ios/App/output/data/Build/Products/Release-iphonesimulator/*.app
           # you can also archive the entire directory
           retention-days: 30
 
-    #############################################################################
-    #         TODO - IOS Deploy Testflight
-    # Possibly separate action to testflight deployment]
-    # Will need to use production code-signing methods (e.g. match or manual p12)
-    # https://docs.fastlane.tools/codesigning/getting-started/
-    #############################################################################
+          #############################################################################
+          #         TODO - IOS Deploy Testflight
+          # Possibly separate action to testflight deployment]
+          # Will need to use production code-signing methods (e.g. match or manual p12)
+          # https://docs.fastlane.tools/codesigning/getting-started/
+          #############################################################################
 
-    # env:
-    # IOS_FASTLANE_MATCH_GCS_SERVICE_JSON: ${{secrets.IOS_FASTLANE_MATCH_GCS_SERVICE_JSON}}
+          # env:
+          # IOS_FASTLANE_MATCH_GCS_SERVICE_JSON: ${{secrets.IOS_FASTLANE_MATCH_GCS_SERVICE_JSON}}
 
-    # IOS_CODE_SIGNING_IDENTITY: ${{ secrets.IOS_CODE_SIGNING_IDENTITY }}
-    # IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
+          # IOS_CODE_SIGNING_IDENTITY: ${{ secrets.IOS_CODE_SIGNING_IDENTITY }}
+          # IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
 
-    # IOS_MOBILEPROVISION_BASE64: ${{secrets.IOS_MOBILEPROVISION_BASE64}}
-    # # Combined P12 key+cert encoded as base64
-    # IOS_P12_BASE64: ${{secrets.IOS_P12_BASE64}}
-    # IOS_P12_PASSWORD: ${{secrets.IOS_P12_PASSWORD}}
+          # IOS_MOBILEPROVISION_BASE64: ${{secrets.IOS_MOBILEPROVISION_BASE64}}
+          # # Combined P12 key+cert encoded as base64
+          # IOS_P12_BASE64: ${{secrets.IOS_P12_BASE64}}
+          # IOS_P12_PASSWORD: ${{secrets.IOS_P12_PASSWORD}}
 
-    # https://docs.fastlane.tools/codesigning/getting-started/
+          # https://docs.fastlane.tools/codesigning/getting-started/
 
-    # TODO - still need to use app store connect to manage
-    # TODO - when passing commands via fastlane run needs formatting differently (should test without run)
-    # - name: Setup development certificates
-    #   working-directory: ios/App
-    #   env:
-    #     IOS_USERNAME: "example@idems.international"
-    #   run: |
-    #     mkdir fastlane
-    #     bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock, default_keychain
-    #     bundle exec fastlane run get_certificates username:"${{env.IOS_USERNAME}}", development, force
-    #     bundle exec fastlane run get_provisioning_profile
-    #     bundle exec fastlane run disable_automatic_code_signing
+          # TODO - still need to use app store connect to manage
+          # TODO - when passing commands via fastlane run needs formatting differently (should test without run)
+          # - name: Setup development certificates
+          #   working-directory: ios/App
+          #   env:
+          #     IOS_USERNAME: "example@idems.international"
+          #   run: |
+          #     mkdir fastlane
+          #     bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock, default_keychain
+          #     bundle exec fastlane run get_certificates username:"${{env.IOS_USERNAME}}", development, force
+          #     bundle exec fastlane run get_provisioning_profile
+          #     bundle exec fastlane run disable_automatic_code_signing
 
-    # - name: Setup Fastlane Match
-    #   working-directory: ios/App/fastlane
-    #   run: |
-    #     echo 'google_cloud_bucket_name("${{env.IOS_FASTLANE_MATCH_GCS_BUCKET_NAME}}")' > Matchfile
-    #     echo 'storage_mode("google_cloud")' >> Matchfile
-    #     echo 'type("development")' >> Matchfile'
+          # - name: Setup Fastlane Match
+          #   working-directory: ios/App/fastlane
+          #   run: |
+          #     echo 'google_cloud_bucket_name("${{env.IOS_FASTLANE_MATCH_GCS_BUCKET_NAME}}")' > Matchfile
+          #     echo 'storage_mode("google_cloud")' >> Matchfile
+          #     echo 'type("development")' >> Matchfile'
 
-    #
-    # - name: Setup IOS Certs
-    #   run: |
-    #     echo ${{env.IOS_P12_BASE64}} | base64 --decode > cert.p12
-    #     bundle exec fastlane create_keychain --name "temp.keychain" --password "temp1234" --unlock true --default-keychain true
-    #     bundle exec import_certificate --certificate_path cert.p12 --certificate_password "${{env.IOS_P12_PASSWORD}}"
+          #
+          # - name: Setup IOS Certs
+          #   run: |
+          #     echo ${{env.IOS_P12_BASE64}} | base64 --decode > cert.p12
+          #     bundle exec fastlane create_keychain --name "temp.keychain" --password "temp1234" --unlock true --default-keychain true
+          #     bundle exec import_certificate --certificate_path cert.p12 --certificate_password "${{env.IOS_P12_PASSWORD}}"
+
+          # TODO - possible config to build xcarchive file that could be signed into IPA after download
+          # https://stackoverflow.com/a/66278353
+          # XCARCHIVE_BUILD_ARGS: --archive_path "./output/archive"
+
+          # TODO - review args required if building signed IPA
+          # IPA_BUILD_ARGS: --build_path "./output/build" --output_directory "./output/output"

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -62,17 +62,24 @@ jobs:
     runs-on: macos-latest
     # needs: build_web
     steps:
-      # TODO - still need to install node_modules for use in build
-      # TODO - copy google plist
+      # checkout and install just the node_modules from the main repo
+      # so that they can be used as part of the ios build process
+      # (capacitor keeps pod files in node_modules)
       - uses: actions/checkout@v4
         with:
           repository: "IDEMSInternational/open-app-builder.git"
           ref: ${{env.APP_CODE_BRANCH}}
+          filter: yarn.lock
       - uses: actions/setup-node@v4
         with:
           node-version: 20.17.0
           cache: yarn
-      - run: yarn workspaces focus --production
+      - name: Install IOS node_modules
+        env:
+          REMOTE: https://github.com/IDEMSInternational/open-app-builder.git
+        run: |
+          git archive --remote=${{env.REMOTE}} HEAD yarn.lock | tar -x
+          yarn workspaces focus --production
 
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
@@ -89,9 +96,8 @@ jobs:
       # capacitor.config.json included
       - name: Setup IOS folder
         run: |
-          mkdir tmp
-          tar -xf artifact.tar --directory tmp
-          cp -R tmp/* ios/
+          mkdir ios
+          tar -xf artifact.tar --directory ios
           echo ${{env.GOOGLE_SERVICES_PLIST}} > ios/App/App/GoogleService-Info.plist
           ls ios/App/App
 

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -47,16 +47,16 @@ jobs:
   #         Build Deployment Web
   #############################################################################
 
-  # build_web:
-  #   uses: ./.github/workflows/reusable-app-build.yml
-  #   with:
-  #     branch: ${{ inputs.branch }}
-  #     post-build-cmd: yarn workflow ios configure && npx cap sync ios
-  #     # Upload ios directory as it includes configured template files and www content
-  #     additional-artifact: ios
-  #     # Ensure build also run on macos to allow npx cap sync to configure ios pods
-  #     workflow-runner: macos-latest
-  #   secrets: inherit
+  build_web:
+    uses: ./.github/workflows/reusable-app-build.yml
+    with:
+      branch: ${{ inputs.branch }}
+      post-build-cmd: yarn workflow ios configure && npx cap sync ios
+      # Upload ios directory as it includes configured template files and www content
+      additional-artifact: ios
+      # Ensure build also run on macos to allow npx cap sync to configure ios pods
+      workflow-runner: macos-latest
+    secrets: inherit
 
   #############################################################################
   #         Build IOS
@@ -64,7 +64,7 @@ jobs:
 
   build_ios:
     runs-on: macos-latest
-    # needs: build_web
+    needs: build_web
     steps:
       # Checkout builder repo and install node_modules so that they can be used in ios build
       # (e.g. capacitor plugins store podfiles in node_modules)
@@ -80,7 +80,7 @@ jobs:
           # Use build artifact generated either as part of this run or from previous run (if debug run id set)
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          run-id: 13743953801
+          # run-id: 13743953801
 
       # Remove default ios folder and replace with artifact generated
       - name: Setup IOS folder

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,19 +52,18 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  # build_web:
-  #   uses: ./.github/workflows/reusable-app-build.yml
-  #   with:
-  #     branch: ${{ inputs.branch }}
-  #     post-build-cmd: npx cap sync ios
-  #     additional-artifact: ios
-  #   secrets: inherit
+  build_web:
+    uses: ./.github/workflows/reusable-app-build.yml
+    with:
+      branch: ${{ inputs.branch }}
+      post-build-cmd: npx cap sync ios
+      additional-artifact: ios
+    secrets: inherit
 
   debug:
     runs-on: macos-latest
-    # needs: build_web
+    needs: build_web
     steps:
-      - uses: actions/checkout@v4
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
         with:
@@ -73,12 +72,11 @@ jobs:
           #   NOTE - need to explicitly include token to download from a different workflow run
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          run-id: 13729563778
+          # run-id: 13729563778
 
-      # Extract contents from the ios artifact into the repo ios folder. This will populate
-      # files previously copied via `npx cap sync ios` post-build command
       - name: Extract Build folder
         run: |
+          mkdir ios
           tar -xf artifact.tar --directory ios
           ls ios
 

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -86,19 +86,35 @@ jobs:
         with:
           ruby-version: "3.0"
           bundler-cache: true
-          working-directory: ios/App
+          working-directory: ios
 
-      # https://docs.fastlane.tools/actions/build_ios_app/
-      - uses: maierj/fastlane-action@v3.1.0
+      - name: Build IOS
         env:
-          workspace: App.xcworkspace
+          workspace: App/App.xcworkspace
           configuration: debug
           scheme: "App"
           output_name: "app.ipa"
           sdk: "iOS 11.1"
-        with:
-          lane: build_ios_app
-          subdirectory: ios/App
+        working-directory: ios
+        run: |
+          fastlane run build_ios_app 
+          --workspace "${{env.workspace}}"
+          --configuration "${{env.configuration}}"
+          --scheme "${{env.scheme}}"
+          --output_name "${{env.output_name}}"
+          --sdk "${{env.sdk}}"
+
+      # https://docs.fastlane.tools/actions/build_ios_app/
+      # - uses: maierj/fastlane-action@v3.1.0
+      #   env:
+      #     workspace: App/App.xcworkspace
+      #     configuration: debug
+      #     scheme: "App"
+      #     output_name: "app.ipa"
+      #     sdk: "iOS 11.1"
+      #   with:
+      #     lane: build_ios_app
+      #     subdirectory: ios
           options: '{"workspace": "${{env.workspace}}","configuration": "${{env.configuration}}","scheme": "${{env.scheme}}","output_name": "${{env.output_name}}","sdk": "${{env.sdk}}"}'
 
     # TODO - google plist

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -51,6 +51,11 @@ jobs:
   #         Build Deployment Web
   #############################################################################
 
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{github.env.DEBUG_RUN_ID}} ${{!github.env.DEBUG_RUN_ID}}
+
   build_web:
     if: ${{!github.env.DEBUG_RUN_ID}}
     uses: ./.github/workflows/reusable-app-build.yml

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -62,16 +62,17 @@ jobs:
     runs-on: macos-latest
     # needs: build_web
     steps:
+      # Checkout builder repo and install node_modules so that they can be used in ios build
+      # (e.g. capacitor plugins store podfiles in node_modules)
+      - uses: actions/checkout@v4
+        with:
+          repository: "IDEMSInternational/open-app-builder.git"
+          ref: ${{env.APP_CODE_BRANCH}}
       - uses: actions/setup-node@v4
         with:
           node-version: 20.17.0
           cache: yarn
-      - name: Install IOS node_modules
-        env:
-          REMOTE: https://github.com/IDEMSInternational/open-app-builder.git
-        run: |
-          git archive --remote=${{env.REMOTE}} HEAD yarn.lock | tar -x
-          yarn workspaces focus --production
+      - run: yarn workspaces focus --production
 
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
@@ -83,12 +84,10 @@ jobs:
           github-token: ${{ github.token }}
           run-id: 13732579493
 
-      # Merge built ios artifact with repo default. Populate google-services plist
-      # NOTE - this is handled manually instead of via npx cap sync to ensure deployment-specific
-      # capacitor.config.json included
+      # Remove default ios folder and replace with artifact generated
       - name: Setup IOS folder
         run: |
-          mkdir ios
+          rm -R ios/*
           tar -xf artifact.tar --directory ios
           echo ${{env.GOOGLE_SERVICES_PLIST}} > ios/App/App/GoogleService-Info.plist
           ls ios/App/App

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -84,9 +84,9 @@ jobs:
       # via the setup-ruby command. This file could also be created and comitted to core repo is required
       - name: Add fastlane gem
         run: |
-          touch Gemfile
           echo 'source "https://rubygems.org"' > Gemfile
-          echo 'gem "fastlane"' > Gemfile
+          echo 'gem "fastlane"' >> Gemfile
+          cat Gemfile
 
       # Setup ruby. This will also default install the Gemfile in the ios folder which includes fastlane
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -99,14 +99,7 @@ jobs:
         with:
           lane: build_ios_app
           subdirectory: ios/App
-          options: |
-            {
-              "workspace": "${{env.workspace}}",
-              "configuration": "${{env.configuration}}",
-              "scheme": "${{env.scheme}}",
-              "output_name": "${{env.output_name}}",
-              "sdk": "${{env.sdk}}",
-            }
+          options: '{"workspace": "${{env.workspace}}","configuration": "${{env.configuration}}","scheme": "${{env.scheme}}","output_name": "${{env.output_name}}","sdk": "${{env.sdk}}"}'
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,13 +52,13 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  #   build_web:
-  #     uses: ./.github/workflows/reusable-app-build.yml
-  #     with:
-  #       branch: ${{ inputs.branch }}
-  #       post-build-cmd: npx cap sync ios
-  #       additional-artifact: ios
-  #     secrets: inherit
+  build_web:
+    uses: ./.github/workflows/reusable-app-build.yml
+    with:
+      branch: ${{ inputs.branch }}
+      post-build-cmd: npx cap sync ios
+      additional-artifact: ios
+    secrets: inherit
 
   debug:
     runs-on: macos-latest
@@ -72,12 +72,11 @@ jobs:
           #   NOTE - need to explicitly include token to download from a different workflow run
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          run-id: 13727815102
+          # run-id: 13727815102
         #   https://github.com/IDEMSInternational/app-debug-content/actions/runs/13727815102/artifacts/2713158337
 
       - name: Extract Build folder
         run: |
-          ls -R
           mkdir ios
           tar -xf artifact.tar --directory ios
           ls -R
@@ -87,6 +86,9 @@ jobs:
           ruby-version: "3.0"
           bundler-cache: true
           working-directory: ios
+
+          # Could not determine gemfile path, skipping "bundle install" and caching
+          # TODO - likely needs gemfile lock
 
       # https://docs.fastlane.tools/actions/build_ios_app/
       - name: Build IOS

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -102,11 +102,14 @@ jobs:
           bundler-cache: true
           working-directory: ios/App
 
+        # https://docs.fastlane.tools/codesigning/getting-started/
+
       - name: Setup development certificates
         run: |
           bundle exec fastlane create_keychain --name "temp.keychain" --password "temp1234" --unlock true --default-keychain true
-          bundle exec fastlane run cert --development true
-          bundle exec fastlane run sigh --development true
+          bundle exec fastlane run get_certificates
+          bundle exec fastlane run get_provisioning_profile
+          bundle exec fastlane run disable_automatic_code_signing
 
       # - name: Setup Fastlane Match
       #   working-directory: ios/App

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -111,19 +111,15 @@ jobs:
 
       # Attempt to create an unsigned build for local testing
       # https://blog.richardszalay.com/2016/08/22/ios-deploy-pipeline-3-setup-and-build-test-phase/
+      # https://stackoverflow.com/a/66278353
       - name: Build IOS
         env:
           # Supported configurations in project are Debug and Release
           configuration: Debug
-          sdk: "iOS 11.1"
         working-directory: ios/App
         run: |
-          bundle exec fastlane run build_ios_app
-          --configuration "${{env.configuration}}"
-          --scheme "App"
-          --sdk "${{env.sdk}}"
-          --skip_codesigning true
-          --skip_package_ipa true
+          bundle exec fastlane run build_ios_app \
+          --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,17 +52,19 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  # build_web:
-  #   uses: ./.github/workflows/reusable-app-build.yml
-  #   with:
-  #     branch: ${{ inputs.branch }}
-  #     post-build-cmd: yarn workflow ios configure && npx cap sync ios
-  #     additional-artifact: ios
-  #   secrets: inherit
+  build_web:
+    uses: ./.github/workflows/reusable-app-build.yml
+    with:
+      branch: ${{ inputs.branch }}
+      post-build-cmd: yarn workflow ios configure && npx cap sync ios
+      additional-artifact: ios
+      # Ensure build also run on macos to allow npx cap sync to configure ios pods
+      workflow-runner: macos-latest
+    secrets: inherit
 
   debug:
     runs-on: macos-latest
-    # needs: build_web
+    needs: build_web
     steps:
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
@@ -72,7 +74,7 @@ jobs:
           #   NOTE - need to explicitly include token to download from a different workflow run
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          run-id: 13731930921
+          # run-id: 13731930921
 
       - name: Extract Build folder
         run: |

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -99,7 +99,14 @@ jobs:
         with:
           lane: build_ios_app
           subdirectory: ios/App
-          options: '{"workspace": "${{env.workspace}}","configuration": "${{env.configuration}}","scheme": "${{env.scheme}}","output_name": "${{env.output_name}}","sdk": "${{env.sdk}}"}'
+          options: |
+            '{
+            "workspace": "${{env.workspace}}",
+            "configuration": "${{env.configuration}}",
+            "scheme": "${{env.scheme}}",
+            "output_name": "${{env.output_name}}",
+            "sdk": "${{env.sdk}}"
+            }'
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,18 +52,19 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  build_web:
-    uses: ./.github/workflows/reusable-app-build.yml
-    with:
-      branch: ${{ inputs.branch }}
-      post-build-cmd: npx cap sync ios
-      additional-artifact: ios
-    secrets: inherit
+  # build_web:
+  #   uses: ./.github/workflows/reusable-app-build.yml
+  #   with:
+  #     branch: ${{ inputs.branch }}
+  #     post-build-cmd: npx cap sync ios
+  #     additional-artifact: ios
+  #   secrets: inherit
 
   debug:
     runs-on: macos-latest
-    needs: build_web
+    # needs: build_web
     steps:
+      - uses: actions/checkout@v4
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
         with:
@@ -72,11 +73,12 @@ jobs:
           #   NOTE - need to explicitly include token to download from a different workflow run
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          # run-id: 13729563778
+          run-id: 13729563778
 
+      # Extract contents from the ios artifact into the repo ios folder. This will populate
+      # files previously copied via `npx cap sync ios` post-build command
       - name: Extract Build folder
         run: |
-          mkdir ios
           tar -xf artifact.tar --directory ios
           ls ios
 

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -59,7 +59,7 @@ jobs:
       should_build: ${{steps.should_build.outputs.should_build}}
     steps:
       - id: should_build
-        run: echo "should_build=${{github.env.DEBUG_RUN_ID==''}}" >> "$GITHUB_OUTPUT"
+        run: echo "should_build=${{!env.DEBUG_RUN_ID}}" >> "$GITHUB_OUTPUT"
 
   build_web:
     if: needs.should_build.outputs.should_build

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -118,11 +118,7 @@ jobs:
           configuration: Debug
         working-directory: ios/App
         run: |
-          bundle exec fastlane run build_ios_app \
-          configuration:"${{env.configuration}}" \
-          scheme:"App" \
-          skip_codesigning \
-          skip_package_ipa
+          bundle exec fastlane build_ios_app --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -105,25 +105,12 @@ jobs:
         # https://docs.fastlane.tools/codesigning/getting-started/
 
       - name: Setup development certificates
+        working-directory: ios/App
         run: |
           bundle exec fastlane create_keychain --name "temp.keychain" --password "temp1234" --unlock true --default-keychain true
           bundle exec fastlane run get_certificates
           bundle exec fastlane run get_provisioning_profile
           bundle exec fastlane run disable_automatic_code_signing
-
-      # - name: Setup Fastlane Match
-      #   working-directory: ios/App
-      #   run: |
-      #     echo 'google_cloud_bucket_name("c2dev-fastlane-match-certs")' > Matchfile
-      #     echo 'storage_mode("google_cloud")' >> Matchfile
-      #     echo 'type("development")' >> Matchfile'
-
-      #
-      # - name: Setup IOS Certs
-      #   run: |
-      #     echo ${{env.IOS_P12_BASE64}} | base64 --decode > cert.p12
-      #     bundle exec fastlane create_keychain --name "temp.keychain" --password "temp1234" --unlock true --default-keychain true
-      #     bundle exec import_certificate --certificate_path cert.p12 --certificate_password "${{env.IOS_P12_PASSWORD}}"
 
       # Call fastlane build_ios_app track
       # https://docs.fastlane.tools/actions/build_ios_app/
@@ -157,3 +144,24 @@ jobs:
     #       # you can also archive the entire directory
     #       # path: ${{ runner.temp }}/build
     #       retention-days: 3
+
+    #############################################################################
+    #         TODO - IOS Deploy Testflight
+    # Possibly separate action to testflight deployment]
+    # Will need to use production code-signing methods (e.g. match or manual p12)
+    # https://docs.fastlane.tools/codesigning/getting-started/
+    #############################################################################
+
+    # - name: Setup Fastlane Match
+    #   working-directory: ios/App
+    #   run: |
+    #     echo 'google_cloud_bucket_name("${{env.IOS_FASTLANE_MATCH_GCS_BUCKET_NAME}}")' > Matchfile
+    #     echo 'storage_mode("google_cloud")' >> Matchfile
+    #     echo 'type("development")' >> Matchfile'
+
+    #
+    # - name: Setup IOS Certs
+    #   run: |
+    #     echo ${{env.IOS_P12_BASE64}} | base64 --decode > cert.p12
+    #     bundle exec fastlane create_keychain --name "temp.keychain" --password "temp1234" --unlock true --default-keychain true
+    #     bundle exec import_certificate --certificate_path cert.p12 --certificate_password "${{env.IOS_P12_PASSWORD}}"

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -113,6 +113,7 @@ jobs:
       - run: yarn workspaces focus frontend --production
 
       # Attempt to create an unsigned build for local testing
+      # https://github.com/fastlane/fastlane/discussions/21996
       # https://blog.richardszalay.com/2016/08/22/ios-deploy-pipeline-3-setup-and-build-test-phase/
       # https://stackoverflow.com/a/66278353
       - name: Build IOS
@@ -120,7 +121,7 @@ jobs:
         # Call fastlane build_ios_app track
         # https://docs.fastlane.tools/actions/build_ios_app/
         run: |
-          bundle exec fastlane build_ios_app --configuration "Release" --scheme "App" --skip_codesigning true --skip_package_ipa true --skip_archive true --build_path "./build" --output_directory "./build"
+          bundle exec fastlane build_ios_app --configuration "Release" --scheme "App" --destination "generic/platform=iOS Simulator" --skip_codesigning true --skip_package_ipa true --skip_archive true --build_path "./build" --output_directory "./build" --derived_data_path "./build"
 
       #############################################################################
       #         Upload

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -96,10 +96,12 @@ jobs:
 
       - name: Setup development certificates
         working-directory: ios/App
+        env:
+          IOS_USERNAME: "example@idems.international"
         run: |
           mkdir fastlane
           bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock, default_keychain
-          bundle exec fastlane run get_certificates
+          bundle exec fastlane run get_certificates username:"${{env.IOS_USERNAME}}", development
           bundle exec fastlane run get_provisioning_profile
           bundle exec fastlane run disable_automatic_code_signing
 

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -88,8 +88,7 @@ jobs:
         run: |
           rm -R ios/*
           tar -xf artifact.tar --directory ios
-          echo $GOOGLE_SERVICES_PLIST > ios/App/App/GoogleService-Info.plist
-          ls ios/App/App
+          echo ${{env.GOOGLE_SERVICES_PLIST}} > ios/App/App/GoogleService-Info.plist
 
       # Create a ruby gemfile declaring fastlane dep for install. This will be auto-installed
       # via the setup-ruby command. This file could also be created and committed to core repo is required

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -19,11 +19,15 @@ env:
 
   GOOGLE_SERVICES_JSON: ${{secrets.GOOGLE_SERVICES_JSON}}
 
-  IOS_CODE_SIGNING_IDENTITY: ${{ secrets.IOS_CODE_SIGNING_IDENTITY }}
-  IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
+  # IOS_FASTLANE_MATCH_GCS_SERVICE_JSON: ${{secrets.IOS_FASTLANE_MATCH_GCS_SERVICE_JSON}}
 
-  IOS_MOBILEPROVISION_BASE64: ${{secrets.IOS_MOBILEPROVISION_BASE64}}
-  IOS_P12_BASE64: ${{secrets.IOS_P12_BASE64}}
+  # IOS_CODE_SIGNING_IDENTITY: ${{ secrets.IOS_CODE_SIGNING_IDENTITY }}
+  # IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
+
+  # IOS_MOBILEPROVISION_BASE64: ${{secrets.IOS_MOBILEPROVISION_BASE64}}
+  # # Combined P12 key+cert encoded as base64
+  # IOS_P12_BASE64: ${{secrets.IOS_P12_BASE64}}
+  # IOS_P12_PASSWORD: ${{secrets.IOS_P12_PASSWORD}}
 
   ##################################################################################
   #         Main Code
@@ -52,19 +56,19 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  build_web:
-    uses: ./.github/workflows/reusable-app-build.yml
-    with:
-      branch: ${{ inputs.branch }}
-      post-build-cmd: yarn workflow ios configure && npx cap sync ios
-      additional-artifact: ios
-      # Ensure build also run on macos to allow npx cap sync to configure ios pods
-      workflow-runner: macos-latest
-    secrets: inherit
+  # build_web:
+  #   uses: ./.github/workflows/reusable-app-build.yml
+  #   with:
+  #     branch: ${{ inputs.branch }}
+  #     post-build-cmd: yarn workflow ios configure && npx cap sync ios
+  #     additional-artifact: ios
+  #     # Ensure build also run on macos to allow npx cap sync to configure ios pods
+  #     workflow-runner: macos-latest
+  #   secrets: inherit
 
   debug:
     runs-on: macos-latest
-    needs: build_web
+    # needs: build_web
     steps:
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
@@ -74,7 +78,7 @@ jobs:
           #   NOTE - need to explicitly include token to download from a different workflow run
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          # run-id: 13731930921
+          run-id: 13732579493
 
       - name: Extract Build folder
         run: |
@@ -97,6 +101,26 @@ jobs:
           ruby-version: "3.0"
           bundler-cache: true
           working-directory: ios/App
+
+      - name: Setup development certificates
+        run: |
+          bundle exec fastlane create_keychain --name "temp.keychain" --password "temp1234" --unlock true --default-keychain true
+          bundle exec fastlane run cert --development true
+          bundle exec fastlane run sigh --development true
+
+      # - name: Setup Fastlane Match
+      #   working-directory: ios/App
+      #   run: |
+      #     echo 'google_cloud_bucket_name("c2dev-fastlane-match-certs")' > Matchfile
+      #     echo 'storage_mode("google_cloud")' >> Matchfile
+      #     echo 'type("development")' >> Matchfile'
+
+      #
+      # - name: Setup IOS Certs
+      #   run: |
+      #     echo ${{env.IOS_P12_BASE64}} | base64 --decode > cert.p12
+      #     bundle exec fastlane create_keychain --name "temp.keychain" --password "temp1234" --unlock true --default-keychain true
+      #     bundle exec import_certificate --certificate_path cert.p12 --certificate_password "${{env.IOS_P12_PASSWORD}}"
 
       # Call fastlane build_ios_app track
       # https://docs.fastlane.tools/actions/build_ios_app/

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -20,10 +20,6 @@ env:
   GOOGLE_SERVICES_JSON: ${{secrets.GOOGLE_SERVICES_JSON}}
   GOOGLE_SERVICES_PLIST: ${{secrets.GOOGLE_SERVICES_PLIST}}
 
-  # If debugging can use build from previous run and skip build_web step
-  # Build artifacts expire after 24h so will need updating
-  DEBUG_RUN_ID: 13744145866
-
   ##################################################################################
   #         Main Code
   ##################################################################################
@@ -51,28 +47,16 @@ jobs:
   #         Build Deployment Web
   #############################################################################
 
-  # Debug - check whether a debug_run_id is provided to determine whether build_web
-  # job can be skipped. This runs as standalone job as job-level `if` cannot access env.
-  should_build:
-    runs-on: ubuntu-latest
-    outputs:
-      should_build: ${{steps.should_build.outputs.should_build}}
-    steps:
-      - id: should_build
-        run: echo "should_build=${{!env.DEBUG_RUN_ID}}" >> "$GITHUB_OUTPUT"
-
-  build_web:
-    if: ${{needs.should_build.outputs.should_build == true}}
-    needs: [should_build]
-    uses: ./.github/workflows/reusable-app-build.yml
-    with:
-      branch: ${{ inputs.branch }}
-      post-build-cmd: yarn workflow ios configure && npx cap sync ios
-      # Upload ios directory as it includes configured template files and www content
-      additional-artifact: ios
-      # Ensure build also run on macos to allow npx cap sync to configure ios pods
-      workflow-runner: macos-latest
-    secrets: inherit
+  # build_web:
+  #   uses: ./.github/workflows/reusable-app-build.yml
+  #   with:
+  #     branch: ${{ inputs.branch }}
+  #     post-build-cmd: yarn workflow ios configure && npx cap sync ios
+  #     # Upload ios directory as it includes configured template files and www content
+  #     additional-artifact: ios
+  #     # Ensure build also run on macos to allow npx cap sync to configure ios pods
+  #     workflow-runner: macos-latest
+  #   secrets: inherit
 
   #############################################################################
   #         Build IOS
@@ -80,7 +64,7 @@ jobs:
 
   build_ios:
     runs-on: macos-latest
-    needs: build_web
+    # needs: build_web
     steps:
       # Checkout builder repo and install node_modules so that they can be used in ios build
       # (e.g. capacitor plugins store podfiles in node_modules)
@@ -96,7 +80,7 @@ jobs:
           # Use build artifact generated either as part of this run or from previous run (if debug run id set)
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          run-id: ${{env.DEBUG_RUN_ID || github.run_id}}
+          run-id: 13744145866
 
       # Remove default ios folder and replace with artifact generated
       - name: Setup IOS folder

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   #############################################################################
-  #         Deployment build
+  #         Build Deployment Web
   #############################################################################
 
   # build_web:
@@ -58,7 +58,11 @@ jobs:
   #     workflow-runner: macos-latest
   #   secrets: inherit
 
-  debug:
+  #############################################################################
+  #         Build IOS
+  #############################################################################
+
+  build_ios:
     runs-on: macos-latest
     # needs: build_web
     steps:
@@ -102,21 +106,6 @@ jobs:
           bundler-cache: true
           working-directory: ios/App
 
-        # https://docs.fastlane.tools/codesigning/getting-started/
-
-      # TODO - still need to use app store connect to manage
-      # TODO - when passing commands via fastlane run needs formatting differently (should test without run)
-      # - name: Setup development certificates
-      #   working-directory: ios/App
-      #   env:
-      #     IOS_USERNAME: "example@idems.international"
-      #   run: |
-      #     mkdir fastlane
-      #     bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock, default_keychain
-      #     bundle exec fastlane run get_certificates username:"${{env.IOS_USERNAME}}", development, force
-      #     bundle exec fastlane run get_provisioning_profile
-      #     bundle exec fastlane run disable_automatic_code_signing
-
       # Install node_module dependencies (includes capacitor plugin pods required for build)
       - uses: actions/setup-node@v4
         with:
@@ -124,38 +113,30 @@ jobs:
           cache: yarn
       - run: yarn workspaces focus --production
 
-      # Call fastlane build_ios_app track
-      # https://docs.fastlane.tools/actions/build_ios_app/
-
       # Attempt to create an unsigned build for local testing
       # https://blog.richardszalay.com/2016/08/22/ios-deploy-pipeline-3-setup-and-build-test-phase/
       # https://stackoverflow.com/a/66278353
       - name: Build IOS
         env:
-          # Supported configurations in project are Debug and Release
+          # Supported configurations in IOS project are Debug and Release
           configuration: Debug
         working-directory: ios/App
+        # Call fastlane build_ios_app track
+        # https://docs.fastlane.tools/actions/build_ios_app/
         run: |
-          bundle exec fastlane build_ios_app --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true
+          bundle exec fastlane build_ios_app --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true --output_directory "build"
 
-    # TODO - google plist
-    #   - name: Populate google-services.json
-    #     env:
-    #       GOOGLE_SERVICES_JSON: ${{ env.GOOGLE_SERVICES_JSON }}
-    #     run: echo $GOOGLE_SERVICES_JSON > android/app/google-services.json
+      #############################################################################
+      #         Upload
+      #############################################################################
 
-    #############################################################################
-    #         IOS Build and Upload
-    #############################################################################
-
-    #   - name: Upload application
-    #     uses: actions/upload-artifact@v3
-    #     with:
-    #       name: app
-    #       path: ${{ runner.temp }}/build/app.ipa
-    #       # you can also archive the entire directory
-    #       # path: ${{ runner.temp }}/build
-    #       retention-days: 3
+      - name: Upload application
+        uses: actions/upload-artifact@v3
+        with:
+          name: app
+          path: ios/App/build
+          # you can also archive the entire directory
+          retention-days: 30
 
     #############################################################################
     #         TODO - IOS Deploy Testflight
@@ -174,6 +155,21 @@ jobs:
     # # Combined P12 key+cert encoded as base64
     # IOS_P12_BASE64: ${{secrets.IOS_P12_BASE64}}
     # IOS_P12_PASSWORD: ${{secrets.IOS_P12_PASSWORD}}
+
+    # https://docs.fastlane.tools/codesigning/getting-started/
+
+    # TODO - still need to use app store connect to manage
+    # TODO - when passing commands via fastlane run needs formatting differently (should test without run)
+    # - name: Setup development certificates
+    #   working-directory: ios/App
+    #   env:
+    #     IOS_USERNAME: "example@idems.international"
+    #   run: |
+    #     mkdir fastlane
+    #     bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock, default_keychain
+    #     bundle exec fastlane run get_certificates username:"${{env.IOS_USERNAME}}", development, force
+    #     bundle exec fastlane run get_provisioning_profile
+    #     bundle exec fastlane run disable_automatic_code_signing
 
     # - name: Setup Fastlane Match
     #   working-directory: ios/App/fastlane

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -51,13 +51,19 @@ jobs:
   #         Build Deployment Web
   #############################################################################
 
-  debug:
+  # Debug - check whether a debug_run_id is provided to determine whether build_web
+  # job can be skipped. This runs as standalone job as job-level `if` cannot access env
+  should_build:
     runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{steps.should_build.outputs.should_build}}
     steps:
-      - run: echo ${{github.env.DEBUG_RUN_ID}} ${{!github.env.DEBUG_RUN_ID}}
+      - id: should_build
+        run: echo "should_build=${{!github.env.DEBUG_RUN_ID}}" >> "$GITHUB_OUTPUT"
 
   build_web:
-    if: ${{!github.env.DEBUG_RUN_ID}}
+    if: needs.should_build.outputs.should_build
+    needs: [should_build]
     uses: ./.github/workflows/reusable-app-build.yml
     with:
       branch: ${{ inputs.branch }}

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -72,7 +72,6 @@ jobs:
         with:
           node-version: 20.17.0
           cache: yarn
-      - run: yarn workspaces focus --production
 
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
@@ -89,7 +88,7 @@ jobs:
         run: |
           rm -R ios/*
           tar -xf artifact.tar --directory ios
-          echo ${{env.GOOGLE_SERVICES_PLIST}} > ios/App/App/GoogleService-Info.plist
+          echo $GOOGLE_SERVICES_PLIST > ios/App/App/GoogleService-Info.plist
           ls ios/App/App
 
       # Create a ruby gemfile declaring fastlane dep for install. This will be auto-installed
@@ -122,6 +121,9 @@ jobs:
       #     bundle exec fastlane run get_certificates username:"${{env.IOS_USERNAME}}", development, force
       #     bundle exec fastlane run get_provisioning_profile
       #     bundle exec fastlane run disable_automatic_code_signing
+
+      # Install node_module dependencies (includes capacitor plugin pods required for build)
+      - run: yarn workspaces focus --production
 
       # Call fastlane build_ios_app track
       # https://docs.fastlane.tools/actions/build_ios_app/

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Setup development certificates
         working-directory: ios/App
         run: |
-          bundle exec fastlane create_keychain(name:"temp.keychain", password:"temp1234", unlock:true, default-keychain:true)
+          bundle exec fastlane create_keychain name:"temp.keychain", password:"temp1234", unlock:true, default-keychain:true
           bundle exec fastlane run get_certificates
           bundle exec fastlane run get_provisioning_profile
           bundle exec fastlane run disable_automatic_code_signing

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -101,7 +101,7 @@ jobs:
           sdk: "iOS 11.1"
         working-directory: ios
         run: |
-          fastlane run build_ios_app 
+          bundle exec fastlane run build_ios_app 
           --workspace "${{env.workspace}}"
           --configuration "${{env.configuration}}"
           --scheme "${{env.scheme}}"

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -94,19 +94,23 @@ jobs:
 
         # https://docs.fastlane.tools/codesigning/getting-started/
 
-      - name: Setup development certificates
-        working-directory: ios/App
-        env:
-          IOS_USERNAME: "example@idems.international"
-        run: |
-          mkdir fastlane
-          bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock, default_keychain
-          bundle exec fastlane run get_certificates username:"${{env.IOS_USERNAME}}", development
-          bundle exec fastlane run get_provisioning_profile
-          bundle exec fastlane run disable_automatic_code_signing
+      # TODO - still need to use app store connect to manage
+      # - name: Setup development certificates
+      #   working-directory: ios/App
+      #   env:
+      #     IOS_USERNAME: "example@idems.international"
+      #   run: |
+      #     mkdir fastlane
+      #     bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock, default_keychain
+      #     bundle exec fastlane run get_certificates username:"${{env.IOS_USERNAME}}", development, force
+      #     bundle exec fastlane run get_provisioning_profile
+      #     bundle exec fastlane run disable_automatic_code_signing
 
       # Call fastlane build_ios_app track
       # https://docs.fastlane.tools/actions/build_ios_app/
+
+      # Attempt to create an unsigned build for local testing
+      # https://blog.richardszalay.com/2016/08/22/ios-deploy-pipeline-3-setup-and-build-test-phase/
       - name: Build IOS
         env:
           configuration: debug
@@ -118,6 +122,8 @@ jobs:
           --scheme "App"
           --output_name "app.ipa"
           --sdk "${{env.sdk}}"
+          --skip_package_ipa true
+          --xcargs "CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''"
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -122,8 +122,7 @@ jobs:
           --configuration "${{env.configuration}}"
           --scheme "App"
           --sdk "${{env.sdk}}"
-          --skip_package_ipa true
-          --export_xcargs "CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''"
+          --skip_codesigning true
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,17 +52,17 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  # build_web:
-  #   uses: ./.github/workflows/reusable-app-build.yml
-  #   with:
-  #     branch: ${{ inputs.branch }}
-  #     post-build-cmd: npx cap sync ios
-  #     additional-artifact: ios
-  #   secrets: inherit
+  build_web:
+    uses: ./.github/workflows/reusable-app-build.yml
+    with:
+      branch: ${{ inputs.branch }}
+      post-build-cmd: npx cap sync ios
+      additional-artifact: ios
+    secrets: inherit
 
   debug:
     runs-on: macos-latest
-    # needs: build_web
+    needs: build_web
     steps:
       - name: Download IOS artifact
         uses: actions/download-artifact@v4
@@ -72,13 +72,13 @@ jobs:
           #   NOTE - need to explicitly include token to download from a different workflow run
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          run-id: 13729563778
+          # run-id: 13729563778
 
       - name: Extract Build folder
         run: |
           mkdir ios
           tar -xf artifact.tar --directory ios
-          ls -R
+          ls ios
 
       # Setup ruby. This will also default install the Gemfile in the ios folder which includes fastlane
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           mkdir tmp
           tar -xf artifact.tar --directory tmp
-          cp -R tmp/* ios/*
+          cp -R tmp/* ios/
           ls ios
 
       # Create a ruby gemfile declaring fastlane dep for install. This will be auto-installed

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           rm -R ios/*
           tar -xf artifact.tar --directory ios
-          echo ${{env.GOOGLE_SERVICES_PLIST}} > ios/App/App/GoogleService-Info.plist
+          echo $GOOGLE_SERVICES_PLIST > ios/App/App/GoogleService-Info.plist
 
       # Create a ruby gemfile declaring fastlane dep for install. This will be auto-installed
       # via the setup-ruby command. This file could also be created and committed to core repo is required

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,7 +52,7 @@ jobs:
   #############################################################################
 
   # Debug - check whether a debug_run_id is provided to determine whether build_web
-  # job can be skipped. This runs as standalone job as job-level `if` cannot access env
+  # job can be skipped. This runs as standalone job as job-level `if` cannot access env.
   should_build:
     runs-on: ubuntu-latest
     outputs:
@@ -62,13 +62,13 @@ jobs:
         run: echo "should_build=${{!env.DEBUG_RUN_ID}}" >> "$GITHUB_OUTPUT"
 
   build_web:
-    if: needs.should_build.outputs.should_build
+    if: ${{needs.should_build.outputs.should_build == true}}
     needs: [should_build]
     uses: ./.github/workflows/reusable-app-build.yml
     with:
       branch: ${{ inputs.branch }}
       post-build-cmd: yarn workflow ios configure && npx cap sync ios
-
+      # Upload ios directory as it includes configured template files and www content
       additional-artifact: ios
       # Ensure build also run on macos to allow npx cap sync to configure ios pods
       workflow-runner: macos-latest

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -113,14 +113,14 @@ jobs:
       # https://blog.richardszalay.com/2016/08/22/ios-deploy-pipeline-3-setup-and-build-test-phase/
       - name: Build IOS
         env:
-          configuration: debug
+          # Supported configurations in project are Debug and Release
+          configuration: Debug
           sdk: "iOS 11.1"
         working-directory: ios/App
         run: |
           bundle exec fastlane run build_ios_app
           --configuration "${{env.configuration}}"
           --scheme "App"
-          --output_name "app.ipa"
           --sdk "${{env.sdk}}"
           --skip_package_ipa true
           --xcargs "CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''"

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -99,14 +99,7 @@ jobs:
         with:
           lane: build_ios_app
           subdirectory: ios/App
-          options: |
-            '{
-            "workspace": "${{env.workspace}}",
-            "configuration": "${{env.configuration}}",
-            "scheme": "${{env.scheme}}",
-            "output_name": "${{env.output_name}}",
-            "sdk": "${{env.sdk}}"
-            }'
+          options: '{"workspace": "${{env.workspace}}","configuration": "${{env.configuration}}","scheme": "${{env.scheme}}","output_name": "${{env.output_name}}","sdk": "${{env.sdk}}"}'
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,13 +52,13 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  build_web:
-    uses: ./.github/workflows/reusable-app-build.yml
-    with:
-      branch: ${{ inputs.branch }}
-      post-build-cmd: npx cap sync ios
-      additional-artifact: ios
-    secrets: inherit
+  # build_web:
+  #   uses: ./.github/workflows/reusable-app-build.yml
+  #   with:
+  #     branch: ${{ inputs.branch }}
+  #     post-build-cmd: npx cap sync ios
+  #     additional-artifact: ios
+  #   secrets: inherit
 
   debug:
     runs-on: macos-latest
@@ -72,8 +72,7 @@ jobs:
           #   NOTE - need to explicitly include token to download from a different workflow run
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          # run-id: 13727815102
-        #   https://github.com/IDEMSInternational/app-debug-content/actions/runs/13727815102/artifacts/2713158337
+          run-id: 13729563778
 
       - name: Extract Build folder
         run: |
@@ -81,6 +80,7 @@ jobs:
           tar -xf artifact.tar --directory ios
           ls -R
 
+      # Setup ruby. This will also default install the Gemfile in the ios folder which includes fastlane
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.0"

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -19,16 +19,6 @@ env:
 
   GOOGLE_SERVICES_JSON: ${{secrets.GOOGLE_SERVICES_JSON}}
 
-  # IOS_FASTLANE_MATCH_GCS_SERVICE_JSON: ${{secrets.IOS_FASTLANE_MATCH_GCS_SERVICE_JSON}}
-
-  # IOS_CODE_SIGNING_IDENTITY: ${{ secrets.IOS_CODE_SIGNING_IDENTITY }}
-  # IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
-
-  # IOS_MOBILEPROVISION_BASE64: ${{secrets.IOS_MOBILEPROVISION_BASE64}}
-  # # Combined P12 key+cert encoded as base64
-  # IOS_P12_BASE64: ${{secrets.IOS_P12_BASE64}}
-  # IOS_P12_PASSWORD: ${{secrets.IOS_P12_PASSWORD}}
-
   ##################################################################################
   #         Main Code
   ##################################################################################
@@ -107,7 +97,7 @@ jobs:
       - name: Setup development certificates
         working-directory: ios/App
         run: |
-          bundle exec fastlane create_keychain --name "temp.keychain" --password "temp1234" --unlock true --default-keychain true
+          bundle exec fastlane create_keychain(name:"temp.keychain", password:"temp1234", unlock:true, default-keychain:true)
           bundle exec fastlane run get_certificates
           bundle exec fastlane run get_provisioning_profile
           bundle exec fastlane run disable_automatic_code_signing
@@ -151,6 +141,17 @@ jobs:
     # Will need to use production code-signing methods (e.g. match or manual p12)
     # https://docs.fastlane.tools/codesigning/getting-started/
     #############################################################################
+
+    # env:
+    # IOS_FASTLANE_MATCH_GCS_SERVICE_JSON: ${{secrets.IOS_FASTLANE_MATCH_GCS_SERVICE_JSON}}
+
+    # IOS_CODE_SIGNING_IDENTITY: ${{ secrets.IOS_CODE_SIGNING_IDENTITY }}
+    # IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
+
+    # IOS_MOBILEPROVISION_BASE64: ${{secrets.IOS_MOBILEPROVISION_BASE64}}
+    # # Combined P12 key+cert encoded as base64
+    # IOS_P12_BASE64: ${{secrets.IOS_P12_BASE64}}
+    # IOS_P12_PASSWORD: ${{secrets.IOS_P12_PASSWORD}}
 
     # - name: Setup Fastlane Match
     #   working-directory: ios/App

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -98,7 +98,7 @@ jobs:
         working-directory: ios/App
         run: |
           mkdir fastlane
-          bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock:true, default_keychain:true
+          bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock, default_keychain
           bundle exec fastlane run get_certificates
           bundle exec fastlane run get_provisioning_profile
           bundle exec fastlane run disable_automatic_code_signing

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -121,7 +121,7 @@ jobs:
         # Call fastlane build_ios_app track
         # https://docs.fastlane.tools/actions/build_ios_app/
         run: |
-          bundle exec fastlane build_ios_app --configuration "Release" --scheme "App" --destination "generic/platform=iOS Simulator" --skip_codesigning true --skip_package_ipa true --skip_archive true --build_path "./build" --output_directory "./build" --derived_data_path "./build"
+          bundle exec fastlane build_ios_app --configuration "Release" --scheme "App" --destination "generic/platform=iOS Simulator" --skip_codesigning true --skip_package_ipa true --skip_archive true --build_path "./build" --output_directory "./build/output" --derived_data_path "./build/data"
 
       #############################################################################
       #         Upload
@@ -131,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ios_build
-          path: ios
+          path: ios/App/build
           # you can also archive the entire directory
           retention-days: 30
 

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -131,7 +131,7 @@ jobs:
       #############################################################################
 
       - name: Upload application
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: ios/App/build

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,13 +52,13 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  # build_web:
-  #   uses: ./.github/workflows/reusable-app-build.yml
-  #   with:
-  #     branch: ${{ inputs.branch }}
-  #     post-build-cmd: npx cap sync ios
-  #     additional-artifact: ios
-  #   secrets: inherit
+  build_web:
+    uses: ./.github/workflows/reusable-app-build.yml
+    with:
+      branch: ${{ inputs.branch }}
+      post-build-cmd: yarn workflow ios configure && npx cap sync ios
+      additional-artifact: ios
+    secrets: inherit
 
   debug:
     runs-on: macos-latest
@@ -98,17 +98,17 @@ jobs:
 
       # Call fastlane build_ios_app track
       # https://docs.fastlane.tools/actions/build_ios_app/
-      - name: Build IOS
-        env:
-          configuration: debug
-          sdk: "iOS 11.1"
-        working-directory: ios/App
-        run: |
-          bundle exec fastlane run build_ios_app 
-          --configuration "${{env.configuration}}"
-          --scheme "App"
-          --output_name "app.ipa"
-          --sdk "${{env.sdk}}"
+      # - name: Build IOS
+      #   env:
+      #     configuration: debug
+      #     sdk: "iOS 11.1"
+      #   working-directory: ios/App
+      #   run: |
+      #     bundle exec fastlane run build_ios_app
+      #     --configuration "${{env.configuration}}"
+      #     --scheme "App"
+      #     --output_name "app.ipa"
+      #     --sdk "${{env.sdk}}"
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -81,18 +81,20 @@ jobs:
           ls ios
 
       # Create a ruby gemfile declaring fastlane dep for install. This will be auto-installed
-      # via the setup-ruby command. This file could also be created and comitted to core repo is required
+      # via the setup-ruby command. This file could also be created and committed to core repo is required
       - name: Add fastlane gem
+        working-directory: ios/App
         run: |
           echo 'source "https://rubygems.org"' > Gemfile
           echo 'gem "fastlane"' >> Gemfile
           cat Gemfile
 
-      # Setup ruby. This will also default install the Gemfile in the ios folder which includes fastlane
+      # Setup ruby. Use bundler-cache to auto-install Gemfile in working directory
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.0"
           bundler-cache: true
+          working-directory: ios/App
 
       # Call fastlane build_ios_app track
       # https://docs.fastlane.tools/actions/build_ios_app/

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -97,7 +97,8 @@ jobs:
       - name: Setup development certificates
         working-directory: ios/App
         run: |
-          bundle exec fastlane create_keychain name:"temp.keychain", password:"temp1234", unlock:true, default-keychain:true
+          mkdir fastlane
+          bundle exec fastlane run create_keychain name:"temp.keychain", password:"temp1234", unlock:true, default_keychain:true
           bundle exec fastlane run get_certificates
           bundle exec fastlane run get_provisioning_profile
           bundle exec fastlane run disable_automatic_code_signing
@@ -154,7 +155,7 @@ jobs:
     # IOS_P12_PASSWORD: ${{secrets.IOS_P12_PASSWORD}}
 
     # - name: Setup Fastlane Match
-    #   working-directory: ios/App
+    #   working-directory: ios/App/fastlane
     #   run: |
     #     echo 'google_cloud_bucket_name("${{env.IOS_FASTLANE_MATCH_GCS_BUCKET_NAME}}")' > Matchfile
     #     echo 'storage_mode("google_cloud")' >> Matchfile

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -52,13 +52,13 @@ jobs:
   #         Deployment build
   #############################################################################
 
-  build_web:
-    uses: ./.github/workflows/reusable-app-build.yml
-    with:
-      branch: ${{ inputs.branch }}
-      post-build-cmd: yarn workflow ios configure && npx cap sync ios
-      additional-artifact: ios
-    secrets: inherit
+  # build_web:
+  #   uses: ./.github/workflows/reusable-app-build.yml
+  #   with:
+  #     branch: ${{ inputs.branch }}
+  #     post-build-cmd: yarn workflow ios configure && npx cap sync ios
+  #     additional-artifact: ios
+  #   secrets: inherit
 
   debug:
     runs-on: macos-latest
@@ -72,7 +72,7 @@ jobs:
           #   NOTE - need to explicitly include token to download from a different workflow run
           # https://github.com/actions/download-artifact/issues/320
           github-token: ${{ github.token }}
-          run-id: 13731332844
+          run-id: 13731930921
 
       - name: Extract Build folder
         run: |
@@ -98,17 +98,17 @@ jobs:
 
       # Call fastlane build_ios_app track
       # https://docs.fastlane.tools/actions/build_ios_app/
-      # - name: Build IOS
-      #   env:
-      #     configuration: debug
-      #     sdk: "iOS 11.1"
-      #   working-directory: ios/App
-      #   run: |
-      #     bundle exec fastlane run build_ios_app
-      #     --configuration "${{env.configuration}}"
-      #     --scheme "App"
-      #     --output_name "app.ipa"
-      #     --sdk "${{env.sdk}}"
+      - name: Build IOS
+        env:
+          configuration: debug
+          sdk: "iOS 11.1"
+        working-directory: ios/App
+        run: |
+          bundle exec fastlane run build_ios_app
+          --configuration "${{env.configuration}}"
+          --scheme "App"
+          --output_name "app.ipa"
+          --sdk "${{env.sdk}}"
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -77,9 +77,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ios
-          # Use build artifact generated either as part of this run or from previous run (if debug run id set)
+          # DEBUG - uncomment lines below, `build_web` job and `needs: build_web` to skip build step
+          # and use the output from a previous run for quicker debugging. Requires github-token
           # https://github.com/actions/download-artifact/issues/320
-          github-token: ${{ github.token }}
+
+          # github-token: ${{ github.token }}
           # run-id: 13743953801
 
       # Remove default ios folder and replace with artifact generated
@@ -114,8 +116,6 @@ jobs:
 
       # Attempt to create an unsigned build for local testing
       # https://github.com/fastlane/fastlane/discussions/21996
-      # https://blog.richardszalay.com/2016/08/22/ios-deploy-pipeline-3-setup-and-build-test-phase/
-      # https://stackoverflow.com/a/66278353
       - name: Build IOS (simulator)
         working-directory: ios/App
         env:
@@ -139,11 +139,10 @@ jobs:
         with:
           name: simulator_app
           path: ios/App/output/data/Build/Products/Release-iphonesimulator/*.app
-          # you can also archive the entire directory
           retention-days: 30
 
           #############################################################################
-          #         TODO - IOS Deploy Testflight
+          #         WiP Notes - IOS Deploy Testflight
           # Possibly separate action to testflight deployment]
           # Will need to use production code-signing methods (e.g. match or manual p12)
           # https://docs.fastlane.tools/codesigning/getting-started/

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -123,7 +123,7 @@ jobs:
           --scheme "App"
           --sdk "${{env.sdk}}"
           --skip_package_ipa true
-          --xcargs "CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''"
+          --export_xcargs "CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''"
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -88,6 +88,7 @@ jobs:
           bundler-cache: true
           working-directory: ios
 
+      # https://docs.fastlane.tools/actions/build_ios_app/
       - name: Build IOS
         env:
           workspace: App/App.xcworkspace
@@ -103,19 +104,6 @@ jobs:
           --scheme "${{env.scheme}}"
           --output_name "${{env.output_name}}"
           --sdk "${{env.sdk}}"
-
-      # https://docs.fastlane.tools/actions/build_ios_app/
-      # - uses: maierj/fastlane-action@v3.1.0
-      #   env:
-      #     workspace: App/App.xcworkspace
-      #     configuration: debug
-      #     scheme: "App"
-      #     output_name: "app.ipa"
-      #     sdk: "iOS 11.1"
-      #   with:
-      #     lane: build_ios_app
-      #     subdirectory: ios
-          options: '{"workspace": "${{env.workspace}}","configuration": "${{env.configuration}}","scheme": "${{env.scheme}}","output_name": "${{env.output_name}}","sdk": "${{env.sdk}}"}'
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -119,7 +119,10 @@ jobs:
         working-directory: ios/App
         run: |
           bundle exec fastlane run build_ios_app \
-          --configuration "${{env.configuration}}" --scheme "App" --skip_codesigning true --skip_package_ipa true
+          configuration:"${{env.configuration}}" \
+          scheme:"App" \
+          skip_codesigning \
+          skip_package_ipa
 
     # TODO - google plist
     #   - name: Populate google-services.json

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -18,6 +18,7 @@ env:
   PARENT_DEPLOYMENT_BRANCH: ${{vars.PARENT_DEPLOYMENT_BRANCH}}
 
   GOOGLE_SERVICES_JSON: ${{secrets.GOOGLE_SERVICES_JSON}}
+  GOOGLE_SERVICES_PLIST: ${{secrets.GOOGLE_SERVICES_PLIST}}
 
   ##################################################################################
   #         Main Code
@@ -51,6 +52,7 @@ jobs:
   #   with:
   #     branch: ${{ inputs.branch }}
   #     post-build-cmd: yarn workflow ios configure && npx cap sync ios
+
   #     additional-artifact: ios
   #     # Ensure build also run on macos to allow npx cap sync to configure ios pods
   #     workflow-runner: macos-latest
@@ -61,6 +63,7 @@ jobs:
     # needs: build_web
     steps:
       # TODO - still need to install node_modules for use in build
+      # TODO - copy google plist
       - uses: actions/checkout@v4
         with:
           repository: "IDEMSInternational/open-app-builder.git"
@@ -81,15 +84,16 @@ jobs:
           github-token: ${{ github.token }}
           run-id: 13732579493
 
-      # Merge built ios artifact with repo default
+      # Merge built ios artifact with repo default. Populate google-services plist
       # NOTE - this is handled manually instead of via npx cap sync to ensure deployment-specific
       # capacitor.config.json included
-      - name: Extract Build folder
+      - name: Setup IOS folder
         run: |
           mkdir tmp
           tar -xf artifact.tar --directory tmp
           cp -R tmp/* ios/
-          ls ios
+          echo ${{env.GOOGLE_SERVICES_PLIST}} > ios/App/App/GoogleService-Info.plist
+          ls ios/App/App
 
       # Create a ruby gemfile declaring fastlane dep for install. This will be auto-installed
       # via the setup-ruby command. This file could also be created and committed to core repo is required

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -62,14 +62,6 @@ jobs:
     runs-on: macos-latest
     # needs: build_web
     steps:
-      # checkout and install just the node_modules from the main repo
-      # so that they can be used as part of the ios build process
-      # (capacitor keeps pod files in node_modules)
-      - uses: actions/checkout@v4
-        with:
-          repository: "IDEMSInternational/open-app-builder.git"
-          ref: ${{env.APP_CODE_BRANCH}}
-          filter: yarn.lock
       - uses: actions/setup-node@v4
         with:
           node-version: 20.17.0

--- a/.github/workflows/reusable-ios-build.yml
+++ b/.github/workflows/reusable-ios-build.yml
@@ -59,7 +59,7 @@ jobs:
       should_build: ${{steps.should_build.outputs.should_build}}
     steps:
       - id: should_build
-        run: echo "should_build=${{!github.env.DEBUG_RUN_ID}}" >> "$GITHUB_OUTPUT"
+        run: echo "should_build=${{github.env.DEBUG_RUN_ID==''}}" >> "$GITHUB_OUTPUT"
 
   build_web:
     if: needs.should_build.outputs.should_build

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,3 +1,0 @@
-source "https://rubygems.org"
-
-gem "fastlane"


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)


## Description
- Add `reusable-ios-build` action to handle build of ios app

- Improve reusable build action to support custom post-build scripts and artifact upload. This enables triggering things like ios configuration scripts following the app build, so that follow-up runner doesn't have to manage deployment-specific code.

## Author Notes
Once this PR is merged similar actions as the one in the debug repo PR can be added to other content repos to generate ios simulator builds. As the action depends on the latest version of the main code repo, the content repo variable for `APP_CODE_BRANCH` will also need to be set to one that includes these merged changes

The action does not (currently) upload automatically to testflight, nor can they generated artifacts be uploaded to the app store (requires follow-up work to handle code signing). So for now the main use-case is manually triggering the build action and then manually uploading the generated artifact to appetize for testing on ios simulator device

The content repo will also need and additional `GOOGLE_SERVICES_PLIST` secret if using the android-equivalent `GOOGLE_SERVICES_JSON` to enable firebase features. This file can be generated from the firebase console for the associated project.

## Review Notes
The action is designed to be triggered by a content repo. A testing PR has been added to the debug repo used to trigger this action: https://github.com/IDEMSInternational/app-debug-content/pull/154

See output artifacts from workflow run. 
[Example Deployment Repo Workflow Run](https://github.com/IDEMSInternational/app-debug-content/actions/runs/13745252358)

This should be a simulator build, able to run locally on a mac or uploaded directly to testflight.

## Dev Notes
There's quite a lot going on in the action, and a whole lot more that will still require further work/follow-up. For now this really just seeks out to lay the groundwork for triggering ios builds, and is likely not yet in a state where it will drastically reduce the amount of ongoing manual work. 

It should however at least be a decent proof-of-concept, and lead to a clearer understanding on the next steps required (the number of [debug workflow runs](https://github.com/IDEMSInternational/app-debug-content/actions/workflows/debug-ios-build.yml) on the content repo should be a good indicator of the learning involved!).

**General action overview**
1. Trigger the reusable web build to set and build code for deployment. Use an additional post-build script to sync the generated www folder to the ios app via the `npx cap sync` command. This is done as part of the build action to avoid having to reconfigure deployment and populate ios config in step 2. Upload the full ios folder as an artifact for use in next step

2. Checkout the builder repo and replace the default ios folder with the artifact generated in the build step (will contain public www contents as well as compiled capacitor.config.json). Install node_modules again as native plugins store podfiles in node_modules folders, and are required for build

This step could possibly be optimised if there were a cleaner way to store just the node_modules required for ios build in an artifact, so that we don't need to run a `yarn install` at all in this step.

3. Generate an unsigned build for simulator and upload.

It would also be possible to generate an unsigned `.xcarchive` that could be imported locally into xcode, signed, and uploaded, although I think it would probably still be better to focus on integrating signing processes into CI instead. So for now the main purpose is generating builds capable of uploading to appetize.

**Github Actions - Choice of Tools**

When it comes to building IOS via CI, there are generally 3 approaches
1. Use raw commands to trigger various `xcrun` or `xcodebuild` commands directly on the runner, with additional steps to [provision apple certificates](https://docs.github.com/en/actions/use-cases-and-examples/deploying/installing-an-apple-certificate-on-macos-runners-for-xcode-development)
2. Use a utility like [fastlane](https://fastlane.tools/) as a wrapper around commands and certificate provisioning
3. Use a 3rd party action, the most popular being [sparkfabrik/ios-build-action](https://github.com/sparkfabrik/ios-build-action) and [yukiarr/ios-build-action](https://github.com/yukiarrr/ios-build-action). On github marketplace these are called `build-ios-action` and `ios-build-action` respectively which is super confusing

I initially went for option 3. however found both actions were just thin wrappers around fastlane scripts (option 2), and included a mix of both a bunch of functionality that we don't want (e.g. direct upload to browserstack, enforce appstore login even when not uploading build), as well as lacking some functionality we may want (e.g. generate simulator/xcarchive builds, upload to appetize, generate screenshots etc.). I also noted the sparkfabrik repo started as a fork of the yukiarr repo, however both are loosely maintained/active. 

Next I went for option 1. however quickly found there to just be a huge amount of boilerplate code required to achieve basic builds and very difficult to deubg/test locally (no access to xcode cli without a mac to test examples). Here's an [example gist](https://gist.github.com/huynguyencong/004e98e4d9e7671f93fec280ddb7fc18) that should give an idea

So I settled on option 2. There is a follow-up choice of how to manage fastlane (namely whether to define scripts in a `fastfile` or execute inline. For now I've opted to execute inline although we may want to setup specific tracks in a fastfile in the future

**Certificate Management**
Building for IOS is typically more involved than android, as both certificates and provisioning profiles are required that need to be provided from a registered apple developer account

There's a few different approaches to this, as outlined in the fastlane [codesigning docs](https://docs.fastlane.tools/codesigning/getting-started/), although the only viable for CI are:

1. Using fastlane's [match](https://docs.fastlane.tools/actions/match/) tool which stores all certificates in external storage (e.g. private git repo or google cloud bucket) for import into workflows
2. Provide files directly via github secrets as base64 encoded files

I've experimented with both options, although limited in what can be done without access to various certs and keys that require developer account admin access as well as a local mac device. For now I've skipped the signing to process to generate only unsiged builds, which can still be exported as `.app` files to run on simulator or `.xcarchive` which can later be signed and exported as `.ipa` via xcode locally. 
I'd recommend a follow-up discussion to decide best way to handle signing builds before following up with action code to automate deploying to testflight. 

For now I think the best option would likely be using [fastlane match](https://docs.fastlane.tools/actions/match/) (1), authenticating via app-store-connect API. The benefit of this over (2) is the amount of secrets that would need encoding into the github action is fewer (1-2 vs 4-5). There would then be a follow-up choice to decide if fastlane match would store credentials in a private git repo or a google cloud storage bucket, here I would be leaning towards GCS as it has slightly better options for user-management (uses service accounts which are reasonably easy to set-up whereas github relies on personal access tokens which have much broader scope)

**Debugging workflow**
To speed up development workflow for triggered actions, I noted it would be possible to just run the build action once and then reference the generated artifacts in future builds via the run-id (instead of rebuilding each time). Local modification to the workflow looks like below (should note that build artifacts expire after 24h, so needs at least one new run per day while testing)
```yml
 #   build_web:
  #     uses: ./.github/workflows/reusable-app-build.yml
  #     with:
  #       branch: ${{ inputs.branch }}
  #       post-build-cmd: npx cap sync ios
  #       additional-artifact: ios
  #     secrets: inherit

  debug:
    runs-on: macos-latest
    # needs: build_web
    steps:
      - name: Download IOS artifact
        uses: actions/download-artifact@v4
        with:
          name: ios
          #   NOTE - need to explicitly include token to download from a different workflow run
          # https://github.com/actions/download-artifact/issues/320
          github-token: ${{ github.token }}
          run-id: 13727815102
```
In order to trigger build, typically new commits need to be pushed on the debug repo. Empty commits can be added via command line
```
git commit --allow-empty -m "chore: Trigger Build"
```

There is added complication that any changes made to builder repo files will only be available to the action after they have been merged into master, due to the way the `APP_CODE_BRANCH` variable specifies which builder branch to checkout. As such if making changes to builder repo files (e.g. creating fastlane files in the ios folder), then this should temporarily be updated to target the current pr branch

**Misc Notes**
I've registered an ios app in the debug-app firebase project and added the google services plist to the debug content repo `GOOGLE_SERVICES_PLIST` secret for use in testing

## TODO - Follow-up
- [ ] Remove debug action from debug repo and replace with named action.
- [ ] Revert debug app `APP_CODE_BRANCH` variable in debug repo (currently targeting this branch, should target `master`) 
- [ ] Fully automate all ios config workflow to setup deployment build as required (migrate manual methods, handle splash/icon and anything else as required)
- [ ] Create additional workflow to upload output to testflight directly from action (likely refactoring ios_build workflow to accept custom input args that could be used to generate either simulator or production build)
- [ ] Organise IDEMS org certificates and include in test action (migrating any existing certs). If exporting credentials from local machine see [example commands](https://www.andrewhoog.com/post/how-to-build-an-ios-app-with-github-actions-2023) from blog post, although might be better to create new credentials for use throughout
- [ ] Setup fastlane locally to remove the amount of boilerplate required for actions (e.g. `fastlane init` files in ios folder)
- [ ] Replace testing credentials with updates on debug repo
- [ ] Extend actions to also submit to testflight using fastlane with [app-store-connect-api](https://docs.fastlane.tools/app-store-connect-api/)
- [ ] Migrate changes to standalone actions repo
- [ ] Refactor android actions to use post-build and additional artifacts to improve efficiency
- [ ] Consider migrating to fastlane match (with google storage bucket)
- [ ] Documentation


## Git Issues

Closes #

## Screenshots/Videos
**Example - content repo action artifacts. The `simulator_app` artifact contains app for upload to appetize**
![image](https://github.com/user-attachments/assets/cee57ab4-c94d-44b9-aad7-838d1efd68bb)

**Example - Debug App built and (manually) uploaded to appetize**
![image](https://github.com/user-attachments/assets/08037407-7dd3-4da2-8788-b294e924866f)
