### PR TITLE
fix: remove excessive top margin from combo-box component

### DIFF
--- a/src/app/shared/components/template/components/combo-box/combo-box.component.html
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.html
@@ -1,6 +1,6 @@
 @if (params().variant === "modal") {
   <button
-    class="open-combobox margin-t-regular"
+    class="open-combobox"
     (click)="openModal()"
     [ngClass]="{
       disabled: disabled(),
@@ -13,12 +13,14 @@
     {{ displayText() | translate }}
   </button>
 } @else if (params().variant === "dropdown" && showSearch()) {
-  <button class="open-search-combobox margin-t-regular"
+  <button
+    class="open-search-combobox"
     (click)="openSearch()"
     [ngClass]="searchButtonClass()"
-    [disabled]="disabled()">
+    [disabled]="disabled()"
+  >
     <span class="text">{{ displayText() | translate }}</span>
-    <ion-icon name="caret-down-sharp" size="small" aria-hidden="true" ></ion-icon>
+    <ion-icon name="caret-down-sharp" size="small" aria-hidden="true"></ion-icon>
   </button>
 } @else if (params().variant === "dropdown" && !showSearch()) {
   <div class="combo-box-container dropdown">


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

The combo-box component has an additional hardcoded top margin, that is inconsistently applied across variants. This PR removes that margin, increasing consistency across variants and consistency in spacing when the combo-box is arranged beneath other elements.

## Git Issues

Addresses one of the causes of https://github.com/ParentingForLifelongHealth/plh-facilitator-app-ph-content/issues/87#issuecomment-2919615391

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
