### PR TITLE
[Bug Fix] Speech Bubble: Add Image asset check

### DIFF
--- a/src/app/shared/components/template/components/text-bubble/text-bubble.component.html
+++ b/src/app/shared/components/template/components/text-bubble/text-bubble.component.html
@@ -25,9 +25,11 @@
       }
     </div>
   </div>
-  <img
-    [src]="params.speakerImageAsset | plhAsset"
-    class="speaker-image"
-    [attr.data-position]="params.speakerPosition"
-  />
+  @if (params.speakerImageAsset) {
+    <img
+      [src]="params.speakerImageAsset | plhAsset"
+      class="speaker-image"
+      [attr.data-position]="params.speakerPosition"
+    />
+  }
 </div>


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Adds validation for the `speech_bubble` image. If image is non-existent, bubble fills the screen

## Git Issues

Closes #3043 

## Screenshots/Videos

<img width="300" src="https://github.com/user-attachments/assets/8fcd116c-568c-417d-85d7-eb300289aa8f" />
