### PR TITLE
feat: add app env fields

### DIFF
--- a/packages/data-models/fields.ts
+++ b/packages/data-models/fields.ts
@@ -3,7 +3,11 @@
  * They are used to store store computed or exported variables and are not user overridable
  */
 enum PROTECTED_FIELDS {
+  /** Runtime environment, `production` or `development` */
+  APP_ENVIRONMENT = "app_environment",
   APP_FIRST_LAUNCH = "app_first_launch",
+  /** Location hostname of app, e.g. `localhost`, `example.web.app` */
+  APP_HOSTNAME = "app_hostname",
   APP_LANGUAGE = "app_language",
   APP_LANGUAGE_DIRECTION = "app_language_direction",
   APP_SKIN = "app_skin",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -164,6 +164,11 @@ export class AppComponent {
     this.localStorageService.setProtected("APP_VERSION", _app_builder_version);
     this.localStorageService.setProtected("CONTENT_VERSION", _content_version);
     this.localStorageService.setProtected("PLATFORM", Capacitor.getPlatform());
+
+    const appEnv = environment.production ? "production" : "development";
+    this.localStorageService.setProtected("APP_ENVIRONMENT", appEnv);
+    this.localStorageService.setProtected("APP_HOSTNAME", location.hostname);
+
     // HACK - ensure first_app_launch migrated from event service
     if (!this.localStorageService.getProtected("APP_FIRST_LAUNCH")) {
       await this.appEventService.ready();


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds two new generated fields for `_app_environment` and `_app_hostname` for use in metadata tracking

## Author Notes
`_app_environment` will show up either as `development` when running locally, or `production` when running either as native app or web preview. Specifically this value represents the app build process, where a development build is used to run locally and a production build when deploying to web, web-preview or native app runtimes.

`_app_hostname` refers to the URL hostname if the app is being delivered on web. When running locally this will show as `localhost`. When running in web/web-preview it will display the partial URL (without http/https and trailing path), such as `plh-teens-app1--pr2885-feat-plh-progress-pa-9jd4wzx2.web.app` for a preview link or `idems-debug.web.app` for web version.
When running on native device this value will either also be `localhost` or simply an empty string depending,although can be distinguished between development localhost either by the app_environment field or the `_platform` field (which will show ios/android on native)

Both of these properties are deployment-independent, and will be automatically populated on app run

## Git Issues

Closes #2927

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
