### PR TITLE
fix: data items external field

### DIFF
--- a/src/app/shared/components/template/components/base.ts
+++ b/src/app/shared/components/template/components/base.ts
@@ -22,8 +22,8 @@ export class TemplateBaseComponent implements ITemplateRowProps {
 
   // TODO - main row should just be an input.required and child code refactored to avoid set override
   // TODO - could also consider whether setting parent required (is it template row map or services?), possibly merge with row
-  // NOTE - the signal does not use an `{equal: isEqual}` optimisation to allow field variable updates
-  // to still trigger signal update on external field update
+  // NOTE - the signal does not use an `{equal: isEqual}` optimisation to allow signal update on external
+  // field set: https://github.com/IDEMSInternational/open-app-builder/pull/2915
   rowSignal = signal<FlowTypes.TemplateRow>(undefined);
   value = computed(() => this.rowSignal()?.value, { equal: isEqual });
   parameterList = computed(() => this.rowSignal().parameter_list || {}, { equal: isEqual });

--- a/src/app/shared/components/template/components/base.ts
+++ b/src/app/shared/components/template/components/base.ts
@@ -22,7 +22,9 @@ export class TemplateBaseComponent implements ITemplateRowProps {
 
   // TODO - main row should just be an input.required and child code refactored to avoid set override
   // TODO - could also consider whether setting parent required (is it template row map or services?), possibly merge with row
-  rowSignal = signal<FlowTypes.TemplateRow>(undefined, { equal: isEqual });
+  // NOTE - the signal does not use an `{equal: isEqual}` optimisation to allow field variable updates
+  // to still trigger signal update on external field update
+  rowSignal = signal<FlowTypes.TemplateRow>(undefined);
   value = computed(() => this.rowSignal()?.value, { equal: isEqual });
   parameterList = computed(() => this.rowSignal().parameter_list || {}, { equal: isEqual });
   actionList = computed<FlowTypes.TemplateRowAction[]>(() => this.rowSignal().action_list || [], {


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
From [mattermost](https://chat.idems.international/all/pl/1zzd7a456inmbkwygpf5d7o5kw) - fix implementing option (1)

---

The issue appears related to the use of rowSignal, which is currently set to only update when the templated row changes, i.e.
```ts
rowSignal = signal<FlowTypes.TemplateRow>(undefined, { equal: isEqual });
```
However, as this is passing reference to local variables which is evaluated in the component itself, e.g. (`@local.some_var`) that means external changes to the local variables do not trigger re-evaluation

So the options are either
1) Remove the isEqual optimisation, which will force reprocessing whenever the parent component re-renders (which happens after every set_field action)

or 
2) Add specific listeners to the data-items service to track external variables and reprocess as required

## Review Notes
Test example in [debug_data_items_local](https://docs.google.com/spreadsheets/d/14XXwZ7R_7qIBo5xKYuxnPVQbQidI--PPJ7TVvZxwy1k/edit?gid=1990453574#gid=1990453574)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
