### PR TITLE
fix: template-injection-context

### DIFF
--- a/src/app/shared/components/template/services/instance/template-process.service.ts
+++ b/src/app/shared/components/template/services/instance/template-process.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from "@angular/core";
+import { Injectable, Injector, runInInjectionContext } from "@angular/core";
 import { FlowTypes } from "data-models";
 import { AppDataService } from "src/app/shared/services/data/app-data.service";
 import { getGlobalService } from "src/app/shared/services/global.service";
@@ -53,21 +53,24 @@ export class TemplateProcessService extends SyncServiceBase {
   public async processTemplateWithoutRender(template: FlowTypes.Template) {
     console.log("[Template Process]", template.flow_name);
     this.ensurePublicMethodServices();
-    // Create mock template container component
-    this.container = new TemplateContainerComponent(
-      this.templateService,
-      this.templateNavService,
-      this.injector
-    );
-    // this.container.name = this.container.name || this.templatename;
-    // this.templateBreadcrumbs = [...(this.parent?.templateBreadcrumbs || []), this.name];
-    this.container.template = template;
-    // reset any existing templateRowMap data
-    this.container.templateRowService.templateRowMap = {};
-    this.container.templateRowService.templateRowMapValues = {};
-    // process the template as if it were rendered
-    // TODO - should filter out template rows to only include those used programatically (e.g. set_variable, set_field etc.)
-    await this.container.templateRowService.processContainerTemplateRows();
+    // Use injection context to avoid error thrown by templatename input signal
+    runInInjectionContext(this.injector, async () => {
+      // Create mock template container component
+      this.container = new TemplateContainerComponent(
+        this.templateService,
+        this.templateNavService,
+        this.injector
+      );
+      // this.container.name = this.container.name || this.templatename;
+      // this.templateBreadcrumbs = [...(this.parent?.templateBreadcrumbs || []), this.name];
+      this.container.template = template;
+      // reset any existing templateRowMap data
+      this.container.templateRowService.templateRowMap = {};
+      this.container.templateRowService.templateRowMapValues = {};
+      // process the template as if it were rendered
+      // TODO - should filter out template rows to only include those used programatically (e.g. set_variable, set_field etc.)
+      await this.container.templateRowService.processContainerTemplateRows();
+    });
   }
 
   public async initialiseStartupTemplates() {

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -77,20 +77,14 @@ export class TemplateContainerComponent implements OnInit, OnDestroy {
     public elRef?: ElementRef,
     private route?: ActivatedRoute
   ) {
-    effect(
-      () => {
-        // re-render template whenever input template name changes
-        // TODO - this isn't passed when running standalone. Should ideally de-couple render/service logic
-        const templatename = this.templatename();
-        if (templatename) {
-          this.hostTemplateName = templatename;
-          this.renderTemplate(templatename);
-        }
-      },
-      // NOTE - pass the injector from the constructor as angular will not be able
-      // to auto-determine injector when called from a standalone template
-      { injector }
-    );
+    effect(() => {
+      // re-render template whenever input template name changes
+      const templatename = this.templatename();
+      if (templatename) {
+        this.hostTemplateName = templatename;
+        this.renderTemplate(templatename);
+      }
+    });
     this.templateActionService = new TemplateActionService(injector, this);
     this.templateRowService = new TemplateRowService(injector, this);
   }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
Fix issue where startup templates would fail to load due to updated way angular checks templates before render (likely following #2900)

## Dev Notes
When running as a standalone template the signal input isn't actually used, but it appears the angular compiler has gotten more sensitive to the potential of using when not in injection context. So simple workaround is to just pass an injection context to the standalone templates (even if not used)

Now that the container is created in an injection context it's possible to remove the previous workaround for handling effect injection context

## Git Issues

Closes #2906

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
