### PR TITLE
style: remove additional padding around pop-up content for fullscreen pop-ups

### DIFF
--- a/src/app/shared/components/template/components/layout/popup/popup.component.scss
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.scss
@@ -1,3 +1,5 @@
+$pop-up-padding: var(--pop-up-padding, 20px);
+
 .popup-backdrop {
   // Ensure some padding applied even when --ion-safe-area-* is 0px
   --pop-up-top-padding: max(var(--ion-safe-area-top), 24px);
@@ -35,7 +37,7 @@
     max-height: 100%;
     background: white;
     border-radius: 20px;
-    padding: 20px;
+    padding: $pop-up-padding;
     overflow: auto;
   }
   .popup-content[data-fullscreen] {
@@ -44,6 +46,7 @@
     max-height: 100vh;
     border-radius: 0;
     margin: 0;
+    padding: 0;
   }
   .popup-content::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Removes padding around content within a pop-up in the case that the pop-up is fullscreen
- Exposes a new `--pop-up-padding` property to theming. Currently no theme overrides this, so the default value of `20px` will be used, maintaining consistency with the current styling.

This will cause visual changes to all fullscreen popups, reducing the padding to more closely match that around content on a non-pop-up page.

## Explanation

The padding around the pop-up content padding is necessary for non-fullscreen pop-ups to display the content sensibly within the pop-up container:

<img width="280" height="746" alt="Screenshot 2025-08-22 at 12 40 04" src="https://github.com/user-attachments/assets/1efb4515-ea11-4753-88fe-b091b16f0231" />

However in the case of fullscreen pop-ups, the pop-up container padding is sufficient because the visible container goes to the very edges of the screen.

<img width="280" height="746" alt="Screenshot 2025-08-22 at 12 40 51" src="https://github.com/user-attachments/assets/4c658406-db56-4301-a115-6beb1243c557" />

## Git Issues

Closes #2865

## Screenshots/Videos

Fullscreen pop-up launched by Button 5 on [example_pop_ups](https://docs.google.com/spreadsheets/d/1K9JZ9Glnj73CFJmpfGIRa5dRA2TBxSsJmaguV6GL8Pc/edit?gid=402992224#gid=402992224) template:

| Before | After |
|---|---|
| <img width="461" height="748" alt="Screenshot 2025-08-22 at 12 52 26" src="https://github.com/user-attachments/assets/1a8f66dd-7750-4f6f-9ce8-6581e257c50d" /> | <img width="465" height="747" alt="Screenshot 2025-08-22 at 12 52 02" src="https://github.com/user-attachments/assets/4eefe4a4-3607-4e71-a073-a76ed0b6af78" /> |