### PR TITLE
Fix: dynamic data delete

### DIFF
--- a/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
@@ -17,7 +17,8 @@ addRxPlugin(RxDBUpdatePlugin);
 import { debounceTime, filter, firstValueFrom, Subject } from "rxjs";
 
 import { FlowTypes } from "data-models";
-import { compareObjectKeys, deepMergeObjects } from "../../../utils";
+import { deepMergeObjects } from "../../../utils";
+import { arrayToHashmap, diffObjects } from "packages/shared/src/utils/object-utils";
 
 /**
  * All persisted docs are stored in the same format with a standard set of meta fields and doc data

--- a/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
@@ -140,7 +140,22 @@ export class PersistedMemoryAdapter {
     this.persistStateToDB();
   }
 
-  public delete(flow_type: FlowTypes.FlowType, flow_name: string, ids?: string[]) {
+  /** Set data for a given entry. Will overwrite any existing data */
+  public set(update: IDataUpdate) {
+    const { flow_name, flow_type, id, data } = update;
+    if (!this.state[flow_type]) this.state[flow_type] = {};
+    if (!this.state[flow_type][flow_name]) this.state[flow_type][flow_name] = {};
+    // Remove any values marked as undefined
+    for (const [key, value] of Object.entries(data)) {
+      if (value === undefined) {
+        delete data[key];
+      }
+    }
+    this.state[flow_type][flow_name][id] = data;
+    this.persistStateToDB();
+  }
+
+  public async delete(flow_type: FlowTypes.FlowType, flow_name: string, ids?: string[]) {
     const stateRef = this.get(flow_type, flow_name);
     if (!stateRef) return;
     // delete individuals
@@ -149,11 +164,11 @@ export class PersistedMemoryAdapter {
         delete this.state[flow_type][flow_name][id];
       }
     }
-    // delete all
+    // delete all - mark as empty so it still persists to disk
     else {
-      delete this.state[flow_type][flow_name];
+      this.state[flow_type][flow_name] = {};
     }
-    this.persistStateToDB();
+    await this.persistStateToDB();
   }
 
   public async deleteAll() {
@@ -185,34 +200,44 @@ export class PersistedMemoryAdapter {
   }
 
   /**
-   * TODO - could perform more incremental updates and avoid overwrite with same data
-   */
+   * Compare in-memory and persisted states, and update persisted state to match memory
+   **/
   private async handleStatePersist() {
-    // Handle insertions and updates
-    const updates: IPersistedDoc[] = [];
+    const persistedState = await this.getPersistedHashmap();
+    const currentState = this.getStateHashmap();
+
+    const ops = diffObjects(persistedState, currentState);
+    const upsert = [...ops.add, ...ops.update].map(({ value }) => value);
+
+    await this.collection.bulkUpsert(upsert);
+    await this.collection.bulkRemove(ops.delete.map(({ key }) => key));
+  }
+
+  /**
+   * Get a flattened hashmap of all rows, keyed by flow_type, name and row id, e.g.
+   * ```ts
+   * {
+   *  data_list__module_list__row_1 : {....},
+   *  data_list__module_list__row_2 : {....}
+   * }
+   * ```
+   */
+  private getStateHashmap() {
+    const hashmap: Record<string, any> = {};
     for (const [flow_type, flowHash] of Object.entries(this.state)) {
       for (const [flow_name, rowHash] of Object.entries(flowHash)) {
-        for (const [row_id, update] of Object.entries(rowHash)) {
+        for (const [row_id, data] of Object.entries(rowHash)) {
           const id = `${flow_type}__${flow_name}__${row_id}`;
-          updates.push({ id, row_id, flow_type, flow_name, data: update });
+          hashmap[id] = { id, row_id, flow_type, flow_name, data };
         }
       }
     }
-    await this.collection.bulkUpsert(updates);
-
-    // Handle deletions (check for flows that exist in DB but not in state, and remove from DB)
-    const db = await this.mapDBToObject({});
-    const idsToDelete = [];
-    for (const flow_type of Object.keys(db)) {
-      const { deleted } = compareObjectKeys(db[flow_type], this.state[flow_type]);
-      for (const flow_name of deleted) {
-        const rowHash = db[flow_type][flow_name];
-        for (const row_id of Object.keys(rowHash)) {
-          idsToDelete.push(`${flow_type}__${flow_name}__${row_id}`);
-        }
-      }
-    }
-    this.collection.bulkRemove(idsToDelete);
+    return hashmap;
+  }
+  private async getPersistedHashmap() {
+    const res: RxDocument[] = await this.collection.find().exec();
+    const docs = res.map((r) => r.toMutableJSON() as IPersistedDoc);
+    return arrayToHashmap(docs, "id");
   }
 
   private async mapDBToState() {

--- a/src/app/shared/services/dynamic-data/adapters/reactiveMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/reactiveMemory.ts
@@ -152,6 +152,12 @@ export class ReactiveMemoryAdapter {
     return success;
   }
 
+  public async bulkUpsert(name: string, docs: any[]) {
+    // NOTE - rxdb 16 bulkUpsert does not track error/success the same as bulkInsert
+    const res = await this.db.collections[name].bulkUpsert(docs);
+    return res;
+  }
+
   /** Update doc or create new if doc with that ID doesn't already exist (upsert) */
   public async updateDoc(update: IDataUpdate) {
     const { collectionName, id, data } = update;


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

**TODO**
- [x] Merge after #2901 and rebase (currently targets pr branch for clearer diff)

## Description
Part of #2899 tidying
Fix issue where dynamic data would not delete correctly

## Dev Notes
The issue is related to the way the state persist methods would compare what is currently stored in the indexeddb vs what is in cache, relying on looking at keys in hashmaps such as `{data_list: {list_1 : {row_1: ...}}}`. 

There main problem was that the comparison only looked one level deep, so would detect if an entire list was added/removed, but not individual rows. So to fix I've refactored to generate a flatter hashmap, where every entried is keyed by a combination of flow_type, list_id and row_id, e.g. `{data_list__list_1__row_1:{...}}`

I don't think this has much impact for current apps as resetting flows to original state still work as expected (would only have been noticed if deleting rows from data-items on lists that do not have initial data) 

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
