### PR TITLE
feat: navigation_bar component style variants

### DIFF
--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.html
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.html
@@ -1,14 +1,17 @@
-<div class="navigation-bar-wrapper">
-  <a
-    *ngFor="let button of buttonList"
-    class="button-wrapper"
-    routerLinkActive="active-link"
-    [routerLink]="'template/' + button.target_template"
-    [attr.data-name]="button.name"
-  >
-    <div class="image-wrapper">
-      <img [src]="button.image | plhAsset" />
-    </div>
-    <p *ngIf="button.text">{{ button.text }}</p>
-  </a>
+<div class="navigation-bar-wrapper" [attr.data-variant]="params().variant">
+  @for (button of params().buttonList; track button.name) {
+    <a
+      class="button-wrapper"
+      routerLinkActive="active-link"
+      [routerLink]="'template/' + button.target_template"
+      [attr.data-name]="button.name"
+    >
+      <div class="image-wrapper">
+        <img [src]="button.image | plhAsset" />
+      </div>
+      @if (button.text) {
+        <p>{{ button.text }}</p>
+      }
+    </a>
+  }
 </div>

--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.scss
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.scss
@@ -33,6 +33,7 @@ $navigation-bar-height: var(--navigation-bar-height);
     }
 
     p {
+      color: var(--ion-color-primary-contrast);
       flex: 0 1 auto;
       text-align: center;
       font-size: var(--font-size-text-tiny);
@@ -41,15 +42,18 @@ $navigation-bar-height: var(--navigation-bar-height);
   }
 }
 
