### PR TITLE
fix: ios visual bugs on elements with drop-shadow

### DIFF
--- a/packages/components/plh/parent-point-box/parent-point-box.component.scss
+++ b/packages/components/plh/parent-point-box/parent-point-box.component.scss
@@ -17,7 +17,7 @@ $item-border: var(--points-item-border, none);
     max-width: 100%; // Don't allow overlap
     height: var(--points-item-height);
     background: $item-background;
-    filter: drop-shadow(var(--ion-default-box-shadow));
+    box-shadow: var(--ion-default-box-shadow);
     border: 1px solid $item-border;
     border-radius: var(--ion-border-radius-standard);
     position: relative;

--- a/packages/components/plh/plh-kids-kw/components/module-list-item/module-list-item.component.scss
+++ b/packages/components/plh/plh-kids-kw/components/module-list-item/module-list-item.component.scss
@@ -90,12 +90,12 @@ $highlighted-color: var(--module-list-item-color-highlighted, var(--ion-color-se
   --circle-width: 84px;
   &[data-locked~="true"] {
     --circle-width: 76px;
+    box-shadow: -2px 2px 5px rgba(0, 0, 0, 0.2);
   }
   width: var(--circle-width);
   height: var(--circle-width);
   border-radius: 50%;
   border-width: 4px;
-  filter: drop-shadow(-2px 2px 5px rgba(0, 0, 0, 0.2));
   overflow: hidden;
   background-color: white;
   position: relative;

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -86,7 +86,6 @@ ion-button[data-variant~="card"] {
   border-radius: var(--ion-border-radius-standard);
   min-height: var(--buttons-short-height);
   box-shadow: var(--ion-default-box-shadow);
-  // filter: drop-shadow(var(--ion-default-box-shadow));
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -85,7 +85,8 @@ ion-button[data-variant~="card"] {
   border: 1px solid var(--ion-color-gray-light);
   border-radius: var(--ion-border-radius-standard);
   min-height: var(--buttons-short-height);
-  filter: drop-shadow(var(--ion-default-box-shadow));
+  box-shadow: var(--ion-default-box-shadow);
+  // filter: drop-shadow(var(--ion-default-box-shadow));
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -6,7 +6,7 @@
   border-radius: var(--ion-border-radius-secondary);
   padding: var(--regular-padding);
   max-width: 400px;
-  filter: drop-shadow(var(--ion-default-box-shadow));
+  box-shadow: var(--ion-default-box-shadow);
 
   // Variants should be set using "variant" param, but support legacy
   // "style" param for "portrait" and "button", which adds a class
@@ -113,7 +113,6 @@
 .badge {
   position: absolute;
   top: -10px;
-  filter: drop-shadow(var(--ion-default-box-shadow));
   &.highlighted-badge {
     right: -10px;
     padding: 5px 10px;
@@ -127,6 +126,7 @@
     width: 36px;
   }
   .circle {
+    box-shadow: var(--ion-default-box-shadow);
     height: 36px;
     width: 36px;
     border-radius: 50%;
@@ -189,7 +189,7 @@
       overflow: hidden;
       background-color: white;
       border: 1px solid rgba(black, 0.07);
-      filter: drop-shadow(var(--ion-default-box-shadow));
+      box-shadow: var(--ion-default-box-shadow);
 
       img {
         width: 100%;

--- a/src/theme/overrides.ios.scss
+++ b/src/theme/overrides.ios.scss
@@ -17,8 +17,8 @@ ion-app[data-platform~="ios"] {
 
   // Elements that make use of `filter: drop-shadow`:
 
-  plh-button {
-    .button-container[data-variant~="card-portrait"] {
+  plh-combo-box {
+    .open-combobox {
       @include force-gpu-acceleration;
     }
   }

--- a/src/theme/overrides.ios.scss
+++ b/src/theme/overrides.ios.scss
@@ -14,4 +14,12 @@ ion-app[data-platform~="ios"] {
       @include force-gpu-acceleration;
     }
   }
+
+  // Elements that make use of `filter: drop-shadow`:
+
+  plh-button {
+    .button-container[data-variant~="card-portrait"] {
+      @include force-gpu-acceleration;
+    }
+  }
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Fixes an issue with the `plh_module_list_item`, where the component would not display properly on iOS (see https://github.com/ParentingForLifelongHealth/plh-kids-app-kw-content/issues/174).
- Fixes related undocumented issues for some other components:
  - `task_card`
  - `button` (`card-portrait` variant)

## Notes

The underlying issue is with the CSS `filter: drop-shadow` on iOS. Similar issues are noted in various places (e.g. [1](https://stackoverflow.com/questions/65801487/drop-shadow-not-working-properly-on-ios-safari), [2](https://www.reddit.com/r/css/comments/bweqdc/safari_bug_css_dropshadow_after_elementhover_issue/)), although not well documented. 

There are two possible workarounds for this issue:
1. Refactor the styling to replace `filter: drop-shadow` with `box-shadow:`
    - The latter does not seem to cause issues on iOS
    - This change does entail some subtle visual changes, since the shadow applied by the `drop-shadow` filter appears to be softer and more blurred than that applied by the `box-shadow` property
2. Make use of the workaround we introduced for similar issue in #2288 – apply the CSS mixin designed for troublesome iOS elements. 

Testing the components that make use of the `drop-shadow` filter, `plh_module_list_item`, `task_card`, and `button` with `card-portrait` variant all exhibited related bugs on iOS. `parent_point_box` and `combo-box` also use a `drop-shadow` filter, and whilst I wasn't able to observe any bugs on these components, I've applied the workaround in anticipation of such bugs.

### `plh_module_list_item`

In the case of the `plh_module_list_item` component for which the issue was noticed, it made most sense to apply option 1., since the other variants of this component already made use of `box-shadow`, so this change improves consistency as well as resolving the issue. See screenshots section for example of the changes.

### `task_card`

For this component, on iOS the shadow around the status badge doesn't appear when overlapping with the main card element. I've resolved this with workaround 1. There is a slight visual difference (the shadow around the card is slightly less blurred), but I don't think this is a problem.

| before | after |
|---|---|
| <img width="220" alt="Screenshot 2025-03-11 at 12 19 19" src="https://github.com/user-attachments/assets/da192e2f-c463-44c1-ae7b-32bc2780125e" /> | <img width="220" alt="Screenshot 2025-03-11 at 12 22 30" src="https://github.com/user-attachments/assets/e24d2a8d-a3ca-4d30-8cd8-a9f3caa56db7" /> |



### `button` (`card-portrait` variant)

I applied workaround 1. As well as fixing this flickering issue, this styling brings the component in line with the shadow for the updated task-card component for a closer visual match, as well the other button variants, which already use `box-shadow`.

Before:

https://github.com/user-attachments/assets/824ebafb-8226-402d-a6e7-c88f47f9ea92

After:

<img width="220" alt="Screenshot 2025-03-11 at 15 28 51" src="https://github.com/user-attachments/assets/f0de891d-be4f-440d-97bd-4b4e5276007c" />


### `parent_point_box`

I couldn't detect any issues, but applied workaround 1. 

### `combo-box`

This is a case where the difference between a `drop-shadow` filter and `box-shadow` is more pronounced, because of the way they interact with transparency. Since the button element consists of just an outline, using a `drop-shadow` filter means the element gets a shadow on the inside as well as the outside, unlike a `box-shadow` which is just applied to the outside. Whilst this change isn't necessarily undesirable, I've opted to implement workaround 2. to preserve the existing look.

Here's the difference that workaround 1. would apply:

| current | potential change (not applied) |
|---|---|
| <img width="220" alt="Screenshot 2025-03-11 at 12 24 15" src="https://github.com/user-attachments/assets/f887ce9a-e696-410e-9049-18b425bc078f" /> | <img width="220" alt="Screenshot 2025-03-11 at 12 23 56" src="https://github.com/user-attachments/assets/b932e20b-4b7f-46c6-8b10-b282aaf1fdd9" /> |



## Git Issues

Closes https://github.com/ParentingForLifelongHealth/plh-kids-app-kw-content/issues/174

## Screenshots/Videos

 component in situ within [comp_plh_progress_path](https://docs.google.com/spreadsheets/d/130xy0FbCqgVMg8astiR5FBzuUMfVBHtg9k6wmweE1BA/edit?gid=603128459#gid=603128459):

| before | after |
|---|---|
| <img width="280" alt="Screenshot 2025-03-11 at 12 01 44" src="https://github.com/user-attachments/assets/43c8c1ac-3c76-46a8-a164-9647ad69b61f" /> | <img width="280" alt="Screenshot 2025-03-11 at 12 00 15" src="https://github.com/user-attachments/assets/b5bcc779-3e4e-4f7e-a114-a3c5769c5fe0" /> |



