### PR TITLE
fix: radio-button-grid text wrapping

### DIFF
--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.scss
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.scss
@@ -39,6 +39,7 @@ $text-color: var(--radio-button-font-color, var(--ion-color-primary));
     .item-text {
       font-size: $text-size;
       color: $text-color;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
Fix text wrapping in radio-button-grid component

## Dev Notes
Not entirely sure why width isn't working with default, I'm guessing something to do with the nested `<p>` inside the `<div>` - could probably just be a single span although I don't want to make any breaking changes to the component so hopefully for now setting the width should fix

## Git Issues

Closes #3114
Closes https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-za-content/issues/176

## Screenshots/Videos
`plh_kids_teens_za` - `/template/module_oneononetime` (a few pages in)

<img width="400" alt="localhost_4200_template_module_oneononetime(Moto G4)" src="https://github.com/user-attachments/assets/87426984-7d41-4529-8bd5-a6ea78d2ffc2" />