-.navigation-bar-wrapper[data-variant="background_primary"] {
-  background-color: var(--ion-color-primary);
-  p {
-    color: var(--ion-color-primary-contrast);
+.navigation-bar-wrapper[data-variant~="text_primary"] {
+  a.button-wrapper {
+    p {
+      color: var(--ion-color-primary);
+    }
   }
 }
-.navigation-bar-wrapper[data-variant="background_none"] {
+
+.navigation-bar-wrapper[data-variant~="background_primary"] {
+  background-color: var(--ion-color-primary);
+}
+
+.navigation-bar-wrapper[data-variant~="background_none"] {
   background-color: transparent;
-  p {
-    color: var(--ion-color-primary);
-  }
 }

--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.scss
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.scss
@@ -7,8 +7,9 @@ $navigation-bar-height: var(--navigation-bar-height);
   height: $navigation-bar-height;
   padding: var(--tiny-padding);
 
-  .button-wrapper {
+  a.button-wrapper {
     @include mixins.flex-centered;
+    text-decoration: none;
     flex-direction: column;
     height: 100%;
     width: 30%;
@@ -33,10 +34,22 @@ $navigation-bar-height: var(--navigation-bar-height);
 
     p {
       flex: 0 1 auto;
-      color: var(--ion-color-primary-contrast);
       text-align: center;
       font-size: var(--font-size-text-tiny);
       margin: var(--tiny-margin) 0;
     }
+  }
+}
+
+.navigation-bar-wrapper[data-variant="background_primary"] {
+  background-color: var(--ion-color-primary);
+  p {
+    color: var(--ion-color-primary-contrast);
+  }
+}
+.navigation-bar-wrapper[data-variant="background_none"] {
+  background-color: transparent;
+  p {
+    color: var(--ion-color-primary);
   }
 }

--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.ts
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.ts
@@ -1,8 +1,16 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, computed } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 import { getParamFromTemplateRow } from "src/app/shared/utils";
+import { FlowTypes } from "packages/data-models";
 
-interface IButton {
+interface INavigationBarParams {
+  /** TEMPLATE PARAMETER: "button_list" */
+  buttonList: INavigationBarButton[];
+  /** TEMPLATE PARAMETER: "variant" */
+  variant: "background_primary" | "background_none";
+}
+
+interface INavigationBarButton {
   image: string | null;
   text: string | null;
   target_template: string | null;
@@ -14,46 +22,13 @@ interface IButton {
   templateUrl: "./navigation-bar.component.html",
   styleUrls: ["./navigation-bar.component.scss"],
 })
-export class TmplNavigationBarComponent extends TemplateBaseComponent implements OnInit {
-  buttonList: IButton[];
+export class TmplNavigationBarComponent extends TemplateBaseComponent {
+  params = computed(() => this.getParams(this.parameterList()));
 
-  ngOnInit() {
-    this.getParams();
+  getParams(authorParams: FlowTypes.TemplateRow["parameter_list"]): INavigationBarParams {
+    return {
+      buttonList: getParamFromTemplateRow(this._row, "button_list", []),
+      variant: getParamFromTemplateRow(this._row, "variant", "background-primary"),
+    };
   }
-
-  getParams() {
-    const buttonListRaw: string[] = getParamFromTemplateRow(this._row, "button_list", []);
-    this.buttonList = parseValueListItems(buttonListRaw);
-  }
-}
-
-/**
- * Radio group and other value lists are often formatted with both name and text properties,
- * which are (currently) separated out at runtime. This function takes the value_list
- * string array and formats into an object array
- * @param items
- * ```
- * [name:name_var_1 | text:Option 1, name:name_var_2 | text: Option 2]
- * ```
- * @returns
- * ```
- * [{name:"name_var_1", text:"Option 1"}, {name:"name_var_2", text: "Option 2"}]
- * ```
- * @deprecated v0.16.27 - PR 2211 should have enabled support for parsing at compile time
- * have added return in case already processed but should hopefully be able to remove in future
- */
-function parseValueListItems(items: string[]): any[] {
-  return items.map((item) => {
-    // avoid parsing items that may have been processed already
-    if (typeof item !== "string") return item;
-    const props = {};
-    item
-      .split("|")
-      .map((i) => i.trim())
-      .forEach((i) => {
-        const [key, value] = i.split(":").map((v) => v.trim());
-        props[key] = value;
-      });
-    return props;
-  });
 }

--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.ts
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.ts
@@ -6,8 +6,8 @@ import { FlowTypes } from "packages/data-models";
 interface INavigationBarParams {
   /** TEMPLATE PARAMETER: "button_list" */
   buttonList: INavigationBarButton[];
-  /** TEMPLATE PARAMETER: "variant" */
-  variant: "background_primary" | "background_none";
+  /** TEMPLATE PARAMETER: "variant". Default: "text_primary_contrast" */
+  variant: "text_primary_contrast" | "text_primary" | "background_primary" | "background_none";
 }
 
 interface INavigationBarButton {
@@ -28,7 +28,9 @@ export class TmplNavigationBarComponent extends TemplateBaseComponent {
   getParams(authorParams: FlowTypes.TemplateRow["parameter_list"]): INavigationBarParams {
     return {
       buttonList: getParamFromTemplateRow(this._row, "button_list", []),
-      variant: getParamFromTemplateRow(this._row, "variant", "background-primary"),
+      variant: getParamFromTemplateRow(this._row, "variant", "text_primary_contrast")
+        .split(",")
+        .join(" "),
     };
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Adds new variants for styling the `navigation_bar` component:
  - `text_primary_contrast` (default)
    - Sets the text colour to `primary-contrast`
  - `text_primary`
    - Sets the text colour to `primary`
  - This differs slightly from the suggested implementation in #2856 but resolves the fundamental issue. I wanted to keep the `navigation_bar` component independent from the footer settings, so the authoring changes required to resolve the underlying issue would be to update the footer template that instantiates the `navigation_bar` component to set `variant: text_primary` on that component.
- Minor refactoring of `navigation_bar` component code

## Notes

The syntax of these variants is a step towards the utility styles proposed in the discussion on #1971. Eventually, utility styles like this should live in the `style_list` column, but it seems acceptable to supply them as a list to the `variant` param for now. 

After going back and forth about how to handle the authoring of these particular style changes, this halfway house seems like an acceptable option. It would be nice if this styling could be authored in the `style_list`, but setting `color: var(--ion-color-primary);` does not have the expected result because of the nested component structure and the way styles are inherited. I also considered exposing equivalent variants to apply styles to the background (e.g. `background_primary`, `background_none`), however this styling can be applied through a simple css rule (e.g. `background-color: var(--ion-color-primary);` – see example in component demo sheet), so have not included.

## Git Issues

Closes #2856

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
