### PR TITLE
fix: track data items rows by row to avoid angular warning

### DIFF
--- a/src/app/shared/components/template/components/data-items/data-items.component.html
+++ b/src/app/shared/components/template/components/data-items/data-items.component.html
@@ -1,4 +1,4 @@
-@for (row of itemRows(); track row._nested_name) {
+@for (row of itemRows(); track row) {
   <plh-template-component
     [row]="row"
     [parent]="parent"


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Changes the way that the Angular `@for` loop tracks data-items rows in order to avoid warning described in #2943. Where previously the rows were tracked by their `_nested_name`, now the whole row is used.

This is a workaround that may involve a minor performance loss. There is potentially a more fundamental issue that our `_nested_name` values are not unique.

## Git Issues

Closes #2943

## Screenshots/Videos

[comp_data_items](https://docs.google.com/spreadsheets/d/1khGTrDekzqDQyW1r2x0ADqknanrlkmhOz1RRzhP6-7c/edit?gid=845703892#gid=845703892) running on this branch (after syncing latest debug sheets):

<img width="960" alt="Screenshot 2025-05-14 at 09 09 40" src="https://github.com/user-attachments/assets/e8c6038f-b93e-4d26-8274-a0358608353e" />
