### PR TITLE
feat: add '_operating_system' protected field

### DIFF
--- a/packages/data-models/fields.ts
+++ b/packages/data-models/fields.ts
@@ -28,6 +28,7 @@ enum PROTECTED_FIELDS {
    * https://capacitorjs.com/docs/plugins/web#aliases
    **/
   NOTIFICATION_PERMISSION_STATUS = "notification_permission_status",
+  OPERATING_SYSTEM = "operating_system",
   PLATFORM = "platform",
   SERVER_SYNC_LATEST = "server_sync_latest",
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { Router } from "@angular/router";
 import { Capacitor } from "@capacitor/core";
 import { SplashScreen } from "@capacitor/splash-screen";
 import { App } from "@capacitor/app";
+import { Device } from "@capacitor/device";
 import { DbService } from "./shared/services/db/db.service";
 import { SkinService } from "./shared/services/skin/skin.service";
 import { ThemeService } from "./feature/theme/services/theme.service";
@@ -170,7 +171,8 @@ export class AppComponent {
     this.localStorageService.setProtected("APP_VERSION", _app_builder_version);
     this.localStorageService.setProtected("CONTENT_VERSION", _content_version);
     this.localStorageService.setProtected("PLATFORM", Capacitor.getPlatform());
-
+    const { operatingSystem } = await Device.getInfo();
+    this.localStorageService.setProtected("OPERATING_SYSTEM", operatingSystem);
     const appEnv = environment.production ? "production" : "development";
     this.localStorageService.setProtected("APP_ENVIRONMENT", appEnv);
     this.localStorageService.setProtected("APP_HOSTNAME", location.hostname);


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new, author-facing field, `_operating_system`, which stores the name of the operating system of the current device. Possible values are `'ios' | 'android' | 'windows' | 'mac' | 'unknown'`.

This value should correspond exactly with the existing user field in the database, `operatingSystem`, see [App User Disaggregation](https://docs.google.com/spreadsheets/d/1EMc-MIWzjJMrnQG8aoB8Hum2WsXESmq7JDWdX70cuOI/edit?gid=1957404107#gid=1957404107).

I'm not entirely sure under what circumstances the Capacitor would return "unknown" for this value, but it would be worth authoring with this possibility in mind, e.g. not relying on the field having one of the values in order to display a critically important button, for example. 

These changes follow the pattern of code used in #2875.

## Git Issues

Closes #3060

## Screenshots/Videos

[example_protected_fields](https://docs.google.com/spreadsheets/d/1X10C5YWsqJ7NRJp-pSiaYjdAoV4hl5-scvisiBThmq8/edit?gid=460679842#gid=460679842)

<img width="600" height="83" alt="Screenshot 2025-07-30 at 10 58 48" src="https://github.com/user-attachments/assets/5bec0a2d-5d9a-4f3c-bfd9-fe80bf58b99a" />

| Web (Chrome on Mac) | iOS (emulator) | Android (emulator) |
|---|---|---|
| <img width="320" height="746" alt="Screenshot 2025-07-30 at 10 58 08" src="https://github.com/user-attachments/assets/9bb27667-e043-4f5d-9371-d0bf9d5a7142" /> | | |
