### PR TITLE
fix: handle numerical value passed to combo-box via field

### DIFF
--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -78,7 +78,9 @@ export class TmplComboBoxComponent
     effect(
       () => {
         if (this.answerOptions().length > 0 && this._row.value) {
-          const selectedAnswer = this.answerOptions().find((x) => x.name === this._row.value);
+          const selectedAnswer = this.answerOptions().find(
+            (x) => String(x.name) === String(this._row.value)
+          );
           if (!selectedAnswer) {
             this.customAnswerSelected.set(true);
           } else {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the combo box instance would not correctly handle an initial value passed in via a field in the case that the value was a number (#2964).

## Git Issues

Closes #2964

## Screenshots/Videos

[debug_combo_box_value](https://docs.google.com/spreadsheets/d/13h4OJiMok3XG9DklnRzVmUue_9cXydVTclI4Ixb5nAo/edit?gid=1916689711#gid=1916689711):

<img width="800" alt="Image" src="https://github.com/user-attachments/assets/806a0aad-cfbe-40cf-9544-de3831176fd7" />

<img width="362" alt="Screenshot 2025-05-28 at 13 31 52" src="https://github.com/user-attachments/assets/e5211e1b-2a40-44a4-8745-2cf8168f3cd0" />
