### PR TITLE
Feat: notification actions

### DIFF
--- a/packages/data-models/fields.ts
+++ b/packages/data-models/fields.ts
@@ -23,6 +23,11 @@ enum PROTECTED_FIELDS {
   DEPLOYMENT_NAME = "deployment_name",
   FEEDBACK_SELECTED_TEXT = "feedback_selected_text",
   FEEDBACK_SIDEBAR_OPEN = "feedback_sidebar_open",
+  /**
+   * Response to notification permission request. For values see
+   * https://capacitorjs.com/docs/plugins/web#aliases
+   **/
+  NOTIFICATION_PERMISSION_STATUS = "notification_permission_status",
   PLATFORM = "platform",
   SERVER_SYNC_LATEST = "server_sync_latest",
 }

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -444,6 +444,7 @@ export namespace FlowTypes {
     "google_auth",
     "nav",
     "nav_stack",
+    "notification",
     "open_external",
     "pop_up",
     "process_template",

--- a/packages/shared/src/models/jsEvaluator/jsEvaluator.ts
+++ b/packages/shared/src/models/jsEvaluator/jsEvaluator.ts
@@ -69,6 +69,7 @@ export class JSEvaluator {
       const evaluated = func.apply(executionContext);
       return evaluated;
     } catch (error) {
+      // console.error(`Failed to evaluate function:\n${expression}`);
       // still throw error so that calling function can decide how to handle, e.g. attempt string replace
       throw error;
     }

--- a/src/app/feature/notification/README.md
+++ b/src/app/feature/notification/README.md
@@ -1,0 +1,18 @@
+# Notifications
+
+The notifications feature is used by authors to schedule one-time notifications.
+
+## Authoring Integration
+**Fields**
+`@fields._notification_permission_status` updates with current notification permission status
+
+**Data Lists**
+`@data._notifications` lists all schedule notifications
+
+## Relation to Campaigns System
+The action, service and types all currently sit independently to the campaigns system, which is tightly coupled to an alternative shared notification service. In the future the two features should likely be merged.
+
+
+## TODO
+- [ ] Update debug pages to track notifications created from action (not only campaigns)
+- [ ] Tests

--- a/src/app/feature/notification/README.md
+++ b/src/app/feature/notification/README.md
@@ -15,4 +15,4 @@ The action, service and types all currently sit independently to the campaigns s
 
 ## TODO
 - [ ] Update debug pages to track notifications created from action (not only campaigns)
-- [ ] Tests
+- [ ] Add support for tracking notification interaction within db entries

--- a/src/app/feature/notification/notification.actions.ts
+++ b/src/app/feature/notification/notification.actions.ts
@@ -1,47 +1,26 @@
-import { Schedule } from "@capacitor/local-notifications";
 import type { IActionHandler } from "src/app/shared/components/template/services/instance/template-action.registry";
-import { LocalNotificationService } from "src/app/shared/services/notification/local-notification.service";
-import { stringToIntegerHash } from "src/app/shared/utils";
+import { NotificationService } from "./notification.service";
+import { INotification } from "./notification.types";
 
-interface INotificationCreateParams {
-  id: string;
-  title: string;
-  body: string;
-  /** Timestamp to schedule at */
-  at: string;
-}
 interface INotificationRemoveParams {
   id: string;
 }
 
-/**
- * TODO
- * - [ ] Support conditional schedule (e.g. if not already)
- * - [ ] Map pending notifications to data_list
- * - [ ] Track field for permission granted
- * - [ ] Input param validation
- * - [ ] Tests
- */
 export class NotificationActionFactory {
-  constructor(private service: LocalNotificationService) {}
+  constructor(private service: NotificationService) {}
 
   public notification: IActionHandler = async ({ params, args }) => {
     const [actionId] = args;
     const childActions = {
       create: async () => {
-        const { body, id, title, at } = params as INotificationCreateParams;
-        const schedule: Schedule = { at: new Date(at) };
-        return this.service.scheduleNotification({
-          id: stringToIntegerHash(id),
-          schedule,
-          body,
-          title,
-          extra: {},
-        });
+        return this.service.scheduleNotification(params as INotification);
       },
-      remove: async () => {
+      cancel: async () => {
         const { id } = params as INotificationRemoveParams;
-        return this.service.removeNotifications([stringToIntegerHash(id)]);
+        return this.service.cancelNotification(id);
+      },
+      cancel_all: async () => {
+        return this.service.cancelAll();
       },
       request_permission: async () => {
         return this.service.requestPermission();

--- a/src/app/feature/notification/notification.actions.ts
+++ b/src/app/feature/notification/notification.actions.ts
@@ -1,0 +1,56 @@
+import { Schedule } from "@capacitor/local-notifications";
+import type { IActionHandler } from "src/app/shared/components/template/services/instance/template-action.registry";
+import { LocalNotificationService } from "src/app/shared/services/notification/local-notification.service";
+import { stringToIntegerHash } from "src/app/shared/utils";
+
+interface INotificationCreateParams {
+  id: string;
+  title: string;
+  body: string;
+  /** Timestamp to schedule at */
+  at: string;
+}
+interface INotificationRemoveParams {
+  id: string;
+}
+
+/**
+ * TODO
+ * - [ ] Support conditional schedule (e.g. if not already)
+ * - [ ] Map pending notifications to data_list
+ * - [ ] Track field for permission granted
+ * - [ ] Input param validation
+ * - [ ] Tests
+ */
+export class NotificationActionFactory {
+  constructor(private service: LocalNotificationService) {}
+
+  public notification: IActionHandler = async ({ params, args }) => {
+    const [actionId] = args;
+    const childActions = {
+      create: async () => {
+        const { body, id, title, at } = params as INotificationCreateParams;
+        const schedule: Schedule = { at: new Date(at) };
+        return this.service.scheduleNotification({
+          id: stringToIntegerHash(id),
+          schedule,
+          body,
+          title,
+          extra: {},
+        });
+      },
+      remove: async () => {
+        const { id } = params as INotificationRemoveParams;
+        return this.service.removeNotifications([stringToIntegerHash(id)]);
+      },
+      request_permission: async () => {
+        return this.service.requestPermission();
+      },
+    };
+    if (!(actionId in childActions)) {
+      console.error(`[NOTIFICATION] No action, ${actionId}`);
+      return;
+    }
+    return childActions[actionId]();
+  };
+}

--- a/src/app/feature/notification/notification.module.ts
+++ b/src/app/feature/notification/notification.module.ts
@@ -8,6 +8,9 @@ import { NotificationsRoutingModule } from "./notification-routing.module";
 import { NotificationsDebugPage } from "./pages/notifications-debug/notifications-debug.page";
 import { NotificationDebugRowComponent } from "./pages/notifications-debug/components/notification-debug-row.component";
 import { NotificationDebugInteractedRowComponent } from "./pages/notifications-debug/components/notification-debug-interacted-row.component";
+import { LocalNotificationService } from "src/app/shared/services/notification/local-notification.service";
+import { TemplateActionRegistry } from "src/app/shared/components/template/services/instance/template-action.registry";
+import { NotificationActionFactory } from "./notification.actions";
 
 @NgModule({
   imports: [CommonModule, FormsModule, IonicModule, NotificationsRoutingModule, SharedPipesModule],
@@ -17,4 +20,9 @@ import { NotificationDebugInteractedRowComponent } from "./pages/notifications-d
     NotificationDebugInteractedRowComponent,
   ],
 })
-export class NotificationsModule {}
+export class NotificationsModule {
+  constructor(service: LocalNotificationService, actionRegistry: TemplateActionRegistry) {
+    const { notification } = new NotificationActionFactory(service);
+    actionRegistry.register({ notification });
+  }
+}

--- a/src/app/feature/notification/notification.module.ts
+++ b/src/app/feature/notification/notification.module.ts
@@ -8,9 +8,9 @@ import { NotificationsRoutingModule } from "./notification-routing.module";
 import { NotificationsDebugPage } from "./pages/notifications-debug/notifications-debug.page";
 import { NotificationDebugRowComponent } from "./pages/notifications-debug/components/notification-debug-row.component";
 import { NotificationDebugInteractedRowComponent } from "./pages/notifications-debug/components/notification-debug-interacted-row.component";
-import { LocalNotificationService } from "src/app/shared/services/notification/local-notification.service";
 import { TemplateActionRegistry } from "src/app/shared/components/template/services/instance/template-action.registry";
 import { NotificationActionFactory } from "./notification.actions";
+import { NotificationService } from "./notification.service";
 
 @NgModule({
   imports: [CommonModule, FormsModule, IonicModule, NotificationsRoutingModule, SharedPipesModule],
@@ -21,7 +21,7 @@ import { NotificationActionFactory } from "./notification.actions";
   ],
 })
 export class NotificationsModule {
-  constructor(service: LocalNotificationService, actionRegistry: TemplateActionRegistry) {
+  constructor(service: NotificationService, actionRegistry: TemplateActionRegistry) {
     const { notification } = new NotificationActionFactory(service);
     actionRegistry.register({ notification });
   }

--- a/src/app/feature/notification/notification.service.spec.ts
+++ b/src/app/feature/notification/notification.service.spec.ts
@@ -1,0 +1,399 @@
+import { fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { Capacitor, PermissionState } from "@capacitor/core";
+import { LocalNotifications } from "@capacitor/local-notifications";
+import { of } from "rxjs";
+import { NotificationService } from "./notification.service";
+import { AppConfigService } from "src/app/shared/services/app-config/app-config.service";
+import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic-data.service";
+import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
+import { INotification, IDBNotification } from "./notification.types";
+import { IAppConfig } from "data-models/appConfig";
+
+/**
+ * Call standalone tests via:
+ * yarn ng test --include src\app\feature\notification\notification.service.spec.ts
+ */
+describe("NotificationService", () => {
+  let service: NotificationService;
+  let mockLocalStorageService: jasmine.SpyObj<LocalStorageService>;
+  let mockAppConfigService: jasmine.SpyObj<AppConfigService>;
+  let mockDynamicDataService: jasmine.SpyObj<DynamicDataService>;
+
+  const mockNotificationDefaults: IAppConfig["NOTIFICATION_DEFAULTS"] = {
+    title: "Default Title",
+    text: "Default Text",
+    time: { hour: 0, minute: 0 },
+  };
+
+  const mockAppConfig: Partial<IAppConfig> = {
+    NOTIFICATION_DEFAULTS: mockNotificationDefaults,
+  };
+
+  beforeEach(async () => {
+    // Create spy objects
+    mockLocalStorageService = jasmine.createSpyObj("LocalStorageService", ["setProtected"]);
+    mockAppConfigService = jasmine.createSpyObj("AppConfigService", ["appConfig"]);
+    mockDynamicDataService = jasmine.createSpyObj("DynamicDataService", [
+      "upsert",
+      "remove",
+      "resetFlow",
+      "query$",
+    ]);
+
+    // Setup default return values
+    mockAppConfigService.appConfig.and.returnValue(mockAppConfig as IAppConfig);
+    mockDynamicDataService.query$.and.returnValue(of([]));
+
+    // Spy on Capacitor methods
+    spyOn(Capacitor, "isNativePlatform").and.returnValue(true);
+    spyOn(LocalNotifications, "checkPermissions").and.resolveTo({
+      display: "granted" as PermissionState,
+    });
+    spyOn(LocalNotifications, "requestPermissions").and.resolveTo({
+      display: "granted" as PermissionState,
+    });
+    spyOn(LocalNotifications, "schedule").and.resolveTo({ notifications: [] });
+    spyOn(LocalNotifications, "cancel").and.resolveTo();
+    spyOn(LocalNotifications, "getPending").and.resolveTo({ notifications: [] });
+
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationService,
+        { provide: LocalStorageService, useValue: mockLocalStorageService },
+        { provide: AppConfigService, useValue: mockAppConfigService },
+        { provide: DynamicDataService, useValue: mockDynamicDataService },
+      ],
+    });
+
+    service = TestBed.inject(NotificationService);
+  });
+
+  afterEach(() => {
+    // Clean up any global spies
+    if ((window as any).Notification) {
+      delete (window as any).Notification;
+    }
+  });
+
+  describe("constructor and initialization", () => {
+    it("should be created", () => {
+      expect(service).toBeTruthy();
+    });
+
+    it("should check permissions on initialization", () => {
+      expect(LocalNotifications.checkPermissions).toHaveBeenCalled();
+    });
+
+    it("should set permission status to local storage", fakeAsync(() => {
+      tick(); // Allow effect to run
+      expect(mockLocalStorageService.setProtected).toHaveBeenCalledWith(
+        "NOTIFICATION_PERMISSION_STATUS",
+        "granted"
+      );
+    }));
+  });
+
+  describe("checkPermissions", () => {
+    it("should set permission status to unsupported on web when Notification API unavailable", async () => {
+      (Capacitor.isNativePlatform as jasmine.Spy).and.returnValue(false);
+      // Don't set window.Notification to simulate unsupported browser
+
+      // Recreate service to trigger constructor
+      service = TestBed.inject(NotificationService);
+
+      await new Promise((resolve) => setTimeout(resolve, 0)); // Allow async initialization
+
+      expect(mockLocalStorageService.setProtected).toHaveBeenCalledWith(
+        "NOTIFICATION_PERMISSION_STATUS",
+        "unsupported"
+      );
+    });
+
+    it("should check permissions on web when Notification API is available", async () => {
+      (Capacitor.isNativePlatform as jasmine.Spy).and.returnValue(false);
+      (window as any).Notification = {}; // Mock Notification API availability
+
+      // Recreate service to trigger constructor
+      service = TestBed.inject(NotificationService);
+
+      expect(LocalNotifications.checkPermissions).toHaveBeenCalled();
+    });
+  });
+
+  describe("requestPermission", () => {
+    it("should request permissions and update status", async () => {
+      const result = await service.requestPermission();
+
+      expect(LocalNotifications.requestPermissions).toHaveBeenCalled();
+      expect(result).toBe("granted");
+    });
+
+    it("should handle denied permissions", async () => {
+      (LocalNotifications.requestPermissions as jasmine.Spy).and.resolveTo({
+        display: "denied" as PermissionState,
+      });
+
+      const result = await service.requestPermission();
+
+      expect(result).toBe("denied");
+    });
+  });
+
+  describe("scheduleNotification", () => {
+    const validNotification: INotification = {
+      id: "test-notification",
+      schedule_at: new Date(Date.now() + 60000).toISOString(), // 1 minute from now
+      title: "Test Title",
+      text: "Test Text",
+    };
+
+    beforeEach(() => {
+      mockDynamicDataService.query$.and.returnValue(of([])); // No existing notification
+    });
+
+    it("should schedule a valid notification", async () => {
+      await service.scheduleNotification(validNotification);
+
+      expect(LocalNotifications.schedule).toHaveBeenCalled();
+      expect(mockDynamicDataService.upsert).toHaveBeenCalledWith(
+        "data_list",
+        "_notifications",
+        jasmine.objectContaining({
+          id: validNotification.id,
+          _internal_id: jasmine.any(Number),
+        })
+      );
+    });
+
+    it("should use default title and text when not provided", async () => {
+      const notificationWithoutDefaults: INotification = {
+        id: "test-notification",
+        schedule_at: new Date(Date.now() + 60000).toISOString(),
+      };
+
+      await service.scheduleNotification(notificationWithoutDefaults);
+
+      const scheduleCall = (LocalNotifications.schedule as jasmine.Spy).calls.mostRecent();
+      const scheduledNotification = scheduleCall.args[0].notifications[0];
+
+      expect(scheduledNotification.title).toBe(mockNotificationDefaults.title);
+      expect(scheduledNotification.body).toBe(mockNotificationDefaults.text);
+    });
+
+    it("should cancel existing notification with same id before scheduling new one", async () => {
+      const existingNotification: IDBNotification = {
+        ...validNotification,
+        _internal_id: 12345,
+      };
+      mockDynamicDataService.query$.and.returnValue(of([existingNotification]));
+
+      await service.scheduleNotification(validNotification);
+
+      expect(LocalNotifications.cancel).toHaveBeenCalledWith({
+        notifications: [{ id: 12345 }],
+      });
+    });
+
+    it("should not schedule notification without id", async () => {
+      const invalidNotification = {
+        schedule_at: new Date(Date.now() + 60000).toISOString(),
+        title: "Test",
+      } as INotification;
+
+      spyOn(console, "warn");
+      await service.scheduleNotification(invalidNotification);
+
+      expect(console.warn).toHaveBeenCalled();
+      expect(LocalNotifications.schedule).not.toHaveBeenCalled();
+    });
+
+    it("should not schedule notification without schedule_at", async () => {
+      const invalidNotification = {
+        id: "test",
+        title: "Test",
+      } as INotification;
+
+      spyOn(console, "warn");
+      await service.scheduleNotification(invalidNotification);
+
+      expect(console.warn).toHaveBeenCalled();
+      expect(LocalNotifications.schedule).not.toHaveBeenCalled();
+    });
+
+    it("should not schedule notification with past schedule_at", async () => {
+      const invalidNotification: INotification = {
+        id: "test",
+        schedule_at: new Date(Date.now() - 60000).toISOString(), // 1 minute ago
+        title: "Test",
+        text: "test text",
+      };
+
+      spyOn(console, "warn");
+      await service.scheduleNotification(invalidNotification);
+
+      expect(console.warn).toHaveBeenCalled();
+      expect(LocalNotifications.schedule).not.toHaveBeenCalled();
+    });
+
+    it("should handle scheduling errors and rollback", async () => {
+      (LocalNotifications.schedule as jasmine.Spy).and.rejectWith(new Error("Scheduling failed"));
+      spyOn(console, "error");
+      spyOn(service, "cancelNotification");
+
+      await service.scheduleNotification(validNotification);
+
+      expect(console.error).toHaveBeenCalled();
+      expect(service.cancelNotification).toHaveBeenCalledWith(validNotification.id);
+    });
+  });
+
+  describe("cancelNotification", () => {
+    it("should cancel existing notification", async () => {
+      const existingNotification: IDBNotification = {
+        id: "test-notification",
+        schedule_at: new Date(Date.now() + 60000).toISOString(),
+        _internal_id: 12345,
+      };
+      mockDynamicDataService.query$.and.returnValue(of([existingNotification]));
+
+      await service.cancelNotification("test-notification");
+
+      expect(LocalNotifications.cancel).toHaveBeenCalledWith({
+        notifications: [{ id: 12345 }],
+      });
+      expect(mockDynamicDataService.remove).toHaveBeenCalledWith("data_list", "_notifications", [
+        "test-notification",
+      ]);
+    });
+
+    it("should do nothing when notification does not exist", async () => {
+      mockDynamicDataService.query$.and.returnValue(of([]));
+
+      await service.cancelNotification("non-existent");
+
+      expect(LocalNotifications.cancel).not.toHaveBeenCalled();
+      expect(mockDynamicDataService.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cancelAll", () => {
+    it("should cancel all notifications", async () => {
+      const pendingNotifications = [{ id: 1 }, { id: 2 }];
+      (LocalNotifications.getPending as jasmine.Spy).and.resolveTo({
+        notifications: pendingNotifications,
+      });
+
+      await service.cancelAll();
+
+      expect(LocalNotifications.cancel).toHaveBeenCalledWith({
+        notifications: pendingNotifications,
+      });
+      expect(mockDynamicDataService.resetFlow).toHaveBeenCalledWith("data_list", "_notifications");
+    });
+  });
+
+  describe("permission validation", () => {
+    it("should reject scheduling when permissions are unsupported", async () => {
+      // Simulate unsupported permissions
+      (LocalNotifications.checkPermissions as jasmine.Spy).and.resolveTo({
+        display: "denied" as PermissionState,
+      });
+      (Capacitor.isNativePlatform as jasmine.Spy).and.returnValue(false);
+
+      // Recreate service with unsupported permissions
+      service = TestBed.inject(NotificationService);
+
+      const notification: INotification = {
+        id: "test",
+        schedule_at: new Date(Date.now() + 60000).toISOString(),
+      };
+
+      spyOn(console, "warn");
+      await service.scheduleNotification(notification);
+
+      expect(console.warn).toHaveBeenCalled();
+      expect(LocalNotifications.schedule).not.toHaveBeenCalled();
+    });
+
+    it("should request permission when not granted and proceed if granted", async () => {
+      // Start with prompt permission state
+      (LocalNotifications.checkPermissions as jasmine.Spy).and.resolveTo({
+        display: "prompt" as PermissionState,
+      });
+      (LocalNotifications.requestPermissions as jasmine.Spy).and.resolveTo({
+        display: "granted" as PermissionState,
+      });
+
+      const notification: INotification = {
+        id: "test",
+        schedule_at: new Date(Date.now() + 60000).toISOString(),
+      };
+
+      await service.scheduleNotification(notification);
+
+      expect(LocalNotifications.requestPermissions).toHaveBeenCalled();
+      expect(LocalNotifications.schedule).toHaveBeenCalled();
+    });
+  });
+
+  describe("web platform specific behavior", () => {
+    beforeEach(() => {
+      (Capacitor.isNativePlatform as jasmine.Spy).and.returnValue(false);
+      (window as any).Notification = {}; // Mock Notification API
+    });
+
+    it("should reschedule pending notifications on web platform when permissions granted", async () => {
+      const futureDate = new Date(Date.now() + 60000).toISOString();
+      const pendingNotifications: IDBNotification[] = [
+        {
+          id: "test1",
+          schedule_at: futureDate,
+          _internal_id: 1,
+        },
+      ];
+
+      mockDynamicDataService.query$.and.returnValue(of(pendingNotifications));
+      spyOn(service, "scheduleNotification").and.resolveTo();
+
+      // Recreate service to trigger constructor and permission check
+      service = TestBed.inject(NotificationService);
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(service.scheduleNotification).toHaveBeenCalledWith(
+        jasmine.objectContaining({ id: "test1" })
+      );
+    });
+  });
+
+  describe("generateInternalNotification", () => {
+    it("should generate internal notification with correct structure", async () => {
+      const notification: INotification = {
+        id: "test-notification",
+        schedule_at: new Date(Date.now() + 60000).toISOString(),
+        title: "Test Title",
+        text: "Test Text",
+      };
+
+      await service.scheduleNotification(notification);
+
+      const scheduleCall = (LocalNotifications.schedule as jasmine.Spy).calls.mostRecent();
+      const internalNotification = scheduleCall.args[0].notifications[0];
+
+      expect(internalNotification).toEqual(
+        jasmine.objectContaining({
+          title: "Test Title",
+          body: "Test Text",
+          schedule: { at: jasmine.any(Date) },
+          id: jasmine.any(Number),
+          extra: { id: "test-notification" },
+        })
+      );
+
+      // Verify ID is within valid range
+      expect(internalNotification.id).toBeGreaterThan(0);
+      expect(internalNotification.id).toBeLessThanOrEqual(2147483647);
+    });
+  });
+});

--- a/src/app/feature/notification/notification.service.spec.ts
+++ b/src/app/feature/notification/notification.service.spec.ts
@@ -273,8 +273,6 @@ describe("NotificationService", () => {
         notifications: pendingNotifications,
       });
       expect(mockDynamicDataService.resetFlow).toHaveBeenCalledWith("data_list", "_notifications");
-      // restore previous spy method
-      spyOn(service["api"], "getPending").and.resolveTo({ notifications: [] });
     });
   });
 

--- a/src/app/feature/notification/notification.service.spec.ts
+++ b/src/app/feature/notification/notification.service.spec.ts
@@ -333,7 +333,7 @@ describe("NotificationService", () => {
   });
 
   describe("generateInternalNotification", () => {
-    fit("should generate internal notification with correct structure", async () => {
+    it("should generate internal notification with correct structure", async () => {
       const notification: INotification = {
         id: "test-notification",
         schedule_at: new Date(Date.now() + 60000).toISOString(),

--- a/src/app/feature/notification/notification.service.ts
+++ b/src/app/feature/notification/notification.service.ts
@@ -25,7 +25,6 @@ export class NotificationService {
     effect(() => {
       const permissionStatus = this.permissionStatus();
       localStorageService.setProtected("NOTIFICATION_PERMISSION_STATUS", permissionStatus);
-      console.log("[Notifications] Permission", permissionStatus);
       if (permissionStatus === "granted") {
         this.recheckScheduledNotifications();
       }
@@ -94,7 +93,6 @@ export class NotificationService {
 
   /** Convert authored notification to schema required by capacitor */
   private generateInternalNotification(notification: INotification) {
-    console.log("validate notification", notification);
     // Create random integer ID compatible with capacitor
     const internalId = Math.floor(Math.random() * NOTIFICATION_ID_MAX);
 

--- a/src/app/feature/notification/notification.service.ts
+++ b/src/app/feature/notification/notification.service.ts
@@ -1,0 +1,181 @@
+import { effect, Injectable, signal } from "@angular/core";
+import { Capacitor, PermissionState } from "@capacitor/core";
+import { LocalNotifications } from "@capacitor/local-notifications";
+import { firstValueFrom } from "rxjs";
+import { AppConfigService } from "src/app/shared/services/app-config/app-config.service";
+import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic-data.service";
+import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
+import { IDBNotification, INotification, INotificationInternal } from "./notification.types";
+
+// Notification ids must be integer +/- 2^31-1 as per capacitor docs
+const NOTIFICATION_ID_MAX = 2147483647;
+
+type IPermissionStatus = PermissionState | "unsupported";
+
+@Injectable({ providedIn: "root" })
+export class NotificationService {
+  private permissionStatus = signal<IPermissionStatus | undefined>(undefined);
+
+  constructor(
+    localStorageService: LocalStorageService,
+    private appConfigService: AppConfigService,
+    private dynamicDataService: DynamicDataService
+  ) {
+    // Ensure permisison status reflected to protected field
+    effect(() => {
+      const permissionStatus = this.permissionStatus();
+      localStorageService.setProtected("NOTIFICATION_PERMISSION_STATUS", permissionStatus);
+      console.log("[Notifications] Permission", permissionStatus);
+      if (permissionStatus === "granted") {
+        this.recheckScheduledNotifications();
+      }
+    });
+
+    // Check permissions on initial load
+    this.checkPermissions();
+  }
+
+  public async requestPermission() {
+    const { display } = await LocalNotifications.requestPermissions();
+    this.permissionStatus.set(display);
+    return display;
+  }
+
+  public async scheduleNotification(notification: INotification) {
+    const { valid, msg } = await this.validateNotification(notification);
+    if (!valid) {
+      console.warn("[Notification]", msg, "cannot create");
+      return;
+    }
+
+    const existingNotification = await this.getNotificationById(notification.id);
+    if (existingNotification) {
+      await this.cancelNotification(existingNotification.id);
+    }
+    // update default values
+    const { NOTIFICATION_DEFAULTS } = this.appConfigService.appConfig();
+    notification.title ??= NOTIFICATION_DEFAULTS.title;
+    notification.text ??= NOTIFICATION_DEFAULTS.text;
+
+    const internalNotification = this.generateInternalNotification(notification);
+
+    try {
+      // Res typically only returns array of ids, so not useful to keep
+      await LocalNotifications.schedule({ notifications: [internalNotification] });
+
+      // Store to dynamic data
+      const dbNotification: IDBNotification = {
+        ...notification,
+        _internal_id: internalNotification.id,
+      };
+      await this.dynamicDataService.upsert("data_list", "_notifications", dbNotification);
+    } catch (error) {
+      // In case of scheduling issues try to rollback
+      console.error(`[Notification] error`, error);
+      return this.cancelNotification(notification.id);
+    }
+  }
+
+  public async cancelNotification(id: string) {
+    const dbNotification = await this.getNotificationById(id);
+    if (dbNotification) {
+      await LocalNotifications.cancel({
+        notifications: [{ id: dbNotification._internal_id }],
+      });
+      await this.dynamicDataService.remove("data_list", "_notifications", [id]);
+    }
+  }
+
+  public async cancelAll() {
+    const { notifications } = await LocalNotifications.getPending();
+    await LocalNotifications.cancel({ notifications }); // Cancels all
+    await this.dynamicDataService.resetFlow("data_list", "_notifications");
+  }
+
+  /** Convert authored notification to schema required by capacitor */
+  private generateInternalNotification(notification: INotification) {
+    console.log("validate notification", notification);
+    // Create random integer ID compatible with capacitor
+    const internalId = Math.floor(Math.random() * NOTIFICATION_ID_MAX);
+
+    const { id, schedule_at, text, title } = notification;
+    const internalNotification: INotificationInternal = {
+      title,
+      body: text,
+      schedule: { at: new Date(schedule_at) },
+      // replace string id with randomly generated integer and store original id in extra
+      id: internalId,
+      extra: { id },
+    };
+    return internalNotification;
+  }
+
+  private async getNotificationById(id: string) {
+    const query = this.dynamicDataService.query$<IDBNotification>("data_list", "_notifications", {
+      selector: { id },
+    });
+    const [notification] = await firstValueFrom(query);
+    return notification;
+  }
+
+  private async checkPermissions() {
+    // If running in browser first check to ensure notification api exists
+    if (!Capacitor.isNativePlatform()) {
+      if (!window.Notification) {
+        this.permissionStatus.set("unsupported");
+        return;
+      }
+    }
+    const { display } = await LocalNotifications.checkPermissions();
+    this.permissionStatus.set(display);
+  }
+
+  /**
+   * Capacitor does not persist notifications on web platform, so manually check
+   * db for listed notifications and reschedule as required
+   */
+  private async recheckScheduledNotifications() {
+    if (!Capacitor.isNativePlatform()) {
+      // On web pending notifications dropped on refresh, so reschedule
+      const pendingNotifications = await this.listDBPendingNotifications();
+      const schedulePromises = pendingNotifications.map((notification) =>
+        this.scheduleNotification(notification)
+      );
+      await Promise.allSettled(schedulePromises);
+    }
+  }
+
+  /** List notifications from DB scheduled in the future */
+  private async listDBPendingNotifications() {
+    // notification schedule_at will not be indexed so retrieve all notifications and filter after
+    const query = this.dynamicDataService.query$<IDBNotification>("data_list", "_notifications");
+    const allNotifications = await firstValueFrom(query);
+    const now = new Date().getTime();
+    return allNotifications.filter((v) => new Date(v.schedule_at).getTime() > now);
+  }
+
+  /** Check for potential scheduling issues and return any errors */
+  private async validateNotification(notification: Partial<INotification> = {}) {
+    const { id, schedule_at } = notification;
+    // Check for notificaiton permisison - request if not already granted
+    if (this.permissionStatus() === "unsupported") {
+      return { valid: false, msg: "unsupported on device" };
+    }
+    if (this.permissionStatus() !== "granted") {
+      const request = await this.requestPermission();
+      if (request === "denied") {
+        return { valid: false, msg: "denied by user permission" };
+      }
+    }
+    if (!id) {
+      return { valid: false, msg: "id not specified" };
+    }
+    if (!schedule_at) {
+      return { valid: false, msg: "schedule_at not specified" };
+    }
+    if (new Date(schedule_at).getTime() <= new Date().getTime()) {
+      return { valid: false, msg: "schedule_at in past" };
+    }
+    return { valid: true };
+  }
+}

--- a/src/app/feature/notification/notification.service.ts
+++ b/src/app/feature/notification/notification.service.ts
@@ -57,10 +57,7 @@ export class NotificationService {
     notification.title ??= NOTIFICATION_DEFAULTS.title;
     notification.text ??= NOTIFICATION_DEFAULTS.text;
 
-    console.log("schedule notification", notification);
-
     const internalNotification = this.generateInternalNotification(notification);
-
     try {
       // Res typically only returns array of ids, so not useful to keep
       await this.api.schedule({ notifications: [internalNotification] });
@@ -73,7 +70,7 @@ export class NotificationService {
       await this.dynamicDataService.upsert("data_list", "_notifications", dbNotification);
     } catch (error) {
       // In case of scheduling issues try to rollback
-      console.error(`[Notification] error`, error);
+      console.error(`[Notification]`, error);
       return this.cancelNotification(notification.id);
     }
   }
@@ -128,7 +125,6 @@ export class NotificationService {
       }
     }
     const { display } = await this.api.checkPermissions();
-    console.log("check permission result", display);
     // Store to localstorage and signal
     this.localStorageService.setProtected("NOTIFICATION_PERMISSION_STATUS", display);
     this.permissionStatus.set(display);

--- a/src/app/feature/notification/notification.types.ts
+++ b/src/app/feature/notification/notification.types.ts
@@ -1,12 +1,12 @@
 import { LocalNotificationSchema } from "@capacitor/local-notifications";
 
 export interface INotification {
-  title: string;
-  text: string;
   id: string;
   // NOTE - when passing from authored date object will be serialized to isoString
   // this will likely be in local timezone format, e.g. "2025-06013T19:20:00"
   schedule_at: string;
+  title?: string;
+  text?: string;
 }
 
 export interface IDBNotification extends INotification {

--- a/src/app/feature/notification/notification.types.ts
+++ b/src/app/feature/notification/notification.types.ts
@@ -1,0 +1,20 @@
+import { LocalNotificationSchema } from "@capacitor/local-notifications";
+
+export interface INotification {
+  title: string;
+  text: string;
+  id: string;
+  // NOTE - when passing from authored date object will be serialized to isoString
+  // this will likely be in local timezone format, e.g. "2025-06013T19:20:00"
+  schedule_at: string;
+}
+
+export interface IDBNotification extends INotification {
+  /** Track integer id provided to internal notification */
+  _internal_id: number;
+}
+
+/** When writing notification to capacitor include db notification id in extra */
+export type INotificationInternal = Omit<LocalNotificationSchema, "extra"> & {
+  extra: { id: string };
+};

--- a/src/app/feature/notification/pages/notifications-debug/notifications-debug.page.ts
+++ b/src/app/feature/notification/pages/notifications-debug/notifications-debug.page.ts
@@ -46,7 +46,10 @@ export class NotificationsDebugPage implements OnInit {
     this.pickerValue = pickerValue;
     if (this.editableNotification) {
       this.editableNotification.schedule.at = new Date(pickerValue);
-      await this.localNotificationService.scheduleNotification(this.editableNotification as any);
+      await this.localNotificationService.scheduleNotification(
+        this.editableNotification as any,
+        this.editableNotification._row_id
+      );
     }
   }
   public logDebugInfo(notification: ILocalNotificationInteraction) {

--- a/src/app/shared/services/notification/local-notification-persist.adapter.ts
+++ b/src/app/shared/services/notification/local-notification-persist.adapter.ts
@@ -50,11 +50,10 @@ export class LocalNotificationPersistAdapter {
       )
       .subscribe(async (action) => {
         const { actionId, notification, inputValue } = action;
-        const { id, text, title, campaign_id } = notification.extra;
         const update: Partial<ILocalNotificationInteraction> = {
           action_id: actionId,
           action_recorded_timestamp: generateTimestamp(),
-          notification_meta: { id, text, title, campaign_id },
+          notification_meta: notification.extra,
         };
         if (inputValue) {
           update.action_meta = { inputValue };
@@ -70,9 +69,8 @@ export class LocalNotificationPersistAdapter {
       .subscribe(async (notifications) => {
         const timestamp = generateTimestamp();
         for (const notification of notifications) {
-          const { id, text, title, campaign_id } = notification.extra;
           await this.recordNotificationInteraction(notification.id, {
-            notification_meta: { id, text, title, campaign_id },
+            notification_meta: notification.extra,
             schedule_timestamp: generateTimestamp(notification.schedule.at),
             sent_recorded_timestamp: timestamp,
           });

--- a/src/app/shared/services/notification/local-notification.service.ts
+++ b/src/app/shared/services/notification/local-notification.service.ts
@@ -119,10 +119,9 @@ export class LocalNotificationService extends AsyncServiceBase {
       await this.cleanDBNotifications();
       await this.handleUnprocessedNotifications();
 
-      // complete one intiial load
+      // complete intial load
       // defer and debounce any further calls to load notifications to avoid duplicate processing
-      await this.handleNotificationLoad();
-      this.notificationsLoader$.pipe(debounceTime(5000)).subscribe(async () => {
+      this.notificationsLoader$.pipe(debounceTime(2000)).subscribe(async () => {
         await this.handleNotificationLoad();
         await this.setApiNotifications();
       });
@@ -287,8 +286,12 @@ export class LocalNotificationService extends AsyncServiceBase {
    * Schedule a local notification
    * This will create an optimistic database update, which will then be scheduled to Capacitor
    * API during the loadNotifications callback
+   *
+   * @param notification - localNotification config passed to capacitor notification api
+   * @param id - string notification id. This will be written to db for notification lookup as
+   * by default capacitor generates and uses integer ids
    */
-  public async scheduleNotification(notification: ILocalNotification) {
+  public async scheduleNotification(notification: ILocalNotification, id: string) {
     if (!this.permissionGranted) return;
     // add default values
     Object.entries(this.localNotificationDefaults).forEach(([key, value]) => {
@@ -305,16 +308,21 @@ export class LocalNotificationService extends AsyncServiceBase {
     // Capacitor notifications use a random integer as id, however we also want to retain the id of the
     // row used to trigger the notification to avoid duplicates. Ideally this _row_id should be the primary
     // key, however swapping the columns would require additional db migration so just retaining both for now
-    notification._row_id = notification.extra.id;
-    notification.id = Math.floor(Math.random() * NOTIFICATION_ID_MAX);
+    notification._row_id = id;
+
     // HACK - for some reason largebody not always passed (possibly from schedule immediate) so reassign
     notification.largeBody = notification.largeBody || notification.body;
 
-    const existingNotification = this.notificationsByRowId[notification._row_id];
+    const existingNotification = this.notificationsByRowId[id];
     if (existingNotification) {
       await this.removeNotifications([existingNotification.id]);
     }
-    this.notificationsByRowId[notification._row_id] = notification;
+    // When writing to db and scheduling use integer ID as required by capacitor
+    const intId = Math.floor(Math.random() * NOTIFICATION_ID_MAX);
+    notification.id = intId;
+    this.notificationsByRowId[id] = notification;
+    console.log("[Notification] schedule", notification);
+
     await this.addDBNotification(notification as ILocalNotification);
     this.loadNotifications();
   }
@@ -342,7 +350,7 @@ export class LocalNotificationService extends AsyncServiceBase {
       ...notification,
       schedule: { at: notificationDeliveryTime },
     };
-    await this.scheduleNotification(immediateNotification);
+    await this.scheduleNotification(immediateNotification, `${notificationDeliveryTime}`);
     // ensure api notification scheduled immediately
     await LocalNotifications.schedule({ notifications: [immediateNotification] });
     if (Capacitor.isNative && forceBackground) {

--- a/src/app/shared/services/notification/local-notification.service.ts
+++ b/src/app/shared/services/notification/local-notification.service.ts
@@ -30,7 +30,11 @@ const NOTIFICATION_ID_MAX = 2147483647;
 /** Utility type to assert local notification has extra and schedule defined */
 export interface ILocalNotification extends LocalNotificationSchema {
   schedule: LocalNotificationSchema["schedule"];
-  extra: any;
+  /**
+   * Depending on notification source, `extra` data may be included for use in processing
+   * E.g. campaigns system provides full campaign row
+   */
+  extra: Record<string, any>;
   _created?: any;
   _row_id?: string;
   _action_performed?: string;
@@ -202,7 +206,7 @@ export class LocalNotificationService extends AsyncServiceBase {
       sound: null,
       attachments: null,
       // actionTypeId: "action_1", // Currently no action buttons included
-      extra: null,
+      extra: {},
       // Note, we don't want android to remove notification as we will handle in db
       autoCancel: false,
     };

--- a/src/app/shared/services/notification/local-notification.service.ts
+++ b/src/app/shared/services/notification/local-notification.service.ts
@@ -46,6 +46,11 @@ export interface ILocalNotification extends LocalNotificationSchema {
   providedIn: "root",
 })
 /**
+ * @deprecated since v0.20.0
+ * This service is tightly coupled with the campaigns system and requires overhaul
+ * Alternate work started within the notifications feature in
+ * `src\app\feature\notification\notification.service.ts`
+ *
  * The local notification service manages scheduled notifications in the database, and handles
  * mapping db notifications to the Capactor notifications API
  * https://capacitorjs.com/docs/apis/local-notifications


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
Creates a new notification system designed to work with authored actions. 

This creates a new `notification` action namespace, with child actions to `create` , `cancel` , `cancel_all` and `request_permission` for notifications. Authors are able to keep track of scheduled notifications within the `_notifications` data_list.

Functionality is demonstrated in new feature sheet [feat_notification_actions](https://docs.google.com/spreadsheets/d/1m_q57wKk7rWCzW5J2DQu8IH4DNYM_rILbDifrN-d_iQ/edit?gid=1107968849#gid=1107968849)

## For Follow-up
See https://github.com/IDEMSInternational/open-app-builder/issues/3007

## Review Notes
See examples in [feat_notification_actions](https://docs.google.com/spreadsheets/d/1m_q57wKk7rWCzW5J2DQu8IH4DNYM_rILbDifrN-d_iQ/edit?gid=1107968849#gid=1107968849)

This sheet can be used to test scheduling notifications through actions. 

It would also be good to test if working as expected on Android and IOS

## Author Notes
The action-based notification system should be considered independent to the campaigns system, and as such it is recommended to only use one system per deployment. In the future we should likely work to align these two systems together, however in the short term that would require significant refactor on the campaigns system so not included as part of this PR.

I wasn't sure whether `notification: create` or `notification: schedule` made more sense from an authoring perspective. I went for `create` as I think we use in some other contexts, but open to suggestion. Similarly was unsure between `cancel` , `remove` and `delete` to revert, opted for `cancel` as it sounded more natural for a notification (although I think we more commonly use `remove` or `delete`?).... Again, open to whatever authoring preferences may be

Assuming happy with the syntax the new feature sheet can likely replace the debug [example_notification_actions](https://docs.google.com/spreadsheets/d/1xeI4L_pfG9rqIH4KivWli4RX5IOTs1_uUL-7XjyewPA/edit?gid=579616705#gid=579616705)

## Dev Notes
Originally I had attempted to use the existing `localNotification` service for scheduling notifications, however it had a number of knock-ons such as the notification-interaction service trying to extract campaign_id of notifications emitted. Given the unintuitive coupling between campaigns and localNotification services, action integration would have required designing either designing the syntax to more closely mimic campaigns, or to significantly refactor the campaigns system. Neither of these options are desirable right now, so instead I opted to create a new, somewhat standalone system.

There is some minor tidying to the campaigns and localNotifications systems which came up during attempted refactor, however these should be mostly minor (larger breaking changes were abandoned and reverted).

Writing tests were a bit of a pain. Initially I just tried to get AI (claude 4) to write them and they looked pretty decent, but there is a bit of a quirk when using the native LocalNotification API - the plugin itself is a proxy for the web API code that is loaded via dynamic `import('./web.ts')` from the package which jasmine isn't designed to intercept (easier if we migrate to jest in the future). So calling something like `spyOn(LocalNotifications,'schedule')` fails because it attaches the spy to the proxy object which is then replaced by dynamic web code. Trying to spy on the web API directly also fails. 

This meant that the actual LocalNotification API would be called within the test browser, which would fail as not able to accept notification permission prompt. Capacitor does have docs on [mocking plugins](https://capacitorjs.com/docs/guides/mocking-plugins) however their suggested approach of mapping full capacitor imports seemed to break the running code, hence the slight workaround to call nativeApi via a private `api` method that is easier to replace.

## Git Issues

Closes #2984

## Screenshots/Videos
**[feat_notification_actions](https://docs.google.com/spreadsheets/d/1m_q57wKk7rWCzW5J2DQu8IH4DNYM_rILbDifrN-d_iQ/edit?gid=1107968849#gid=1107968849) sheet screenshot**
![localhost_4200_template_feat_notification_actions](https://github.com/user-attachments/assets/f26a1063-63fd-417f-984d-7d0a2cab2eb3)
