### PR TITLE
fix: sticky display group inside a fullscreen pop-up respects device safe area

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
@@ -7,9 +7,9 @@
   z-index: 10;
 
   &[sticky-position="top"] {
-    top: var(--ion-safe-area-top, 0);
+    top: var(--pop-up-top-padding, 0);
   }
   &[sticky-position="bottom"] {
-    bottom: var(--ion-safe-area-bottom, 0);
+    bottom: var(--pop-up-bottom-padding, 0);
   }
 }

--- a/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/sticky/display-group-sticky.component.scss
@@ -7,9 +7,9 @@
   z-index: 10;
 
   &[sticky-position="top"] {
-    top: 0;
+    top: var(--ion-safe-area-top, 0);
   }
   &[sticky-position="bottom"] {
-    bottom: 0;
+    bottom: var(--ion-safe-area-bottom, 0);
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where a sticky display group inside a fullscreen pop-up would not respect the device's safe area. E.g. a display group with `sticky: top` inside a fullscreen pop-up may appear behind the device notch. Sticky display groups that are not within fullscreen pop-ups are unaffected.

This is an extension of the solution in #2688, now applied to stick display groups.

## Git Issues

Closes #

## Screenshots/Videos

Example from `plh_kids_tz` deployment:

| Before | After |
|---|---|
| <img width="400" alt="Screenshot 2025-05-28 at 15 31 34" src="https://github.com/user-attachments/assets/49c727d0-54d0-4a40-928a-07ea52c324b3" /> | <img width="400" alt="Screenshot 2025-05-28 at 16 02 14" src="https://github.com/user-attachments/assets/6ac45b37-fef4-4075-9e2f-e43f6f825d27" /> |