### PR TITLE
fix: task card badge not-started

### DIFF
--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -126,6 +126,9 @@
     width: 36px;
   }
   .circle {
+    &.notStarted {
+      display: none;
+    }
     box-shadow: var(--ion-default-box-shadow);
     height: 36px;
     width: 36px;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes a regression issue introduced by #2842 whereby a task card component with completion status "notStarted" would display a shadow for an invisible progress badge.

## Git Issues

Closes #2849

## Screenshots/Videos

[comp_progress_path](https://docs.google.com/spreadsheets/d/14BBKG07nqUWDmcscdUMv1AKYSWGBUPCNDT-VcSERHyU/edit?gid=569531329#gid=569531329) template:

<img width="240" alt="Screenshot 2025-03-17 at 11 02 02" src="https://github.com/user-attachments/assets/6f0964ad-6785-480b-9fa7-08c93e3bbb47" />
