### PR TITLE
Feat: expose pop-up background colour to theming

### DIFF
--- a/src/app/shared/components/template/components/layout/popup/popup.component.scss
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.scss
@@ -1,8 +1,8 @@
-$popup-background-color: var(--pop-up-background-color, var(--ion-background-color));
+$pop-up-background: var(--pop-up-background, var(--ion-background-color));
 
 // Set the background color var to the popup background color for any children
 :host {
-  --ion-background-color: $popup-background-color;
+  --ion-background-color: $pop-up-background;
 }
 
 .popup-backdrop {
@@ -27,7 +27,7 @@ $popup-background-color: var(--pop-up-background-color, var(--ion-background-col
     padding-bottom: var(--pop-up-bottom-padding);
   }
   &[data-fullscreen] {
-    background: $popup-background-color;
+    background: $pop-up-background;
     .popup-container {
       height: 100%;
       max-height: unset;
@@ -40,7 +40,7 @@ $popup-background-color: var(--pop-up-background-color, var(--ion-background-col
   .popup-content {
     height: fit-content;
     max-height: 100%;
-    background: $popup-background-color;
+    background: $pop-up-background;
     border-radius: 20px;
     padding: 20px;
     overflow: auto;

--- a/src/app/shared/components/template/components/layout/popup/popup.component.scss
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.scss
@@ -1,3 +1,10 @@
+$popup-background-color: var(--pop-up-background-color, var(--ion-background-color));
+
+// Set the background color var to the popup background color for any children
+:host {
+  --ion-background-color: $popup-background-color;
+}
+
 .popup-backdrop {
   // Ensure some padding applied even when --ion-safe-area-* is 0px
   --pop-up-top-padding: max(var(--ion-safe-area-top), 24px);
@@ -20,7 +27,7 @@
     padding-bottom: var(--pop-up-bottom-padding);
   }
   &[data-fullscreen] {
-    background: white;
+    background: $popup-background-color;
     .popup-container {
       height: 100%;
       max-height: unset;
@@ -33,7 +40,7 @@
   .popup-content {
     height: fit-content;
     max-height: 100%;
-    background: white;
+    background: $popup-background-color;
     border-radius: 20px;
     padding: 20px;
     overflow: auto;
@@ -61,7 +68,7 @@
     justify-content: center;
     border: 1px solid var(--ion-color-primary);
     font-size: 24px;
-    z-index: 1;
+    z-index: 100;
     box-shadow: var(--ion-default-box-shadow);
     color: var(--ion-color-primary);
     // align 18px from end (varies with rtl/ltr direction)

--- a/src/app/shared/components/template/components/layout/popup/popup.component.scss
+++ b/src/app/shared/components/template/components/layout/popup/popup.component.scss
@@ -68,7 +68,7 @@ $popup-background-color: var(--pop-up-background-color, var(--ion-background-col
     justify-content: center;
     border: 1px solid var(--ion-color-primary);
     font-size: 24px;
-    z-index: 100;
+    z-index: 1;
     box-shadow: var(--ion-default-box-shadow);
     color: var(--ion-color-primary);
     // align 18px from end (varies with rtl/ltr direction)

--- a/src/theme/themes/default.scss
+++ b/src/theme/themes/default.scss
@@ -68,7 +68,7 @@
       text-bubble-border-color-3: var(--ion-color-yellow-700),
       text-bubble-background-color-4: var(--gradient-yellow-vertical),
       text-bubble-border-color-4: var(--ion-color-secondary-700),
-      pop-up-background-color: white
+      pop-up-background: white
     );
     @include utils.generateTheme(
       $p: $color-primary,

--- a/src/theme/themes/default.scss
+++ b/src/theme/themes/default.scss
@@ -67,7 +67,8 @@
       text-bubble-background-color-3: var(--ion-color-yellow-100),
       text-bubble-border-color-3: var(--ion-color-yellow-700),
       text-bubble-background-color-4: var(--gradient-yellow-vertical),
-      text-bubble-border-color-4: var(--ion-color-secondary-700)
+      text-bubble-border-color-4: var(--ion-color-secondary-700),
+      pop-up-background-color: white
     );
     @include utils.generateTheme(
       $p: $color-primary,


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Exposes a theme variable, `--pop-up-background`, for customising the background colour of pop-up modals (including fullscreen). By default, this will take the value of the theme's `page-background` colour. Previously, this was hardcoded as `white`.

As it happens, the only theme that doesn't use a white page background is the `default` theme. In order to preserve current behaviour, where the `default` theme styles page backgrounds as a pale variant of the primary theme colour, and pop-up backgrounds as white, the `default` theme has been updated to set `--pop-up-background` explicitly to white.

Also resolves an issue where any styling that made use of the page background colour would not work as expected within pop-ups, since it the global page background colour may differ from the pop-up background colour. See screenshots below.

## Git Issues

Closes #

## Screenshots/Videos

[debug_pop_up_bg](https://docs.google.com/spreadsheets/d/1ESiY3It66heuxfPl9PMZuYOKM6jjjpk9qIWH48Q_m-s/edit?gid=2079927361#gid=2079927361). Note the subtle box around the title elements previously, which are due to the display group with `style: background_solid` making use of the page background colour in its styling.

<img width="800" height="165" alt="Screenshot 2025-08-22 at 13 33 06" src="https://github.com/user-attachments/assets/e012afcf-d2f5-4912-a3eb-8f8db402842a" />

| Pop-up type | Before | After |
|---|---|---|
| Not fullscreen | <img width="308" height="631" alt="Screenshot 2025-08-22 at 13 20 22" src="https://github.com/user-attachments/assets/2017e90b-3680-46c7-9e0b-bfad68b08251" /> | <img width="308" height="630" alt="Screenshot 2025-08-22 at 13 18 48" src="https://github.com/user-attachments/assets/2b613bb9-00e9-44b6-bd6d-0c6ba4ca2cdf" /> |
| Fullscreen | <img width="311" height="632" alt="Screenshot 2025-08-22 at 13 20 30" src="https://github.com/user-attachments/assets/f3466d2f-ea0a-4496-9068-0872e9c52553" /> | <img width="309" height="631" alt="Screenshot 2025-08-22 at 13 18 57" src="https://github.com/user-attachments/assets/d3928ca4-2423-408b-af7c-c9845f97c7ee" /> |
