### PR TITLE
Fix: audio component styling

### DIFF
--- a/src/app/shared/components/template/components/audio/audio.component.html
+++ b/src/app/shared/components/template/components/audio/audio.component.html
@@ -1,4 +1,4 @@
-<div class="container-player margin-t-large" [attr.data-variant]="params.variant">
+<div class="container-player" [attr.data-variant]="params.variant">
   @if (params.title) {
     <div class="top-row">
       <h3>{{ params.title }}</h3>

--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -347,35 +347,54 @@
 
   // audio
   plh-audio {
-    border: 1px solid transparent;
-    .container-player[data-variant~="compact"] {
-      width: var(--buttons-full-width);
-
-      border: 0.9px solid var(--ion-color-primary-100);
-      border-radius: var(--ion-border-radius-rounded);
+    .container-player[data-variant~="compact"],
+    .container-player[data-variant~="large"] {
+      // Remove visible bounding box from container level and apply to second-row instead
+      border: unset;
+      border-radius: unset;
       box-shadow: none;
-
-      background-color: var(--ion-color-primary-50);
-      padding: 8px 16px;
-      padding-right: 24px;
-      margin-top: 30px;
+      background-color: unset;
+      padding: 0;
 
       .top-row {
-        min-height: 0 !important;
-        position: absolute;
-        top: -52px;
-        margin: 0 0 0 -14px;
-        // padding-top: 30px;
+        padding-bottom: 18px;
         h3 {
           margin: 0;
           color: var(--ion-color-gray-900) !important;
           max-width: 95%;
           font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
-          // margin-top: 20px !important;
         }
       }
+
       .second-row {
+        box-shadow: none;
+      }
+
+      .progress-block {
+        ion-range {
+          --bar-background: var(--color-surface-white) !important;
+          --bar-height: 12px !important;
+          --bar-border-radius: var(--ion-border-radius-standard) !important;
+        }
+
+        .time-value {
+          font-size: var(--font-size-text-small) !important;
+          line-height: var(--line-height-text-tiny) !important;
+          color: var(--ion-color-gray-700) !important;
+        }
+      }
+    }
+
+    // Compact variant
+    .container-player[data-variant~="compact"] {
+      width: 100%;
+      .second-row {
+        width: 100%;
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-rounded);
+        background: var(--ion-color-primary-50);
+        padding: 8px 16px;
+        padding-right: 24px;
         .controls {
           ion-button.btn-play {
             --background: var(--ion-color-secondary-600) !important;
@@ -391,52 +410,28 @@
         .progress-block {
           ion-range {
             width: 100% !important;
-            --bar-background: var(--color-surface-white) !important;
-            --bar-height: 12px !important;
             --knob-size: 20px !important;
             --knob-background: var(--ion-color-secondary-600) !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
           }
-          .time {
-            .time-value {
-              font-size: var(--font-size-text-small) !important;
-              font-weight: var(--font-weight-medium) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
+          .time .time-value {
+            font-weight: var(--font-weight-medium) !important;
           }
         }
       }
     }
+
+    // Large variant
     .container-player[data-variant~="large"] {
-      background: var(--ion-color-gary-100);
-      border: 0.9px solid var(--ion-color-gray-200);
       box-sizing: border-box;
-      box-shadow: none;
-      border-radius: var(--ion-border-radius-standard);
-      padding: 12px 16px;
       display: flex;
       position: relative;
       flex-direction: column;
-      margin-top: 20px;
-      .top-row {
-        position: absolute;
-        top: -56px;
-        margin: 0 0 0 -14px;
-        h3 {
-          margin: 0;
-          margin-right: 0;
-          color: var(--ion-color-gray-900);
-          max-width: 85%;
-          font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
-        }
-        ion-button.action-button {
-          --padding-start: 2px;
-          --padding-end: 2px;
-        }
-      }
+
       .second-row {
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-standard);
+        background: var(--ion-color-primary-50);
+        padding: 12px 16px;
         display: flex;
         flex-direction: column-reverse;
         .controls {
@@ -451,7 +446,7 @@
           }
           .btn-play {
             @include mixins.large-square;
-            --background: var(--ion-color-gary-100) !important;
+            --background: var(--ion-color-primary-50) !important;
             --border-radius: var(--ion-border-radius-rounded) !important;
             --padding: 0 !important;
             --box-shadow: none !important;
@@ -465,9 +460,6 @@
         .progress-block {
           .audio-range {
             --bar-background-active: var(--ion-color-primary-400) !important;
-            --bar-background: var(--color-surface-white) !important;
-            --bar-height: 12px !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
             --knob-size: 0px !important;
             --pin-background: var(--ion-color-primary-300) !important;
             --knob-background: var(--ion-color-primary-300) !important;
@@ -481,13 +473,6 @@
           ion-range::part(bar-active) {
             top: -1.5px !important;
             margin-left: 0 !important;
-          }
-          .time {
-            &-value {
-              font-size: var(--font-size-text-small) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
           }
         }
       }

--- a/src/theme/themes/plh_facilitator_my/overrides.scss
+++ b/src/theme/themes/plh_facilitator_my/overrides.scss
@@ -371,35 +371,54 @@
 
   // audio
   plh-audio {
-    border: 1px solid transparent;
-    .container-player[data-variant~="compact"] {
-      width: var(--buttons-full-width);
-
-      border: 0.9px solid var(--ion-color-primary-100);
-      border-radius: var(--ion-border-radius-rounded);
+    .container-player[data-variant~="compact"],
+    .container-player[data-variant~="large"] {
+      // Remove visible bounding box from container level and apply to second-row instead
+      border: unset;
+      border-radius: unset;
       box-shadow: none;
-
-      background-color: var(--ion-color-primary-50);
-      padding: 8px 16px;
-      padding-right: 24px;
-      margin-top: 30px;
+      background-color: unset;
+      padding: 0;
 
       .top-row {
-        min-height: 0 !important;
-        position: absolute;
-        top: -52px;
-        margin: 0 0 0 -14px;
-        // padding-top: 30px;
+        padding-bottom: 18px;
         h3 {
           margin: 0;
           color: var(--ion-color-gray-900) !important;
           max-width: 95%;
           font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
-          // margin-top: 20px !important;
         }
       }
+
       .second-row {
+        box-shadow: none;
+      }
+
+      .progress-block {
+        ion-range {
+          --bar-background: var(--color-surface-white) !important;
+          --bar-height: 12px !important;
+          --bar-border-radius: var(--ion-border-radius-standard) !important;
+        }
+
+        .time-value {
+          font-size: var(--font-size-text-small) !important;
+          line-height: var(--line-height-text-tiny) !important;
+          color: var(--ion-color-gray-700) !important;
+        }
+      }
+    }
+
+    // Compact variant
+    .container-player[data-variant~="compact"] {
+      width: 100%;
+      .second-row {
+        width: 100%;
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-rounded);
+        background: var(--ion-color-primary-50);
+        padding: 8px 16px;
+        padding-right: 24px;
         .controls {
           ion-button.btn-play {
             --background: var(--ion-color-secondary-600) !important;
@@ -415,53 +434,28 @@
         .progress-block {
           ion-range {
             width: 100% !important;
-            --bar-background: var(--color-surface-white) !important;
-            --bar-height: 12px !important;
-            --knob-size: 16px !important;
+            --knob-size: 20px !important;
             --knob-background: var(--ion-color-secondary-600) !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
-            --knob-box-shadow: none !important;
           }
-          .time {
-            .time-value {
-              font-size: var(--font-size-text-small) !important;
-              font-weight: var(--font-weight-medium) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
+          .time .time-value {
+            font-weight: var(--font-weight-medium) !important;
           }
         }
       }
     }
+
+    // Large variant
     .container-player[data-variant~="large"] {
-      background: var(--ion-color-gray-100);
-      border: 0.9px solid var(--ion-color-gray-200);
       box-sizing: border-box;
-      box-shadow: none;
-      border-radius: var(--ion-border-radius-standard);
-      padding: 12px 16px;
       display: flex;
       position: relative;
       flex-direction: column;
-      margin-top: 20px;
-      .top-row {
-        position: absolute;
-        top: -56px;
-        margin: 0 0 0 -14px;
-        h3 {
-          margin: 0;
-          margin-right: 0;
-          color: var(--ion-color-gray-900);
-          max-width: 85%;
-          font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
-        }
-        ion-button.action-button {
-          --padding-start: 2px;
-          --padding-end: 2px;
-        }
-      }
+
       .second-row {
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-standard);
+        background: var(--ion-color-primary-50);
+        padding: 12px 16px;
         display: flex;
         flex-direction: column-reverse;
         .controls {
@@ -476,7 +470,7 @@
           }
           .btn-play {
             @include mixins.large-square;
-            --background: var(--ion-color-gray-100) !important;
+            --background: var(--ion-color-primary-50) !important;
             --border-radius: var(--ion-border-radius-rounded) !important;
             --padding: 0 !important;
             --box-shadow: none !important;
@@ -489,13 +483,10 @@
         }
         .progress-block {
           .audio-range {
-            --bar-background-active: var(--ion-color-secondary-600) !important;
-            --bar-background: var(--color-surface-white) !important;
-            --bar-height: 12px !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
+            --bar-background-active: var(--ion-color-primary-400) !important;
             --knob-size: 0px !important;
-            --pin-background: var(--ion-color-secondary-300) !important;
-            --knob-background: var(--ion-color-secondary-300) !important;
+            --pin-background: var(--ion-color-primary-300) !important;
+            --knob-background: var(--ion-color-primary-300) !important;
             padding-inline: 0;
           }
 
@@ -506,13 +497,6 @@
           ion-range::part(bar-active) {
             top: -1.5px !important;
             margin-left: 0 !important;
-          }
-          .time {
-            &-value {
-              font-size: var(--font-size-text-small) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
           }
         }
       }

--- a/src/theme/themes/plh_facilitator_ph/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_ph/_overrides.scss
@@ -369,35 +369,54 @@
 
   // audio
   plh-audio {
-    border: 1px solid transparent;
-    .container-player[data-variant~="compact"] {
-      width: var(--buttons-full-width);
-
-      border: 0.9px solid var(--ion-color-primary-100);
-      border-radius: var(--ion-border-radius-rounded);
+    .container-player[data-variant~="compact"],
+    .container-player[data-variant~="large"] {
+      // Remove visible bounding box from container level and apply to second-row instead
+      border: unset;
+      border-radius: unset;
       box-shadow: none;
-
-      background-color: var(--ion-color-primary-50);
-      padding: 8px 16px;
-      padding-right: 24px;
-      margin-top: 30px;
+      background-color: unset;
+      padding: 0;
 
       .top-row {
-        min-height: 0 !important;
-        position: absolute;
-        top: -52px;
-        margin: 0 0 0 -14px;
-        // padding-top: 30px;
+        padding-bottom: 18px;
         h3 {
           margin: 0;
           color: var(--ion-color-gray-900) !important;
           max-width: 95%;
           font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
-          // margin-top: 20px !important;
         }
       }
+
       .second-row {
+        box-shadow: none;
+      }
+
+      .progress-block {
+        ion-range {
+          --bar-background: var(--color-surface-white) !important;
+          --bar-height: 12px !important;
+          --bar-border-radius: var(--ion-border-radius-standard) !important;
+        }
+
+        .time-value {
+          font-size: var(--font-size-text-small) !important;
+          line-height: var(--line-height-text-tiny) !important;
+          color: var(--ion-color-gray-700) !important;
+        }
+      }
+    }
+
+    // Compact variant
+    .container-player[data-variant~="compact"] {
+      width: 100%;
+      .second-row {
+        width: 100%;
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-rounded);
+        background: var(--ion-color-primary-50);
+        padding: 8px 16px;
+        padding-right: 24px;
         .controls {
           ion-button.btn-play {
             --background: var(--ion-color-secondary-600) !important;
@@ -413,53 +432,28 @@
         .progress-block {
           ion-range {
             width: 100% !important;
-            --bar-background: var(--color-surface-white) !important;
-            --bar-height: 12px !important;
-            --knob-size: 16px !important;
+            --knob-size: 20px !important;
             --knob-background: var(--ion-color-secondary-600) !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
-            --knob-box-shadow: none !important;
           }
-          .time {
-            .time-value {
-              font-size: var(--font-size-text-small) !important;
-              font-weight: var(--font-weight-medium) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
+          .time .time-value {
+            font-weight: var(--font-weight-medium) !important;
           }
         }
       }
     }
+
+    // Large variant
     .container-player[data-variant~="large"] {
-      background: var(--ion-color-gray-100);
-      border: 0.9px solid var(--ion-color-gray-200);
       box-sizing: border-box;
-      box-shadow: none;
-      border-radius: var(--ion-border-radius-standard);
-      padding: 12px 16px;
       display: flex;
       position: relative;
       flex-direction: column;
-      margin-top: 20px;
-      .top-row {
-        position: absolute;
-        top: -56px;
-        margin: 0 0 0 -14px;
-        h3 {
-          margin: 0;
-          margin-right: 0;
-          color: var(--ion-color-gray-900);
-          max-width: 85%;
-          font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
-        }
-        ion-button.action-button {
-          --padding-start: 2px;
-          --padding-end: 2px;
-        }
-      }
+
       .second-row {
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-standard);
+        background: var(--ion-color-primary-50);
+        padding: 12px 16px;
         display: flex;
         flex-direction: column-reverse;
         .controls {
@@ -474,7 +468,7 @@
           }
           .btn-play {
             @include mixins.large-square;
-            --background: var(--ion-color-gray-100) !important;
+            --background: var(--ion-color-primary-50) !important;
             --border-radius: var(--ion-border-radius-rounded) !important;
             --padding: 0 !important;
             --box-shadow: none !important;
@@ -487,13 +481,10 @@
         }
         .progress-block {
           .audio-range {
-            --bar-background-active: var(--ion-color-secondary-600) !important;
-            --bar-background: var(--color-surface-white) !important;
-            --bar-height: 12px !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
+            --bar-background-active: var(--ion-color-primary-400) !important;
             --knob-size: 0px !important;
-            --pin-background: var(--ion-color-secondary-300) !important;
-            --knob-background: var(--ion-color-secondary-300) !important;
+            --pin-background: var(--ion-color-primary-300) !important;
+            --knob-background: var(--ion-color-primary-300) !important;
             padding-inline: 0;
           }
 
@@ -504,13 +495,6 @@
           ion-range::part(bar-active) {
             top: -1.5px !important;
             margin-left: 0 !important;
-          }
-          .time {
-            &-value {
-              font-size: var(--font-size-text-small) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
           }
         }
       }

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -130,13 +130,14 @@
 
   // audio
   plh-audio {
-    .container-player {
+    .container-player[data-variant~="compact"],
+    .container-player[data-variant~="large"] {
       // Remove visible bounding box from container level and apply to second-row instead
-      border: unset !important;
-      border-radius: unset !important;
-      box-shadow: none !important;
-      background-color: unset !important;
-      padding: 0 !important;
+      border: unset;
+      border-radius: unset;
+      box-shadow: none;
+      background-color: unset;
+      padding: 0;
 
       .top-row {
         padding-bottom: 18px;
@@ -145,7 +146,6 @@
           color: var(--ion-color-gray-900) !important;
           max-width: 95%;
           font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
         }
       }
 
@@ -154,11 +154,10 @@
       }
 
       .progress-block {
-        ion-range,
-        .audio-range {
-          --bar-background: var(--color-surface-white) !important;
-          --bar-height: 12px !important;
-          --bar-border-radius: var(--ion-border-radius-standard) !important;
+        ion-range {
+          --bar-background: var(--color-surface-white);
+          --bar-height: 12px;
+          --bar-border-radius: var(--ion-border-radius-standard);
         }
 
         .time-value {

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -138,9 +138,9 @@
       background-color: unset;
       padding: 0;
       .top-row {
+        padding-bottom: 18px;
         h3 {
           margin: 0;
-          padding-bottom: var(--large-padding);
           color: var(--ion-color-gray-900) !important;
           max-width: 95%;
           font-weight: var(--font-weight-bold);
@@ -189,34 +189,37 @@
       }
     }
     .container-player[data-variant~="large"] {
-      background: var(--ion-color-primary-50);
-      border: 0.9px solid var(--ion-color-primary-100);
+      background-color: unset;
+      border: unset;
       box-sizing: border-box;
       box-shadow: none;
-      border-radius: var(--ion-border-radius-standard);
-      padding: 12px 16px;
+      border-radius: unset;
+      padding: 0;
       display: flex;
       position: relative;
       flex-direction: column;
-      margin-top: 20px;
       .top-row {
-        position: absolute;
-        top: -56px;
-        margin: 0 0 0 -14px;
+        padding-bottom: 18px;
         h3 {
           margin: 0;
-          margin-right: 0;
-          color: var(--ion-color-gray-900);
-          max-width: 85%;
+          color: var(--ion-color-gray-900) !important;
+          max-width: 95%;
           font-weight: var(--font-weight-bold);
           font-size: var(var(--font-size-text-medium) + 2);
         }
-        ion-button.action-button {
-          --padding-start: 2px;
-          --padding-end: 2px;
+        .info-icon-container {
+          ion-button.action-button {
+            --padding-start: 2px;
+            --padding-end: 2px;
+          }
         }
       }
       .second-row {
+        background: var(--ion-color-primary-50);
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-standard);
+        box-shadow: none;
+        padding: 12px 16px;
         display: flex;
         flex-direction: column-reverse;
         .controls {

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -155,9 +155,9 @@
 
       .progress-block {
         ion-range {
-          --bar-background: var(--color-surface-white);
-          --bar-height: 12px;
-          --bar-border-radius: var(--ion-border-radius-standard);
+          --bar-background: var(--color-surface-white) !important;
+          --bar-height: 12px !important;
+          --bar-border-radius: var(--ion-border-radius-standard) !important;
         }
 
         .time-value {

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -130,13 +130,14 @@
 
   // audio
   plh-audio {
-    .container-player[data-variant~="compact"] {
-      width: 100%;
-      border: unset;
-      border-radius: unset;
-      box-shadow: none;
-      background-color: unset;
-      padding: 0;
+    .container-player {
+      // Remove visible bounding box from container level and apply to second-row instead
+      border: unset !important;
+      border-radius: unset !important;
+      box-shadow: none !important;
+      background-color: unset !important;
+      padding: 0 !important;
+
       .top-row {
         padding-bottom: 18px;
         h3 {
@@ -147,13 +148,35 @@
           font-size: var(var(--font-size-text-medium) + 2);
         }
       }
+
+      .second-row {
+        box-shadow: none;
+      }
+
+      .progress-block {
+        ion-range,
+        .audio-range {
+          --bar-background: var(--color-surface-white) !important;
+          --bar-height: 12px !important;
+          --bar-border-radius: var(--ion-border-radius-standard) !important;
+        }
+
+        .time-value {
+          font-size: var(--font-size-text-small) !important;
+          line-height: var(--line-height-text-tiny) !important;
+          color: var(--ion-color-gray-700) !important;
+        }
+      }
+    }
+
+    // Compact variant
+    .container-player[data-variant~="compact"] {
+      width: 100%;
       .second-row {
         width: 100%;
         border: 0.9px solid var(--ion-color-primary-100);
         border-radius: var(--ion-border-radius-rounded);
-        box-shadow: none;
-
-        background-color: var(--ion-color-primary-50);
+        background: var(--ion-color-primary-50);
         padding: 8px 16px;
         padding-right: 24px;
         .controls {
@@ -171,54 +194,27 @@
         .progress-block {
           ion-range {
             width: 100% !important;
-            --bar-background: var(--color-surface-white) !important;
-            --bar-height: 12px !important;
             --knob-size: 20px !important;
             --knob-background: var(--ion-color-secondary-600) !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
           }
-          .time {
-            .time-value {
-              font-size: var(--font-size-text-small) !important;
-              font-weight: var(--font-weight-medium) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
+          .time .time-value {
+            font-weight: var(--font-weight-medium) !important;
           }
         }
       }
     }
+
+    // Large variant
     .container-player[data-variant~="large"] {
-      background-color: unset;
-      border: unset;
       box-sizing: border-box;
-      box-shadow: none;
-      border-radius: unset;
-      padding: 0;
       display: flex;
       position: relative;
       flex-direction: column;
-      .top-row {
-        padding-bottom: 18px;
-        h3 {
-          margin: 0;
-          color: var(--ion-color-gray-900) !important;
-          max-width: 95%;
-          font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
-        }
-        .info-icon-container {
-          ion-button.action-button {
-            --padding-start: 2px;
-            --padding-end: 2px;
-          }
-        }
-      }
+
       .second-row {
-        background: var(--ion-color-primary-50);
         border: 0.9px solid var(--ion-color-primary-100);
         border-radius: var(--ion-border-radius-standard);
-        box-shadow: none;
+        background: var(--ion-color-primary-50);
         padding: 12px 16px;
         display: flex;
         flex-direction: column-reverse;
@@ -248,9 +244,6 @@
         .progress-block {
           .audio-range {
             --bar-background-active: var(--ion-color-primary-400) !important;
-            --bar-background: var(--color-surface-white) !important;
-            --bar-height: 12px !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
             --knob-size: 0px !important;
             --pin-background: var(--ion-color-primary-300) !important;
             --knob-background: var(--ion-color-primary-300) !important;
@@ -264,13 +257,6 @@
           ion-range::part(bar-active) {
             top: -1.5px !important;
             margin-left: 0 !important;
-          }
-          .time {
-            &-value {
-              font-size: var(--font-size-text-small) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
           }
         }
       }

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -130,35 +130,32 @@
 
   // audio
   plh-audio {
-    border: 1px solid transparent;
     .container-player[data-variant~="compact"] {
-      width: var(--buttons-full-width);
-
-      border: 0.9px solid var(--ion-color-primary-100);
-      border-radius: var(--ion-border-radius-rounded);
+      width: 100%;
+      border: unset;
+      border-radius: unset;
       box-shadow: none;
-
-      background-color: var(--ion-color-primary-50);
-      padding: 8px 16px;
-      padding-right: 24px;
-      margin-top: 30px;
-
+      background-color: unset;
+      padding: 0;
       .top-row {
-        min-height: 0 !important;
-        position: absolute;
-        top: -52px;
-        margin: 0 0 0 -14px;
-        // padding-top: 30px;
         h3 {
           margin: 0;
+          padding-bottom: var(--large-padding);
           color: var(--ion-color-gray-900) !important;
           max-width: 95%;
           font-weight: var(--font-weight-bold);
           font-size: var(var(--font-size-text-medium) + 2);
-          // margin-top: 20px !important;
         }
       }
       .second-row {
+        width: 100%;
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-rounded);
+        box-shadow: none;
+
+        background-color: var(--ion-color-primary-50);
+        padding: 8px 16px;
+        padding-right: 24px;
         .controls {
           ion-button.btn-play {
             --background: var(--ion-color-secondary-600) !important;

--- a/src/theme/themes/plh_kids_tz/_index.scss
+++ b/src/theme/themes/plh_kids_tz/_index.scss
@@ -42,13 +42,22 @@
       ion-border-radius-small: 8px,
       ion-border-radius-standard: 12px,
       ion-border-radius-secondary: 20px,
-      ion-border-radius-round: 50px,
+      ion-border-radius-rounded: 50px,
 
       // BORDERS
       border-color-default: var(--ion-color-gray-200),
       border-width-default: 1px,
       border-standard: var(--border-width-default) solid var(--border-color-default),
       border-thin-standard: 1px solid var(--border-color-default),
+      // SURFACE COLOUR PALETTE
+      color-surface-white: #ffffff,
+      color-surface-white-variant: #f9f9fa,
+      color-surface-black: #1b1c1d,
+      color-surface-black-variant: #44474a,
+      color-outline: #74777c,
+      color-outline-variant: #c4c7c9,
+
+      // COMPONENTS
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),

--- a/src/theme/themes/plh_kids_tz/_overrides.scss
+++ b/src/theme/themes/plh_kids_tz/_overrides.scss
@@ -94,42 +94,61 @@
   }
   // Audio
   plh-audio {
-    border: 1px solid transparent;
-    .container-player[data-variant~="compact"] {
-      width: var(--buttons-full-width);
-
-      border: 0.9px solid var(--ion-color-primary-100);
-      border-radius: var(--ion-border-radius-round);
+    .container-player[data-variant~="compact"],
+    .container-player[data-variant~="large"] {
+      // Remove visible bounding box from container level and apply to second-row instead
+      border: unset;
+      border-radius: unset;
       box-shadow: none;
-
-      background-color: var(--ion-color-primary-50);
-      padding: 8px 16px;
-      padding-right: 24px;
-      margin-top: 30px;
+      background-color: unset;
+      padding: 0;
 
       .top-row {
-        min-height: 0 !important;
-        position: absolute;
-        top: -52px;
-        margin: 0 0 0 -14px;
-        // padding-top: 30px;
+        padding-bottom: 18px;
         h3 {
           margin: 0;
           color: var(--ion-color-gray-900) !important;
           max-width: 95%;
           font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
-          // margin-top: 20px !important;
         }
       }
+
       .second-row {
+        box-shadow: none;
+      }
+
+      .progress-block {
+        ion-range {
+          --bar-background: var(--color-surface-white) !important;
+          --bar-height: 12px !important;
+          --bar-border-radius: var(--ion-border-radius-standard) !important;
+        }
+
+        .time-value {
+          font-size: var(--font-size-text-small) !important;
+          line-height: var(--line-height-text-tiny) !important;
+          color: var(--ion-color-gray-700) !important;
+        }
+      }
+    }
+
+    // Compact variant
+    .container-player[data-variant~="compact"] {
+      width: 100%;
+      .second-row {
+        width: 100%;
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-rounded);
+        background: var(--ion-color-primary-50);
+        padding: 8px 16px;
+        padding-right: 24px;
         .controls {
           ion-button.btn-play {
-            --background: var(--ion-color-primary-600) !important;
-            --border-radius: var(--ion-border-radius-round) !important;
+            --background: var(--ion-color-secondary-600) !important;
+            --border-radius: var(--ion-border-radius-rounded) !important;
             --box-shadow: none !important;
-            height: 56px !important;
-            width: 56px !important;
+            height: 52px !important;
+            width: 52px !important;
             ion-icon {
               font-size: var(--icon-size-large) !important;
             }
@@ -138,53 +157,28 @@
         .progress-block {
           ion-range {
             width: 100% !important;
-            --bar-background: var(--ion-color-danger-contrast) !important;
-            --bar-height: 12px !important;
-            --knob-size: 16px !important;
-            --knob-background: var(--ion-color-primary-600) !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
-            --knob-box-shadow: none !important;
+            --knob-size: 20px !important;
+            --knob-background: var(--ion-color-secondary-600) !important;
           }
-          .time {
-            .time-value {
-              font-size: var(--font-size-text-small) !important;
-              font-weight: var(--font-weight-medium) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
+          .time .time-value {
+            font-weight: var(--font-weight-medium) !important;
           }
         }
       }
     }
+
+    // Large variant
     .container-player[data-variant~="large"] {
-      background: var(--ion-color-primary-50);
-      border: 0.9px solid var(--ion-color-primary-100);
       box-sizing: border-box;
-      box-shadow: none;
-      border-radius: var(--ion-border-radius-standard);
-      padding: 12px 16px;
       display: flex;
       position: relative;
       flex-direction: column;
-      margin-top: 20px;
-      .top-row {
-        position: absolute;
-        top: -56px;
-        margin: 0 0 0 -14px;
-        h3 {
-          margin: 0;
-          margin-right: 0;
-          color: var(--ion-color-gray-900);
-          max-width: 85%;
-          font-weight: var(--font-weight-bold);
-          font-size: var(var(--font-size-text-medium) + 2);
-        }
-        ion-button.action-button {
-          --padding-start: 2px;
-          --padding-end: 2px;
-        }
-      }
+
       .second-row {
+        border: 0.9px solid var(--ion-color-primary-100);
+        border-radius: var(--ion-border-radius-standard);
+        background: var(--ion-color-primary-50);
+        padding: 12px 16px;
         display: flex;
         flex-direction: column-reverse;
         .controls {
@@ -193,29 +187,26 @@
           .forward {
             ion-icon {
               font-size: var(--icon-size-extra-large) !important;
-              color: var(--ion-color-primary-600) !important;
+              color: var(--ion-color-secondary-600) !important;
               border-radius: 2px !important;
             }
           }
           .btn-play {
             @include mixins.large-square;
             --background: var(--ion-color-primary-50) !important;
-            --border-radius: var(--ion-border-radius-round) !important;
+            --border-radius: var(--ion-border-radius-rounded) !important;
             --padding: 0 !important;
             --box-shadow: none !important;
             ion-icon {
               position: absolute !important;
               font-size: var(--icon-size-largest) !important;
-              color: var(--ion-color-primary-600) !important;
+              color: var(--ion-color-secondary-600) !important;
             }
           }
         }
         .progress-block {
           .audio-range {
-            --bar-background-active: var(--ion-color-primary-600) !important;
-            --bar-background: var(--ion-color-danger-contrast) !important;
-            --bar-height: 12px !important;
-            --bar-border-radius: var(--ion-border-radius-standard) !important;
+            --bar-background-active: var(--ion-color-primary-400) !important;
             --knob-size: 0px !important;
             --pin-background: var(--ion-color-primary-300) !important;
             --knob-background: var(--ion-color-primary-300) !important;
@@ -229,13 +220,6 @@
           ion-range::part(bar-active) {
             top: -1.5px !important;
             margin-left: 0 !important;
-          }
-          .time {
-            &-value {
-              font-size: var(--font-size-text-small) !important;
-              line-height: var(--line-height-text-tiny) !important;
-              color: var(--ion-color-gray-700) !important;
-            }
           }
         }
       }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes some issues with spacing around the audio component that led to inconsistencies.

- `default` theme:
  - removes excess whitespace at top of audio component (https://github.com/IDEMSInternational/open-app-builder/pull/3125/commits/71d8a1be12b54002fdb570391f63d2590c61e7ff)
- `plh_kids_kw` theme and its descendants:
  - fixes issues with display of audio component title
  - removes excessive vertical spacing around audio component
  - refactors styling overrides
  - applies consistency in colours across variants and themes, see screenshots below

## Dev notes

The KW-based themes override the core structure of the component, moving the title from inside the demarcated area to outside. Previously, this was achieved with a workaround that absolutely positioned the title, which was brittle. This is refactored so that the same result is achieved in the theme overrides by moving the visible bounding box from the top-level container to the functional audio player element of the component, excluding the title. @FaithDaka if/when we generally refactor the styling of components to use the KW-based overrides by default, then the HTML and SCSS of the base component can be tidied up.

## Git Issues

Closes #3124

## Screenshots/Videos

[comp_audio](https://docs.google.com/spreadsheets/d/1utD4Kr0WVjvDwnMbg2wYupaPQ0VY0H2csb86fyi4bPI/edit?gid=603128459#gid=603128459) template. Note the changes to the background colour of the `large` variant for some themes – I don't believe this variant is actually used in production currently.

Also note the more significant colour changes for the `plh_kids_tz` deployment – this brings it in line with the other themes, but the colours could be overridden to preserve the current look if desirable (which was updated in #2928). Indeed there's a general question for @FaithDaka of whether the colour of the controls of the audio player should use the new secondary colour post theme generator refactor, which is taken to be a contrasting colour, or use the primary-variant colour, which is taken to be a similar variant of the primary colour.

| theme | before | after |
|---|---|---|
| default | <img width="760" height="3348" alt="default before" src="https://github.com/user-attachments/assets/e5bb5628-c75f-4c67-9dd5-f57bfc26aea0" /> | <img width="760" height="3348" alt="default after" src="https://github.com/user-attachments/assets/56ada58b-21d2-453e-8908-e7b8090be323" /> |
| plh_kids_kw | <img width="760" height="3348" alt="kw before" src="https://github.com/user-attachments/assets/ebf132f9-02eb-471d-9a3a-d690da84e8ee" /> | <img width="760" height="3348" alt="kw after" src="https://github.com/user-attachments/assets/ebb24d3c-84b9-492c-9d3d-1ec960e053f0" /> |
| plh_facilitator_mx | <img width="760" height="3348" alt="mx before" src="https://github.com/user-attachments/assets/2aa01f32-69d8-4257-8919-176717f7df67" /> | <img width="760" height="3348" alt="mx after" src="https://github.com/user-attachments/assets/204d06d6-2335-4977-925a-c67c2014ef9e" /> |
| plh_facilitator_my | <img width="760" height="3348" alt="my before" src="https://github.com/user-attachments/assets/23e77882-0a1e-4644-bfc6-27b393a77bc9" /> | <img width="760" height="3348" alt="my after" src="https://github.com/user-attachments/assets/d41882e7-aaf7-4c03-8b90-0132dea8fdf6" /> |
| plh_facilitator_ph | <img width="760" height="3348" alt="ph before" src="https://github.com/user-attachments/assets/25d453cf-57c4-43ad-a822-b77ff4dfe77d" /> | <img width="760" height="3348" alt="ph after" src="https://github.com/user-attachments/assets/c5be8d29-1ee2-4fe4-b7ad-208c15ee224b" /> |
| plh_kids_tz | <img width="760" height="3348" alt="tz before" src="https://github.com/user-attachments/assets/2cfcaf51-c65d-4e95-92f9-91d63832c8d7" /> | <img width="760" height="3348" alt="tz after" src="https://github.com/user-attachments/assets/88a5090b-e6ba-4cd9-80c4-4432e326e5d2" /> |








