### PR TITLE
chore(plh-parent-group): when importing rapidpro parents, generate unique local ID

### DIFF
--- a/packages/components/plh/parent-group/plh-parent-group.service.spec.ts
+++ b/packages/components/plh/parent-group/plh-parent-group.service.spec.ts
@@ -5,8 +5,6 @@ import { PlhParentGroupService } from "./plh-parent-group.service";
 import { AuthService } from "src/app/shared/services/auth/auth.service";
 import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic-data.service";
 import { SharedDataService } from "src/app/feature/shared-data/shared-data.service";
-import type { IParent, IParentFromRapidPro, IParentInSharedData } from "./plh-parent-group.types";
-import { rapidproUtils } from "./utils/rapidpro.utils";
 
 /**
  * Call standalone tests via:

--- a/packages/components/plh/parent-group/utils/rapidpro.utils.spec.ts
+++ b/packages/components/plh/parent-group/utils/rapidpro.utils.spec.ts
@@ -1,11 +1,10 @@
 import { rapidproUtils } from "./rapidpro.utils";
-import type {
-  IParent,
-  IParentFromRapidPro,
-  IParentInSharedData,
-  IParentGroup,
-} from "../plh-parent-group.types";
+import type { IParent, IParentFromRapidPro, IParentInSharedData } from "../plh-parent-group.types";
 
+/**
+ * Call standalone tests via:
+ * yarn ng test --include ../packages/components/plh/parent-group/utils/rapidpro.utils.spec.ts
+ */
 describe("rapidproUtils", () => {
   it("should format a parent from RapidPro correctly", () => {
     const parentFromRapidPro = {
@@ -22,7 +21,7 @@ describe("rapidproUtils", () => {
       parentGroupId
     );
     expect(result).toEqual({
-      id: "uuid-123",
+      id: "group-456+uuid-123",
       group_id: "group-456",
       rp_uuid: "uuid-123",
       rp_name: "Jasper",

--- a/packages/components/plh/parent-group/utils/rapidpro.utils.ts
+++ b/packages/components/plh/parent-group/utils/rapidpro.utils.ts
@@ -86,7 +86,8 @@ function transformParentWithRapidProDataToLocalFormat(
   return {
     ...rest,
     ...parsedRapidProFields,
-    id: rapidpro_uuid,
+    // Use a combined id of the parent group id and the rapidpro_uuid to ensure uniqueness
+    id: parentGroupId + "+" + rapidpro_uuid,
     group_id: parentGroupId,
     rp_uuid: rapidpro_uuid,
   } as IParent;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow-up to #3055.

When first pulling parent group data from shared data that includes a parent that has been added by RapidPro, a unique ID is generated to be associated with the parent in local data (as the `id` field). This ID is generated by concatenating the parent group ID and the `rapidpro_uuid`, separated with a `+` symbol. Previously, the `rapidpro_uuid` alone was used, but this didn't allow for a parent appearing in multiple groups (which may happen, temporarily, if a parent is moved from one group to another, for example). 

## Git Issues

Closes https://github.com/IDEMSInternational/open-app-builder-functions/issues/8

## Screenshots/Videos


