### PR TITLE
chore: handle case of task progress bar with no data list

### DIFF
--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -141,7 +141,13 @@ export class TmplTaskProgressBarComponent
   }
 
   async ngOnInit() {
-    this.getParams();
+    const params = this.getParams();
+    if (params.dataListName) {
+      await this.initialiseTaskGroupData();
+    }
+  }
+
+  private async initialiseTaskGroupData() {
     await this.getTaskGroupDataRows();
     this.checkAndSetUseDynamicData();
     if (this.useDynamicData) {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow up to #2985. Minor fix to handle case where the task progress bar component has it's progress set explicitly via the `progress_percent` param, in which case the component should not try to read from task group data. This results in an error no longer being thrown when no `task_group_data` is provided to the component.

## Git Issues

Closes #2999 

## Screenshots/Videos

[comp_task_progress_bar](https://docs.google.com/spreadsheets/d/1KenOF4C7BjVmg07zONWQgRygVWMDaXCOGLOSfC5vx7g/edit?gid=2015154474#gid=2015154474), no longer throwing the error documented in the issue:

<img width="1000" alt="Screenshot 2025-06-19 at 09 46 20" src="https://github.com/user-attachments/assets/d2205d8c-6b28-413d-9821-4375b6a8995f" />

