### PR TITLE
fix(plh parent group): handle merging with existing data when pushing and pulling

### DIFF
--- a/packages/components/plh/parent-group/plh-parent-group.service.ts
+++ b/packages/components/plh/parent-group/plh-parent-group.service.ts
@@ -416,11 +416,11 @@ export class PlhParentGroupService extends SyncServiceBase {
     });
     const [parentGroupData] = await firstValueFrom(parentGroupQuery);
 
-    // HACK: currently the parent group name is used as the ID assigned to parents, so use this for the query
-    const parentGroupName = parentGroupData.name;
-
     const parentsQuery = this.dynamicDataService.query$("data_list", parentsDataList, {
-      selector: { group_id: parentGroupName },
+      selector: {
+        // HACK: currently the parent group name is used as the ID assigned to parents in some cases, so get parent instances for both
+        $or: [{ group_id: parentGroupData.id }, { group_id: parentGroupData.name }],
+      },
     });
     const parentsData = await firstValueFrom(parentsQuery);
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)
- [ ] includes #3104, which should be merged first

## Description

Addresses some issues with pushing and pulling parent data to/from shared data. Namely:
- Ensures that data to be pushed is processed in correct order
  - Previously `rp_*` fields were stripped out from local data before attempting to merge with existing shared data. This meant that matching parents were not being identified based on their rapidpro id since this field was not there to compare.
- Ensures that incoming parent data is merged with existing local parent data when pulling
  - Previously, the incoming data for each parent would overwrite the existing data for the corresponding parent

## Git Issues

Closes https://github.com/ParentingForLifelongHealth/plh-facilitator-app-my-content/issues/180

## Screenshots/Videos

User journey on `plh_facilitator_my` deployment that was previously documented as broken in https://github.com/ParentingForLifelongHealth/plh-facilitator-app-my-content/issues/180


