### PR TITLE
chore: rename some app config properties; add deprecation migration system

### DIFF
--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -233,7 +233,12 @@ const APP_CONFIG = {
 };
 
 /**
- * Deprecation migrations to support renamed propertiesfor backwards compatibility
+ * List of deprecated app_config properties
+ * These will be replaced at runtime if applied as config overrides
+ *
+ * Mappings should be maintained until methods exist in the parser to ensure authored
+ * configurations are valid. This will require updates to check for template-level
+ * config overrides (deployment and skin configs are otherwise type-checked)
  */
 const DEPRECATION_RULES = {
   APP_FOOTER_DEFAULTS: {
@@ -250,9 +255,7 @@ const DEPRECATION_RULES = {
   },
 };
 
-/**
- * Applies deprecation migrations to the app config, converting deprecated properties to their new equivalents
- */
+/** Convert any deprecated properties to their new equivalents */
 export function applyAppConfigDeprecations(config: RecursivePartial<IAppConfig>) {
   Object.entries(DEPRECATION_RULES).forEach(([configSection, rules]) => {
     const sourceSection = config[configSection];

--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -84,7 +84,7 @@ export type IHeaderFooterBackgroundOptions = "primary" | "secondary" | "none";
 /** The "compact" variant reduces the header height and removes the title */
 export type IHeaderVariantOptions = "default" | "compact";
 
-interface IAppConfigHeaderBase {
+interface IAppConfigHeader {
   back_button: {
     hidden?: boolean;
   };
@@ -97,10 +97,6 @@ interface IAppConfigHeaderBase {
   template: string | null;
   title: string;
   variant: IHeaderVariantOptions;
-}
-
-/** Include deprecated properties for backwards compatibility */
-interface IAppConfigHeader extends IAppConfigHeaderBase {
   /** @deprecated, use "background" instead */
   colour?: IHeaderFooterBackgroundOptions;
 }
@@ -125,13 +121,9 @@ const activeRoute = (location: Location) => {
   return path;
 };
 
-interface IAppConfigFooterBase {
+interface IAppConfigFooter {
   background: IHeaderFooterBackgroundOptions;
   template: string | null;
-}
-
-/** Include deprecated properties for backwards compatibility */
-interface IAppConfigFooter extends IAppConfigFooterBase {
   /** @deprecated, use "background" instead */
   templateName?: string | null;
 }

--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -97,7 +97,7 @@ interface IAppConfigHeader {
   template: string | null;
   title: string;
   variant: IHeaderVariantOptions;
-  /** @deprecated, use "background" instead */
+  /** @deprecated use "background" instead */
   colour?: IHeaderFooterBackgroundOptions;
 }
 
@@ -124,7 +124,7 @@ const activeRoute = (location: Location) => {
 interface IAppConfigFooter {
   background: IHeaderFooterBackgroundOptions;
   template: string | null;
-  /** @deprecated, use "template" instead */
+  /** @deprecated use "template" instead */
   templateName?: string | null;
 }
 

--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -124,7 +124,7 @@ const activeRoute = (location: Location) => {
 interface IAppConfigFooter {
   background: IHeaderFooterBackgroundOptions;
   template: string | null;
-  /** @deprecated, use "background" instead */
+  /** @deprecated, use "template" instead */
   templateName?: string | null;
 }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -45,11 +45,11 @@
         <div class="route-container" [ngStyle]="routeContainerStyle()">
           <ion-router-outlet id="main-content"></ion-router-outlet>
         </div>
-        @if (footerConfig().templateName; as footerTemplateName) {
+        @if (footerConfig().template; as footerTemplate) {
           <ion-footer>
             <ion-toolbar [color]="footerConfig().background">
               <plh-template-container
-                [templatename]="footerTemplateName"
+                [templatename]="footerTemplate"
                 [ignoreQueryParamChanges]="true"
               ></plh-template-container>
             </ion-toolbar>

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -1,13 +1,13 @@
 <ion-header
-  [class.ion-no-border]="headerConfig().colour === 'none'"
+  [class.ion-no-border]="headerConfig().background === 'none'"
   [style.marginTop]="marginTop() + 'px'"
 >
   <!-- When the header is hidden at the app config level, render the ion-toolbar element with 0 height to handle the top safe area on iOS.
  See https://github.com/IDEMSInternational/open-app-builder/issues/2692 -->
   <ion-toolbar
-    [color]="headerConfig().hidden ? 'none' : headerConfig().colour"
+    [color]="headerConfig().hidden ? 'none' : headerConfig().background"
     [class.header-hidden]="headerConfig().hidden"
-    [attr.data-colour]="headerConfig().colour"
+    [attr.data-background]="headerConfig().background"
   >
     @if (!headerConfig().hidden) {
       <ion-buttons slot="start" style="position: absolute">

--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -1,6 +1,6 @@
 ion-toolbar {
   --min-height: var(--header-height);
-  &[data-colour~="none"] {
+  &[data-background~="none"] {
     // Override default ionic settings to make icons and text appear as primary colour
     --ion-color-contrast: var(--ion-color-primary);
   }

--- a/src/app/shared/services/app-config/app-config.service.spec.ts
+++ b/src/app/shared/services/app-config/app-config.service.spec.ts
@@ -10,7 +10,7 @@ import { firstValueFrom } from "rxjs/internal/firstValueFrom";
 import { MockDeploymentService } from "../deployment/deployment.service.mock.spec";
 
 const MOCK_DEPLOYMENT_CONFIG: Partial<IDeploymentRuntimeConfig> = {
-  app_config: { APP_FOOTER_DEFAULTS: { templateName: "mock_footer" } },
+  app_config: { APP_FOOTER_DEFAULTS: { template: "mock_footer" } },
 };
 
 /**
@@ -36,14 +36,14 @@ describe("AppConfigService", () => {
   });
 
   it("applies deployment-specific config overrides on init", () => {
-    expect(service.appConfig().APP_FOOTER_DEFAULTS.templateName).toEqual("mock_footer");
+    expect(service.appConfig().APP_FOOTER_DEFAULTS.template).toEqual("mock_footer");
   });
 
   it("applies skin-level overrides to app config", () => {
     service.setAppConfig({ APP_HEADER_DEFAULTS: { title: "updated" } }, "skin");
     expect(service.appConfig().APP_HEADER_DEFAULTS.title).toEqual("updated");
     // also ensure doesn't unset default deployment
-    expect(service.appConfig().APP_FOOTER_DEFAULTS.templateName).toEqual("mock_footer");
+    expect(service.appConfig().APP_FOOTER_DEFAULTS.template).toEqual("mock_footer");
   });
 
   it("emits partial changes on app config update", async () => {
@@ -55,27 +55,27 @@ describe("AppConfigService", () => {
   });
 
   it("ignores lower-order updates when higher order exists", async () => {
-    service.setAppConfig({ APP_FOOTER_DEFAULTS: { templateName: "template_footer" } }, "template");
-    expect(service.appConfig().APP_FOOTER_DEFAULTS.templateName).toEqual("template_footer");
-    service.setAppConfig({ APP_FOOTER_DEFAULTS: { templateName: "skin_footer" } }, "skin");
-    expect(service.appConfig().APP_FOOTER_DEFAULTS.templateName).toEqual("template_footer");
+    service.setAppConfig({ APP_FOOTER_DEFAULTS: { template: "template_footer" } }, "template");
+    expect(service.appConfig().APP_FOOTER_DEFAULTS.template).toEqual("template_footer");
+    service.setAppConfig({ APP_FOOTER_DEFAULTS: { template: "skin_footer" } }, "skin");
+    expect(service.appConfig().APP_FOOTER_DEFAULTS.template).toEqual("template_footer");
     // the second service set should not trigger any changes to appConfig signal (or observable)
     expect(appConfigSetSpy).toHaveBeenCalledTimes(1);
   });
 
   it("reverts to initial config values when all overrides removed", async () => {
-    service.setAppConfig({ APP_FOOTER_DEFAULTS: { templateName: "template_footer" } }, "template");
-    expect(service.appConfig().APP_FOOTER_DEFAULTS.templateName).toEqual("template_footer");
+    service.setAppConfig({ APP_FOOTER_DEFAULTS: { template: "template_footer" } }, "template");
+    expect(service.appConfig().APP_FOOTER_DEFAULTS.template).toEqual("template_footer");
     service.setAppConfig({}, "template");
-    expect(service.appConfig().APP_FOOTER_DEFAULTS.templateName).toEqual("mock_footer");
+    expect(service.appConfig().APP_FOOTER_DEFAULTS.template).toEqual("mock_footer");
   });
 
   it("reverts to lower order config values when higher order override removed", async () => {
-    service.setAppConfig({ APP_FOOTER_DEFAULTS: { templateName: "skin_footer" } }, "skin");
-    expect(service.appConfig().APP_FOOTER_DEFAULTS.templateName).toEqual("skin_footer");
-    service.setAppConfig({ APP_FOOTER_DEFAULTS: { templateName: "template_footer" } }, "template");
-    expect(service.appConfig().APP_FOOTER_DEFAULTS.templateName).toEqual("template_footer");
+    service.setAppConfig({ APP_FOOTER_DEFAULTS: { template: "skin_footer" } }, "skin");
+    expect(service.appConfig().APP_FOOTER_DEFAULTS.template).toEqual("skin_footer");
+    service.setAppConfig({ APP_FOOTER_DEFAULTS: { template: "template_footer" } }, "template");
+    expect(service.appConfig().APP_FOOTER_DEFAULTS.template).toEqual("template_footer");
     service.setAppConfig({}, "template");
-    expect(service.appConfig().APP_FOOTER_DEFAULTS.templateName).toEqual("skin_footer");
+    expect(service.appConfig().APP_FOOTER_DEFAULTS.template).toEqual("skin_footer");
   });
 });

--- a/src/app/shared/services/app-config/app-config.service.ts
+++ b/src/app/shared/services/app-config/app-config.service.ts
@@ -1,5 +1,10 @@
 import { Injectable, signal } from "@angular/core";
-import { getDefaultAppConfig, IAppConfig, IAppConfigOverride } from "data-models";
+import {
+  getDefaultAppConfig,
+  IAppConfig,
+  IAppConfigOverride,
+  applyAppConfigDeprecations,
+} from "data-models";
 import { BehaviorSubject } from "rxjs";
 import { deepMergeObjects, RecursivePartial, trackObservableObjectChanges } from "../../utils";
 import { SyncServiceBase } from "../syncService.base";
@@ -78,6 +83,8 @@ export class AppConfigService extends SyncServiceBase {
    * with the initial config
    */
   public setAppConfig(overrides: IAppConfigOverride = {}, source: IAppConfigOverrideSource) {
+    overrides = applyAppConfigDeprecations(overrides);
+
     // use override source to specify index used in override order
     const overrideIndex = APP_CONFIG_OVERRIDE_ORDER[source];
 

--- a/src/app/shared/services/skin/skin.service.spec.ts
+++ b/src/app/shared/services/skin/skin.service.spec.ts
@@ -23,7 +23,7 @@ class MockTemplateService implements Partial<TemplateService> {
 
 const MOCK_SKIN_1: IAppSkin = {
   name: "MOCK_SKIN_1",
-  appConfig: { APP_HEADER_DEFAULTS: { title: "mock 1", colour: "primary" } },
+  appConfig: { APP_HEADER_DEFAULTS: { title: "mock 1", background: "primary" } },
 };
 const MOCK_SKIN_2: IAppSkin = {
   name: "MOCK_SKIN_2",
@@ -37,7 +37,7 @@ const MOCK_APP_CONFIG: Partial<IAppConfig> = {
     template: null,
     title: "default",
     collapse: false,
-    colour: "none",
+    background: "none",
     variant: "default",
   },
   APP_SKINS: {

--- a/src/app/shared/services/skin/skin.service.spec.ts
+++ b/src/app/shared/services/skin/skin.service.spec.ts
@@ -49,7 +49,7 @@ const MOCK_APP_CONFIG: Partial<IAppConfig> = {
     defaultThemeName: "MOCK_THEME_1",
   },
   APP_FOOTER_DEFAULTS: {
-    templateName: "mock_footer",
+    template: "mock_footer",
     background: "primary",
   },
 };
@@ -88,7 +88,7 @@ describe("SkinService", () => {
 
   it("does not change non-overridden values", () => {
     expect(service["appConfigService"].appConfig().APP_FOOTER_DEFAULTS).toEqual({
-      templateName: "mock_footer",
+      template: "mock_footer",
       background: "primary",
     });
   });


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Renames some app config properties for consistency. After merge, the new names should be used going forward.
  - `APP_FOOTER_DEFAULTS.templateName` -> `APP_FOOTER_DEFAULTS.template`
  - `APP_HEADER_DEFAULTS.colour` -> `APP_HEADER_DEFAULTS.background`
- Introduces a way to handle renaming app config properties such as these in such a way as to continue to support deprecated names

There should be no functional changes. 

## Testing

Test all templates within [feature_app_layout](https://docs.google.com/spreadsheets/d/1Z46gTluTPeffqpiAZMapYo0imm59GU03j0sW9UChvPM/edit?gid=3937162#gid=3937162), e.g. [feat_app_layout_custom_footer](https://docs.google.com/spreadsheets/d/1Z46gTluTPeffqpiAZMapYo0imm59GU03j0sW9UChvPM/edit?gid=569531329#gid=569531329), to ensure header and footer overrides are still functioning as expected.

## Git Issues

Closes #

## Screenshots/Videos

Highlighting of deprecated properties in deployment config (`debug` deployment):

<img width="600" alt="Screenshot 2025-03-18 at 15 14 25" src="https://github.com/user-attachments/assets/08414ebf-4f59-48f5-8bfe-b81746720e05" />
