### PR TITLE
feat: add 'platform' protected field

### DIFF
--- a/packages/data-models/fields.ts
+++ b/packages/data-models/fields.ts
@@ -19,6 +19,7 @@ enum PROTECTED_FIELDS {
   DEPLOYMENT_NAME = "deployment_name",
   FEEDBACK_SELECTED_TEXT = "feedback_selected_text",
   FEEDBACK_SIDEBAR_OPEN = "feedback_sidebar_open",
+  PLATFORM = "platform",
   SERVER_SYNC_LATEST = "server_sync_latest",
 }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -161,6 +161,7 @@ export class AppComponent {
     this.localStorageService.setProtected("DEPLOYMENT_NAME", name);
     this.localStorageService.setProtected("APP_VERSION", _app_builder_version);
     this.localStorageService.setProtected("CONTENT_VERSION", _content_version);
+    this.localStorageService.setProtected("PLATFORM", Capacitor.getPlatform());
     // HACK - ensure first_app_launch migrated from event service
     if (!this.localStorageService.getProtected("APP_FIRST_LAUNCH")) {
       await this.appEventService.ready();


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new protected field to track the platform that the app is currently running on. This is accessible through the `_platform` field, e.g. `@fields._platform`.

This field has three possible values: `"web"`, `"ios"` or `"android"`. These can be used for string comparison, e.g. in a condition on a row: `@fields._platform === "ios"`, to only show that row when the app is running on an ios device.

Note that when running on web, "web" will always be the returned value, even when devtools device mode is set to an android or ios device.

## Git Issues

Closes #2870

## Screenshots/Videos

Demos of [example_protected_fields](https://docs.google.com/spreadsheets/d/1X10C5YWsqJ7NRJp-pSiaYjdAoV4hl5-scvisiBThmq8/edit?gid=460679842#gid=460679842) template (previously called "example_hardcoded_fields")

<img width="600" alt="Screenshot 2025-03-27 at 15 11 55" src="https://github.com/user-attachments/assets/03d1e7e0-3e98-42cb-92dd-893eaf2c4c31" />

### web

<img width="400" alt="Screenshot 2025-03-27 at 14 55 57" src="https://github.com/user-attachments/assets/58278313-61cc-47ae-907d-889f9d8e93c7" />

### ios:

[appetize link](https://appetize.io/app/ios/international.idems.debug-app?device=iphone14pro&osVersion=16.2&toolbar=true)


<img width="297" alt="Screenshot 2025-03-27 at 14 57 15" src="https://github.com/user-attachments/assets/e4574c4b-8567-4ead-b8e6-17d28bfcfc45" />


### android

[appetize link](https://appetize.io/app/android/international.idems.debug_app?device=pixel7&osVersion=13.0&toolbar=true)

<img width="288" alt="Screenshot 2025-03-27 at 15 10 56" src="https://github.com/user-attachments/assets/b198b0a1-518d-4e49-b0a5-67d8c22b2ec6" />




