### PR TITLE
feat: add 'auth: delete_account' template action

### DIFF
--- a/src/app/shared/services/auth/auth.service.ts
+++ b/src/app/shared/services/auth/auth.service.ts
@@ -118,6 +118,7 @@ export class AuthService extends AsyncServiceBase {
           sign_in_google: async () => await this.provider.signInWithGoogle(),
           sign_in_apple: async () => await this.provider.signInWithApple(),
           sign_out: async () => await this.provider.signOut(),
+          delete_account: async () => await this.provider.deleteAccount(),
         };
         if (!(actionId in childActions)) {
           console.error(`[AUTH] - No action, "${actionId}"`);

--- a/src/app/shared/services/auth/providers/base.auth.ts
+++ b/src/app/shared/services/auth/providers/base.auth.ts
@@ -20,4 +20,9 @@ export class AuthProviderBase {
     this.authUser.set(undefined);
     return this.authUser();
   }
+
+  public async deleteAccount() {
+    throw new Error("Delete account not enabled");
+    return this.authUser();
+  }
 }

--- a/src/app/shared/services/auth/providers/firebase.auth.ts
+++ b/src/app/shared/services/auth/providers/firebase.auth.ts
@@ -64,6 +64,13 @@ export class FirebaseAuthProvider extends AuthProviderBase {
     return this.authUser();
   }
 
+  public async deleteAccount() {
+    await FirebaseAuthentication.deleteUser();
+    this.authUser.set(undefined);
+    localStorage.removeItem(AUTH_METADATA_FIELD);
+    return this.authUser();
+  }
+
   private setAuthUser(user: User, profile: Partial<IAuthUser>) {
     const authUser: IAuthUser = {
       ...profile,


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new template action: `auth: delete_account`. This action deletes the account of the currently signed in user from Firebase auth, and resets local data to ensure that the user does not appear to be signed in.

This action does not affect any data in the postgres database, it simply deletes the user's auth account in firebase. If other functionality is used that makes use of the user's auth ID, e.g. shared data in Firebase Firestore, then this is also unaffected: in the case of shared data, there will still exist documents that grant access permissions to a user with the old auth ID, but there will no longer exist a user with such an ID.

## Testing

I have confirmed that deleting an account from within the app causes the account to be deleted in the Firebase Auth console. Signing into the app with the same email address creates a new account with a different auth ID.

When testing this functionality on deployments other than the debug deployment, it may be worth using an additional Google/Apple account to the one usually used, in case you want to keep the data associated with that account for testing other features (e.g. shared data functionality, profile data restore).

## Git Issues

Closes #3010 

## Screenshots/Videos



