### PR TITLE
feat: translate text component value to specified language

### DIFF
--- a/src/app/shared/components/template/components/text/text.component.html
+++ b/src/app/shared/components/template/components/text/text.component.html
@@ -1,14 +1,12 @@
-@if (this._row.value) {
+@if (this.value()) {
   <div
     class="large standard normal"
-    [class]="params.style"
+    [class]="params().style"
     [ngStyle]="!hasTextValue ? { display: 'none' } : { display: 'block' }"
     [innerHTML]="
-      params.type === 'numbered'
-        ? (this._row.value | number)
-        : (this._row.value?.toString() | markdown)
+      params().type === 'numbered' ? (this.value() | number) : (this.value()?.toString() | markdown)
     "
     [style]="_row.style_list | styleList"
-    [style.textAlign]="params.textAlign"
+    [style.textAlign]="params().textAlign"
   ></div>
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Exposes a new parameter on the text component, `language_code`. If provided, and if a valid language code for which translations exist for the current app and string in question, then the value of the text component will be translated to this language, which may not match the current app language.

## Dev notes

Because of the requirement of the issue that the actual value of the component must change, not just the value rendered in the DOM, there are some complications with the implementation that involve storing the previous language in order to translate from a non-default language back to the default. Additionally, the fact that the default language doesn't have a translations file associated with it results in a reverse object lookup being used.

## Git Issues

Closes #2996 

## Screenshots/Videos

[feature_translate_text](https://docs.google.com/spreadsheets/d/1gg953sra_4FnUFKcAkoZQKxM0NHHNIc2qA9-z26Azdw/edit?gid=569531329#gid=569531329)

<img width="800" alt="Screenshot 2025-06-18 at 17 13 17" src="https://github.com/user-attachments/assets/fe3d2868-b4e4-4b6f-93e4-119c6305e0e5" />

<img width="600" alt="Screenshot 2025-06-18 at 17 13 05" src="https://github.com/user-attachments/assets/42b9f406-608b-4d2e-85bc-b91fe9db7841" />

