### PR TITLE
fix: accordion style for kw-based themes

### DIFF
--- a/src/theme/themes/plh_facilitator_mapa/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mapa/_overrides.scss
@@ -521,7 +521,6 @@ body[data-theme="plh_facilitator_mapa"] {
       align-items: flex-start;
       min-width: 220px;
       width: 100%;
-      --inner-padding-end: 0px;
     }
     ion-item.accordion-content {
       border-top: 1px solid var(--color-outline-variant) !important;

--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -521,7 +521,6 @@ body[data-theme="plh_facilitator_mx"] {
       align-items: flex-start;
       min-width: 220px;
       width: 100%;
-      --inner-padding-end: 0px;
     }
     ion-item.accordion-content {
       border-top: 1px solid var(--color-outline-variant) !important;

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -304,7 +304,6 @@ body[data-theme="plh_kids_kw"] {
       align-items: flex-start;
       min-width: 220px;
       width: 100%;
-      --inner-padding-end: 0px;
     }
     ion-item.accordion-content {
       border-top: 1px solid var(--color-outline-variant) !important;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the icon in the accordion component would appear fully aligned to the end of the element, for themes based on the `plh_kids_kw` theme. This was presumably an unexpected knock-on from #2890.

The themes affected are:
- `plh_kids_kw`
- `plh_facilitator_mx`
- `plh_facilitator_mapa`

As we don't currently have inheritance between these themes, I've just made the minor update manually to each theme.

## Git Issues

Closes #2921

## Screenshots/Videos

Demo of [comp_accordion](https://docs.google.com/spreadsheets/d/1He3nS_qWno-_kJrzizhcUdC1vONKWaluPzC1rr-RfSw/edit?gid=569531329#gid=569531329) for `plh_kids_kw` theme:

| LTR | RTL |
|---|---|
| <img width="640" alt="Screenshot 2025-05-01 at 12 35 04" src="https://github.com/user-attachments/assets/109c8fe0-1e3c-498a-8750-67cc41c5530d" /> | <img width="640" alt="Screenshot 2025-05-01 at 12 37 19" src="https://github.com/user-attachments/assets/6befd412-a48a-48e6-8cd2-32f267485905" /> |


