### PR TITLE
style: remove extra whitespace around task-card for plh_facilitator_my theme

### DIFF
--- a/src/theme/themes/plh_facilitator_my/overrides.scss
+++ b/src/theme/themes/plh_facilitator_my/overrides.scss
@@ -43,7 +43,6 @@ body[data-theme="plh_facilitator_my"] {
       filter: none !important;
       border: 1px solid var(--ion-color-primary-200) !important;
       box-shadow: -2px 3px 6px rgba($color: #dae8f6, $alpha: 0.3);
-      margin: 14px auto !important;
     }
     .image-wrapper {
       img {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

The `plh_facilitator_my` theme included additional margins around the task card component. This is removed in this PR, as the default spacing should be sufficient. There is an additional question of whether data-items rows should include default vertical margin/padding, for which I've added a new issue, #3069.

@esmeetewinkel had effectively already resolved this as part of the issue description.

The other themes based on the KW theme also include this additional margin, which should be removed. However, I understand that this is, at least in some cases, being counteracted by authoring negative margins in some production templates. Rather than include changes to all affected themes, which would potentially require authoring changes for all associated deployments, I think it makes sense to limit this to the deployment with the visual bug for now. Rolling out these changes to other themes can be done as part of the planned process of updating all of the KW-based themes to make use of the new colour palettes (see #3017) and reduce the number of style overrides.

## Git Issues

Closes #3061

## Screenshots/Videos

`plh_facilitator_my` home screen:
<img width="340" height="745" alt="Screenshot 2025-07-31 at 15 01 53" src="https://github.com/user-attachments/assets/1d8d8da4-8412-4d24-977a-632f87a6312e" />
