### PR TITLE
fix: service init defer

### DIFF
--- a/src/app/feature/shared-data/shared-data.service.ts
+++ b/src/app/feature/shared-data/shared-data.service.ts
@@ -49,7 +49,7 @@ export class SharedDataService extends AsyncServiceBase {
   ) {
     super("Shared Data");
     this.provider = getDataProvider(this.config.provider);
-    this.registerInitFunction(this.initialise);
+    this.registerInitFunction(this.initialise, "defer");
   }
 
   /**
@@ -265,6 +265,7 @@ export class SharedDataService extends AsyncServiceBase {
   }
 
   private async initialise() {
+    console.trace("[shared data] init");
     await this.provider.initialise(this.injector);
     await this.dynamicDataService.ready();
   }

--- a/src/app/feature/shared-data/shared-data.service.ts
+++ b/src/app/feature/shared-data/shared-data.service.ts
@@ -265,7 +265,6 @@ export class SharedDataService extends AsyncServiceBase {
   }
 
   private async initialise() {
-    console.trace("[shared data] init");
     await this.provider.initialise(this.injector);
     await this.dynamicDataService.ready();
   }

--- a/src/app/shared/services/asyncService.base.ts
+++ b/src/app/shared/services/asyncService.base.ts
@@ -44,7 +44,8 @@ export class AsyncServiceBase {
    * On the plus side it means extended class init methods can be marked as private and do not have
    * to be called init
    *
-   * @param callImmediately Call init function immediately (default false, defer until first `ready()` called)
+   * @param strategy specify whether the service should automatically call the init after a delay (default)
+   * or whether to defer calling init until related service calls `ready()` function
    */
   public registerInitFunction(fn: () => Promise<void>, strategy: "delay" | "defer" = "delay") {
     this.initFunction = fn;

--- a/src/app/shared/services/asyncService.base.ts
+++ b/src/app/shared/services/asyncService.base.ts
@@ -46,16 +46,20 @@ export class AsyncServiceBase {
    *
    * @param callImmediately Call init function immediately (default false, defer until first `ready()` called)
    */
-  public registerInitFunction(fn: () => Promise<void>, callImmediately = false) {
+  public registerInitFunction(fn: () => Promise<void>, strategy: "delay" | "defer" = "delay") {
     this.initFunction = fn;
-    if (callImmediately) {
-      this.callInitFunction();
+    // HACK - specify random delay to ensure initialised but at random time after template init (5-10s)
+    if (strategy === "delay") {
+      setTimeout(
+        () => {
+          this.callInitFunction();
+        },
+        5000 + Math.random() * 5000
+      );
     }
-    // HACK - until code a bit tidier ensure all services still register after random timeout (5-10s)
-    else {
-      setTimeout(() => {
-        this.callInitFunction();
-      }, 5000 + Math.random() * 5000);
+    // Avoiding calling init function until service ready call
+    if (strategy === "defer") {
+      return;
     }
   }
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Fix issue where shared-data service would attempt to register even when not in use. E.g. shared-data
![image](https://github.com/user-attachments/assets/09c66f7f-ff58-408e-b788-f989ff7eb708)

## Review Notes
Confirm that `shared-data` service no longer tries to initialise (which throws error on any deployment without firebase enabled)

## Dev Notes
Looking at the async service base, it appears that all services were set by default to call their init function after a random delay, with an optional override to call immediately. I think both of these options are somewhat part of legacy code (now pretty much all services explicitly await `ready` calls which in-turn triggers init if not already triggered), however I'm slightly wary of refactoring right now in case of unintended knock-ons

As such I've added a new option to `defer` init, which will explicitly prevent the delayed init being called. I've also removed the `callImmediately` option as no services in the existing codebase set that corresponding arg

## Git Issues

Closes #

## Screenshots/Videos
Example checking code for any services that register init function with the `callImmediately` variable set. This would be indicated by `this.registerInitFunction(..., true)` in previous syntax.
![image](https://github.com/user-attachments/assets/6168724d-7eb6-4231-a1d7-e2e8d9af74d7)
