### PR TITLE
style: remove excess top margin on text-area component

### DIFF
--- a/src/app/shared/components/template/components/text-area/text-area.component.html
+++ b/src/app/shared/components/template/components/text-area/text-area.component.html
@@ -1,4 +1,4 @@
-<div class="wrapper margin-t-regular">
+<div class="wrapper">
   <ion-textarea
     #input
     class="text_area"


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow up to PR https://github.com/IDEMSInternational/open-app-builder/pull/3121, addressing an issue higlighted in https://github.com/IDEMSInternational/open-app-builder/issues/3051#issuecomment-3155633251.

## Git Issues

Closes #

## Screenshots/Videos

Before / After (`comp_text_area` template): 
<img width="357" height="794" alt="image" src="https://github.com/user-attachments/assets/43c5e833-0052-4bc2-8603-81d7ac2b416a" /> <img width="357" height="794" alt="image" src="https://github.com/user-attachments/assets/2a7f4640-85dd-43c7-a317-1082a2cd3d44" />

