### PR TITLE
Feat: apple auth

### DIFF
--- a/capacitor.config.template.ts
+++ b/capacitor.config.template.ts
@@ -16,7 +16,7 @@ const config: CapacitorConfig = {
     },
     FirebaseAuthentication: {
       skipNativeAuth: false,
-      providers: ["google.com"],
+      providers: ["google.com", "apple.com"],
     },
   },
   server: {

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -4,6 +4,7 @@ App/output
 App/App/public
 DerivedData
 xcuserdata
+App.xcscheme
 
 # Cordova plugins for Capacitor
 capacitor-cordova-ios-plugins

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -53,7 +53,7 @@ export interface IDeploymentRuntimeConfig {
     config: {
       apiKey: string;
       authDomain: string;
-      databaseURL: string;
+      databaseURL?: string;
       projectId: string;
       storageBucket: string;
       messagingSenderId: string;

--- a/src/app/shared/services/auth/auth.service.ts
+++ b/src/app/shared/services/auth/auth.service.ts
@@ -116,6 +116,7 @@ export class AuthService extends AsyncServiceBase {
         const [actionId] = args;
         const childActions = {
           sign_in_google: async () => await this.provider.signInWithGoogle(),
+          sign_in_apple: async () => await this.provider.signInWithApple(),
           sign_out: async () => await this.provider.signOut(),
         };
         if (!(actionId in childActions)) {

--- a/src/app/shared/services/auth/providers/base.auth.ts
+++ b/src/app/shared/services/auth/providers/base.auth.ts
@@ -6,6 +6,11 @@ export class AuthProviderBase {
 
   public async initialise(injector: Injector) {}
 
+  public async signInWithApple() {
+    throw new Error("Apple sign in not enabled");
+    return this.authUser();
+  }
+
   public async signInWithGoogle() {
     throw new Error("Google sign in not enabled");
     return this.authUser();

--- a/src/app/shared/services/auth/providers/firebase.auth.ts
+++ b/src/app/shared/services/auth/providers/firebase.auth.ts
@@ -1,5 +1,9 @@
 import { Injectable, Injector } from "@angular/core";
-import { FirebaseAuthentication, User } from "@capacitor-firebase/authentication";
+import {
+  AdditionalUserInfo,
+  FirebaseAuthentication,
+  User,
+} from "@capacitor-firebase/authentication";
 import { getAuth, initializeAuth, indexedDBLocalPersistence, Auth } from "firebase/auth";
 import { FirebaseService } from "../../firebase/firebase.service";
 import { AuthProviderBase } from "./base.auth";
@@ -28,15 +32,22 @@ export class FirebaseAuthProvider extends AuthProviderBase {
     await this.handleAutomatedLogin();
   }
 
+  public async signInWithApple() {
+    console.log("signInWithApple");
+    const result = await FirebaseAuthentication.signInWithApple();
+    const { user, additionalUserInfo } = result;
+    console.log("signInWithApple result", result);
+    if (user) {
+      // Note: Apple allows for anonymous sign-in so profile info may be minimal
+      this.saveUserInfo(user, additionalUserInfo);
+    }
+    return this.authUser();
+  }
+
   public async signInWithGoogle() {
     const { user, additionalUserInfo } = await FirebaseAuthentication.signInWithGoogle();
     if (user) {
-      // NOTE - additionalUserInfo is only returned on first signIn so persist to localStorage
-      // for access on automated sign-in following restart. Use fallback empty object if null
-      const { profile = {} } = additionalUserInfo;
-      localStorage.setItem(AUTH_METADATA_FIELD, JSON.stringify(profile));
-
-      this.setAuthUser(user, profile);
+      this.saveUserInfo(user, additionalUserInfo);
     }
     return this.authUser();
   }
@@ -67,8 +78,18 @@ export class FirebaseAuthProvider extends AuthProviderBase {
     const authUser: IAuthUser = {
       ...profile,
       uid: user.uid,
+      name: user.displayName,
     };
     this.authUser.set(authUser);
+  }
+
+  private saveUserInfo(user: User, additionalUserInfo: AdditionalUserInfo) {
+    // NOTE - additionalUserInfo is only returned on first signIn so persist to localStorage
+    // for access on automated sign-in following restart. Use fallback empty object if null
+    const { profile = {} } = additionalUserInfo;
+    localStorage.setItem(AUTH_METADATA_FIELD, JSON.stringify(profile));
+
+    this.setAuthUser(user, profile);
   }
 
   /**

--- a/src/app/shared/services/auth/providers/firebase.auth.ts
+++ b/src/app/shared/services/auth/providers/firebase.auth.ts
@@ -33,13 +33,12 @@ export class FirebaseAuthProvider extends AuthProviderBase {
   }
 
   public async signInWithApple() {
-    console.log("signInWithApple");
-    const result = await FirebaseAuthentication.signInWithApple();
-    const { user, additionalUserInfo } = result;
-    console.log("signInWithApple result", result);
+    const { user, additionalUserInfo } = await FirebaseAuthentication.signInWithApple();
     if (user) {
       // Note: Apple allows for anonymous sign-in so profile info may be minimal
-      this.saveUserInfo(user, additionalUserInfo);
+      const { profile = {} } = additionalUserInfo;
+      this.setAuthUser(user, profile);
+      this.saveUserInfo(user, profile);
     }
     return this.authUser();
   }
@@ -47,7 +46,9 @@ export class FirebaseAuthProvider extends AuthProviderBase {
   public async signInWithGoogle() {
     const { user, additionalUserInfo } = await FirebaseAuthentication.signInWithGoogle();
     if (user) {
-      this.saveUserInfo(user, additionalUserInfo);
+      const { profile = {} } = additionalUserInfo;
+      this.setAuthUser(user, profile);
+      this.saveUserInfo(user, profile);
     }
     return this.authUser();
   }
@@ -83,13 +84,10 @@ export class FirebaseAuthProvider extends AuthProviderBase {
     this.authUser.set(authUser);
   }
 
-  private saveUserInfo(user: User, additionalUserInfo: AdditionalUserInfo) {
+  private saveUserInfo(user: User, profile: AdditionalUserInfo["profile"]) {
     // NOTE - additionalUserInfo is only returned on first signIn so persist to localStorage
     // for access on automated sign-in following restart. Use fallback empty object if null
-    const { profile = {} } = additionalUserInfo;
     localStorage.setItem(AUTH_METADATA_FIELD, JSON.stringify(profile));
-
-    this.setAuthUser(user, profile);
   }
 
   /**


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Enables sign in via Apple using Firebase auth.

To enable the feature for given deployment, additional configuration is required in both the associated project in the Firebase console and the associated app in the Apple Developer console. See Firebase docs, with links to relevant Apple docs, [here](https://firebase.google.com/docs/auth/ios/apple).

## Testing

- [iOS appetize link](https://appetize.io/app/b_yswli5qmzbdnltj7dmf6pdmhlq?device=iphone14pro&osVersion=16.2&toolbar=true)
- Web funcitonality can be tested by checking out this feature branch, syncing debug content, and running the app locally
  - The functionality is not currently working on web preview for me via the web preview for this PR: I get an "unauthorised domain" error, despite having added the URL to the whitelisted domains in the Authentication section of the [Firebase console for the debug project](https://console.firebase.google.com/u/1/project/debug-e8934/authentication/settings). This may be due to the fact that the hosting for the debug deployment is set to use a different Firebase project (`plh-teens-app1`) vs the one for which auth is configured (`debug`).
- Android functionality should be testable after merging https://github.com/IDEMSInternational/open-app-builder/pull/2836
  - Will need to upload a signed build to appetize and configure the associated SHA keys for the android app in the `debug` firebase project

## Follow-ups

- [ ] Create dedicated Apple Sign In button component, equivalent to #2788
  - #2871
- [ ] Enable authors to tailor content based on device platform
  - #2870
- [ ] Enable Apple Sign In for iOS apps of the specific desired deployments
  - chiefly `plh_kids_kw`, but also `plh_facilitator_mx`
- [ ] Test and debug feature on Android
  - #2876

## Git Issues

Closes #

## Screenshots/Videos

Demos use [example_auth](https://docs.google.com/spreadsheets/d/12xo0ewDN0bbeVrs3klWd9J8DkFQLTCYX1zhGWnovqIo/edit?gid=579616705#gid=579616705) template

<img width="800" alt="Screenshot 2025-03-25 at 15 20 34" src="https://github.com/user-attachments/assets/8ca902b2-b004-45b7-a16c-1cdcb013541c" />

### Web

https://github.com/user-attachments/assets/5138fd8a-d743-4094-9492-ac3ff11a7568

### iOS

#### emulator
Initially I wasn't signed in with my Apple ID at the level of the emulated device settings, and got this message:

https://github.com/user-attachments/assets/aaec3230-f699-43ca-acfd-e08ccee08db7

I've edited out the process of signing in at the device level, but returning to the app after doing so, I was able to sign in via the template action:

https://github.com/user-attachments/assets/3f37bc9d-7c92-4a83-9556-217d151a6196

#### appetize

Sign in success on appetize (again, I needed to sign in at the device level first):

<img width="240" alt="Screenshot 2025-03-25 at 15 28 32" src="https://github.com/user-attachments/assets/78f80626-3bc9-4579-ba7e-3dd6ca3ee132" />

