### PR TITLE
fix(plh parent groupss): handle parent group_id foreign key being either parent group id or parent group name

### DIFF
--- a/packages/components/plh/parent-group/plh-parent-group.service.ts
+++ b/packages/components/plh/parent-group/plh-parent-group.service.ts
@@ -416,11 +416,11 @@ export class PlhParentGroupService extends SyncServiceBase {
     });
     const [parentGroupData] = await firstValueFrom(parentGroupQuery);
 
-    // HACK: currently the parent group name is used as the ID assigned to parents, so use this for the query
-    const parentGroupName = parentGroupData.name;
-
     const parentsQuery = this.dynamicDataService.query$("data_list", parentsDataList, {
-      selector: { group_id: parentGroupName },
+      selector: {
+        // HACK: currently the parent group name is used as the ID assigned to parents in some cases, so get parent instances for both
+        $or: [{ group_id: parentGroupData.id }, { group_id: parentGroupData.name }],
+      },
     });
     const parentsData = await firstValueFrom(parentsQuery);
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

When handling parent groups data, there is some disparity in how parents are linked to a parent group in local data. For complicated reasons, the `plh_facilitator_ph` deployment uses the parent group's `name` field (which is sometimes the same as the `id` but not always) as the foreign key for the parent table's `group_id` field, whereas the `plh_facilitator_my` deployment uses the parent group's `id` field for this purpose. This PR updates the custom parent group code so that the method that gathers data from the respective parent group and parent tables handles both cases.

## Git Issues

Closes #
