### PR TITLE
fix: parse percentage values from sheets

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/processors/xlsxWorkbook.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/xlsxWorkbook.ts
@@ -7,7 +7,7 @@ import BaseProcessor from "./base";
 import { existsSync } from "fs-extra";
 import { IContentsEntry, parseAppDataCollectionString } from "../utils";
 
-const cacheVersion = 20250429.0;
+const cacheVersion = 20250515.0;
 const sheetsFolderBaseUrl = "https://drive.google.com/drive/u/0/folders";
 
 export class XLSXWorkbookProcessor extends BaseProcessor<IContentsEntry> {
@@ -59,6 +59,18 @@ export class XLSXWorkbookProcessor extends BaseProcessor<IContentsEntry> {
         ) {
           html = html.replace(/<span[^>]*>/g, "<span>"); // Remove span style
           worksheet[cellId].v = html;
+        }
+      });
+      // If authored value was a percentage, override converted decimal value to preserve percentage representation
+      Object.keys(worksheet).forEach((cellId) => {
+        const cell = worksheet[cellId];
+        // parser saves formatted text version of cell value in the .w field
+        // https://docs.sheetjs.com/docs/api/parse-options#parsing-options
+        const cellText = cell?.w;
+        if (cell && typeof cell.v === "number" && cellText) {
+          if (cellText.includes("%")) {
+            cell.v = cellText;
+          }
         }
       });
       json[sheet_name] = xlsx.utils.sheet_to_json(worksheet);


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

When a sheet cell contains a percentage value, e.g. `50%`, then this value is preserved through parsing and remains a string. Previously, the string would be converted to a number, e.g. `0,5`, due to the fact that spreadsheet software stores the raw value as a number with percentage formatting applied.

## Git Issues

Closes #2947

## Screenshots/Videos

[debug_parse_percentage](https://docs.google.com/spreadsheets/d/1_x5-AVV5eVcXicjpqcbKXgVZ3US-cWvqB8SdoT5DhVE/edit?gid=1422144003#gid=1422144003):

<img width="420" alt="Screenshot 2025-05-15 at 12 44 29" src="https://github.com/user-attachments/assets/4051623a-5c29-4ed2-8f27-69aa099514eb" />

<img width="420" alt="Screenshot 2025-05-15 at 12 43 44" src="https://github.com/user-attachments/assets/4c1c5d01-56bb-44ab-846a-8886833ffd8e" />
