### PR TITLE
style: apple and google sign in buttons (alt)

### DIFF
--- a/src/app/shared/components/template/components/button-apple-sign-in/button-apple-sign-in.component.html
+++ b/src/app/shared/components/template/components/button-apple-sign-in/button-apple-sign-in.component.html
@@ -1,4 +1,10 @@
-<button id="sign-in-apple" class="apple-signin-btn" (click)="handleClick()">
+<button
+  id="sign-in-apple"
+  class="apple-signin-btn"
+  (click)="handleClick()"
+  [disabled]="params().disabled"
+  [attr.data-variant]="params().variant"
+>
   <img src="assets/icon/shared/apple_logo_white.svg" class="apple-logo" />
   {{ value() }}
 </button>

--- a/src/app/shared/components/template/components/button-apple-sign-in/button-apple-sign-in.component.scss
+++ b/src/app/shared/components/template/components/button-apple-sign-in/button-apple-sign-in.component.scss
@@ -1,10 +1,43 @@
-// Button is styled in line with Apple's guidleines:
+// native_apple variant is styled precisely in line with Apple's guidleines:
 // https://developer.apple.com/documentation/sign_in_with_apple/displaying-sign-in-with-apple-buttons-on-the-web
 
+// Default variant
 .apple-signin-btn {
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: white;
+  color: var(--ion-color-secondary-contrast);
+  padding: var(--regular-margin) var(--tiny-padding);
+  border-radius: 50px;
+  font-size: 20px;
+  font-weight: var(--font-weight-bold);
+  font-family: inherit;
+  border: 1px solid var(--ion-color-secondary-contrast);
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+  height: 100%;
+  width: 100%;
+  min-width: 140px;
+
+  .apple-logo {
+    height: 20px;
+    margin-inline-end: 12px;
+    filter: invert(1);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.4;
+  }
+
+  &:not(:disabled):active {
+    background-color: var(--ion-color-gray-light);
+  }
+}
+
+// native_apple variant override styles
+.apple-signin-btn[data-variant="native_apple"] {
   background-color: black;
   color: white;
   padding: 10px 30px 14px;
@@ -13,21 +46,26 @@
   font-weight: 600;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   border: none;
-  cursor: pointer;
-  transition: background-color 0.2s ease-in-out;
   height: 40px;
-  min-width: 140px;
+  width: auto;
 
   .apple-logo {
     height: 14px;
     margin-inline-end: 10px;
+    filter: none;
   }
 
-  &:hover {
-    background-color: #333;
+  &:disabled {
+    cursor: default;
   }
 
-  &:active {
-    background-color: #555;
+  &:not(:disabled) {
+    &:hover {
+      background-color: #333;
+    }
+
+    &:active {
+      background-color: #555;
+    }
   }
 }

--- a/src/app/shared/components/template/components/button-apple-sign-in/button-apple-sign-in.component.scss
+++ b/src/app/shared/components/template/components/button-apple-sign-in/button-apple-sign-in.component.scss
@@ -1,3 +1,5 @@
+$border-radius: var(--button-border-radius, var(--ion-border-radius-standard));
+
 // native_apple variant is styled precisely in line with Apple's guidleines:
 // https://developer.apple.com/documentation/sign_in_with_apple/displaying-sign-in-with-apple-buttons-on-the-web
 
@@ -7,13 +9,13 @@
   align-items: center;
   justify-content: center;
   background-color: white;
-  color: var(--ion-color-secondary-contrast);
+  color: black;
   padding: var(--regular-margin) var(--tiny-padding);
-  border-radius: 50px;
+  border-radius: $border-radius;
   font-size: 20px;
   font-weight: var(--font-weight-bold);
   font-family: inherit;
-  border: 1px solid var(--ion-color-secondary-contrast);
+  border: 1px solid black;
   cursor: pointer;
   transition: background-color 0.2s ease-in-out;
   height: 100%;

--- a/src/app/shared/components/template/components/button-apple-sign-in/button-apple-sign-in.component.ts
+++ b/src/app/shared/components/template/components/button-apple-sign-in/button-apple-sign-in.component.ts
@@ -1,12 +1,24 @@
-import { Component } from "@angular/core";
+import { Component, computed } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 import { AuthService } from "src/app/shared/services/auth/auth.service";
+import { FlowTypes } from "packages/data-models";
+import {
+  getBooleanParamFromTemplateRow,
+  getStringParamFromTemplateRow,
+} from "src/app/shared/utils";
+
+interface IButtonAppleSignInComponentParams {
+  variant: null | "native_apple";
+  disabled: boolean;
+}
+
 @Component({
   selector: "tmpl-button-apple-sign-in",
   templateUrl: "./button-apple-sign-in.component.html",
   styleUrls: ["./button-apple-sign-in.component.scss"],
 })
 export class TmplButtonAppleSignInComponent extends TemplateBaseComponent {
+  params = computed(() => this.getParams(this.parameterList()));
   // The button text is set as row value directly in the HTML template
 
   constructor(private authService: AuthService) {
@@ -16,5 +28,14 @@ export class TmplButtonAppleSignInComponent extends TemplateBaseComponent {
   public async handleClick() {
     await this.authService.provider.signIn("apple.com");
     this.triggerActions("click");
+  }
+
+  private getParams(
+    authorParams: FlowTypes.TemplateRow["parameter_list"]
+  ): IButtonAppleSignInComponentParams {
+    return {
+      variant: getStringParamFromTemplateRow(this._row, "variant", null),
+      disabled: getBooleanParamFromTemplateRow(this._row, "disabled", false),
+    } as IButtonAppleSignInComponentParams;
   }
 }

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.html
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.html
@@ -1,6 +1,6 @@
 <!-- HTML copied from https://developers.google.com/identity/branding-guidelines
  with Theme: Light; Shape: Pill -->
-<button class="gsi-material-button" (click)="handleClick()">
+<button class="gsi-material-button" (click)="handleClick()" [attr.data-variant]="params().variant">
   <div class="gsi-material-button-state"></div>
   <div class="gsi-material-button-content-wrapper">
     <div class="gsi-material-button-icon">

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.html
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.html
@@ -1,6 +1,11 @@
 <!-- HTML copied from https://developers.google.com/identity/branding-guidelines
  with Theme: Light; Shape: Pill -->
-<button class="gsi-material-button" (click)="handleClick()" [attr.data-variant]="params().variant">
+<button
+  class="gsi-material-button"
+  (click)="handleClick()"
+  [attr.data-variant]="params().variant"
+  [disabled]="params().disabled"
+>
   <div class="gsi-material-button-state"></div>
   <div class="gsi-material-button-content-wrapper">
     <div class="gsi-material-button-icon">

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
@@ -116,3 +116,117 @@ The only modification is using `margin-inline-end` instead of `margin-right` to 
     opacity: 8%;
   }
 }
+
+.gsi-material-button:not([data-variant]) {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  -webkit-appearance: none;
+  background-color: white;
+  background-image: none;
+  border: 1px solid black;
+  -webkit-border-radius: var(--ion-border-radius-rounded);
+  border-radius: var(--ion-border-radius-rounded);
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  color: black;
+  cursor: pointer;
+  font-family: "Roboto", arial, sans-serif;
+  font-size: var(--buttons-font-size-small);
+  height: 100%;
+  letter-spacing: 0px;
+  outline: none;
+  overflow: hidden;
+  padding: var(--regular-margin) var(--tiny-padding);
+  position: relative;
+  text-align: center;
+  -webkit-transition:
+    background-color 0.218s,
+    border-color 0.218s,
+    box-shadow 0.218s;
+  transition:
+    background-color 0.218s,
+    border-color 0.218s,
+    box-shadow 0.218s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 100%;
+  max-width: 400px;
+  min-width: min-content;
+
+  .gsi-material-button-icon {
+    height: 20px;
+    margin-inline-end: 12px;
+    min-width: 20px;
+    width: 20px;
+  }
+
+  .gsi-material-button-content-wrapper {
+    -webkit-align-items: center;
+    align-items: center;
+    display: flex;
+    -webkit-flex-direction: row;
+    flex-direction: row;
+    -webkit-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    height: 100%;
+    justify-content: center;
+    position: relative;
+    width: 100%;
+  }
+
+  .gsi-material-button-contents {
+    -webkit-flex-grow: 0;
+    flex-grow: 0;
+    font-family: "Roboto", arial, sans-serif;
+    font-weight: 500;
+    overflow: visible;
+    text-overflow: ellipsis;
+    vertical-align: top;
+  }
+
+  .gsi-material-button-state {
+    -webkit-transition: opacity 0.218s;
+    transition: opacity 0.218s;
+    bottom: 0;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  &:disabled {
+    cursor: default;
+    background-color: #ffffff61;
+    border-color: #1f1f1f1f;
+  }
+
+  &:disabled .gsi-material-button-contents {
+    opacity: 38%;
+  }
+
+  &:disabled .gsi-material-button-icon {
+    opacity: 38%;
+  }
+
+  &:not(:disabled):active .gsi-material-button-state,
+  &:not(:disabled):focus .gsi-material-button-state {
+    background-color: #303030;
+    opacity: 12%;
+  }
+
+  &:not(:disabled):hover {
+    -webkit-box-shadow:
+      0 1px 2px 0 rgba(60, 64, 67, 0.3),
+      0 1px 3px 1px rgba(60, 64, 67, 0.15);
+    box-shadow:
+      0 1px 2px 0 rgba(60, 64, 67, 0.3),
+      0 1px 3px 1px rgba(60, 64, 67, 0.15);
+  }
+
+  &:not(:disabled):hover .gsi-material-button-state {
+    background-color: #303030;
+    opacity: 8%;
+  }
+}

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
@@ -3,7 +3,7 @@ with Theme: Light; Shape: Pill
 The only modification is using `margin-inline-end` instead of `margin-right` to support RTL languages
 */
 
-.gsi-material-button {
+.gsi-material-button[data-variant="native_google"] {
   -moz-user-select: none;
   -webkit-user-select: none;
   -ms-user-select: none;
@@ -39,80 +39,80 @@ The only modification is using `margin-inline-end` instead of `margin-right` to 
   width: auto;
   max-width: 400px;
   min-width: min-content;
-}
 
-.gsi-material-button .gsi-material-button-icon {
-  height: 20px;
-  margin-inline-end: 12px;
-  min-width: 20px;
-  width: 20px;
-}
+  .gsi-material-button-icon {
+    height: 20px;
+    margin-inline-end: 12px;
+    min-width: 20px;
+    width: 20px;
+  }
 
-.gsi-material-button .gsi-material-button-content-wrapper {
-  -webkit-align-items: center;
-  align-items: center;
-  display: flex;
-  -webkit-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  height: 100%;
-  justify-content: space-between;
-  position: relative;
-  width: 100%;
-}
+  .gsi-material-button-content-wrapper {
+    -webkit-align-items: center;
+    align-items: center;
+    display: flex;
+    -webkit-flex-direction: row;
+    flex-direction: row;
+    -webkit-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+    height: 100%;
+    justify-content: space-between;
+    position: relative;
+    width: 100%;
+  }
 
-.gsi-material-button .gsi-material-button-contents {
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  font-family: "Roboto", arial, sans-serif;
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  vertical-align: top;
-}
+  .gsi-material-button-contents {
+    -webkit-flex-grow: 1;
+    flex-grow: 1;
+    font-family: "Roboto", arial, sans-serif;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: top;
+  }
 
-.gsi-material-button .gsi-material-button-state {
-  -webkit-transition: opacity 0.218s;
-  transition: opacity 0.218s;
-  bottom: 0;
-  left: 0;
-  opacity: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-}
+  .gsi-material-button-state {
+    -webkit-transition: opacity 0.218s;
+    transition: opacity 0.218s;
+    bottom: 0;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
 
-.gsi-material-button:disabled {
-  cursor: default;
-  background-color: #ffffff61;
-  border-color: #1f1f1f1f;
-}
+  &:disabled {
+    cursor: default;
+    background-color: #ffffff61;
+    border-color: #1f1f1f1f;
+  }
 
-.gsi-material-button:disabled .gsi-material-button-contents {
-  opacity: 38%;
-}
+  &:disabled .gsi-material-button-contents {
+    opacity: 38%;
+  }
 
-.gsi-material-button:disabled .gsi-material-button-icon {
-  opacity: 38%;
-}
+  &:disabled .gsi-material-button-icon {
+    opacity: 38%;
+  }
 
-.gsi-material-button:not(:disabled):active .gsi-material-button-state,
-.gsi-material-button:not(:disabled):focus .gsi-material-button-state {
-  background-color: #303030;
-  opacity: 12%;
-}
+  &:not(:disabled):active .gsi-material-button-state,
+  &:not(:disabled):focus .gsi-material-button-state {
+    background-color: #303030;
+    opacity: 12%;
+  }
 
-.gsi-material-button:not(:disabled):hover {
-  -webkit-box-shadow:
-    0 1px 2px 0 rgba(60, 64, 67, 0.3),
-    0 1px 3px 1px rgba(60, 64, 67, 0.15);
-  box-shadow:
-    0 1px 2px 0 rgba(60, 64, 67, 0.3),
-    0 1px 3px 1px rgba(60, 64, 67, 0.15);
-}
+  &:not(:disabled):hover {
+    -webkit-box-shadow:
+      0 1px 2px 0 rgba(60, 64, 67, 0.3),
+      0 1px 3px 1px rgba(60, 64, 67, 0.15);
+    box-shadow:
+      0 1px 2px 0 rgba(60, 64, 67, 0.3),
+      0 1px 3px 1px rgba(60, 64, 67, 0.15);
+  }
 
-.gsi-material-button:not(:disabled):hover .gsi-material-button-state {
-  background-color: #303030;
-  opacity: 8%;
+  &:not(:disabled):hover .gsi-material-button-state {
+    background-color: #303030;
+    opacity: 8%;
+  }
 }

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
@@ -1,123 +1,11 @@
-/* CSS copied from https://developers.google.com/identity/branding-guidelines
-with Theme: Light; Shape: Pill 
-The only modification is using `margin-inline-end` instead of `margin-right` to support RTL languages
+/* 
+CSS adapted from https://developers.google.com/identity/branding-guidelines
+with Theme: Light; Shape: Pill.
+Native Google variant reflects the example styling exactly
 */
 
-.gsi-material-button[data-variant="native_google"] {
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
-  -webkit-appearance: none;
-  background-color: WHITE;
-  background-image: none;
-  border: 1px solid #747775;
-  -webkit-border-radius: 20px;
-  border-radius: 20px;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-  color: #1f1f1f;
-  cursor: pointer;
-  font-family: "Roboto", arial, sans-serif;
-  font-size: 14px;
-  height: 40px;
-  letter-spacing: 0.25px;
-  outline: none;
-  overflow: hidden;
-  padding: 0 12px;
-  position: relative;
-  text-align: center;
-  -webkit-transition:
-    background-color 0.218s,
-    border-color 0.218s,
-    box-shadow 0.218s;
-  transition:
-    background-color 0.218s,
-    border-color 0.218s,
-    box-shadow 0.218s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-  max-width: 400px;
-  min-width: min-content;
-
-  .gsi-material-button-icon {
-    height: 20px;
-    margin-inline-end: 12px;
-    min-width: 20px;
-    width: 20px;
-  }
-
-  .gsi-material-button-content-wrapper {
-    -webkit-align-items: center;
-    align-items: center;
-    display: flex;
-    -webkit-flex-direction: row;
-    flex-direction: row;
-    -webkit-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    height: 100%;
-    justify-content: space-between;
-    position: relative;
-    width: 100%;
-  }
-
-  .gsi-material-button-contents {
-    -webkit-flex-grow: 1;
-    flex-grow: 1;
-    font-family: "Roboto", arial, sans-serif;
-    font-weight: 500;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    vertical-align: top;
-  }
-
-  .gsi-material-button-state {
-    -webkit-transition: opacity 0.218s;
-    transition: opacity 0.218s;
-    bottom: 0;
-    left: 0;
-    opacity: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-  }
-
-  &:disabled {
-    cursor: default;
-    background-color: #ffffff61;
-    border-color: #1f1f1f1f;
-  }
-
-  &:disabled .gsi-material-button-contents {
-    opacity: 38%;
-  }
-
-  &:disabled .gsi-material-button-icon {
-    opacity: 38%;
-  }
-
-  &:not(:disabled):active .gsi-material-button-state,
-  &:not(:disabled):focus .gsi-material-button-state {
-    background-color: #303030;
-    opacity: 12%;
-  }
-
-  &:not(:disabled):hover {
-    -webkit-box-shadow:
-      0 1px 2px 0 rgba(60, 64, 67, 0.3),
-      0 1px 3px 1px rgba(60, 64, 67, 0.15);
-    box-shadow:
-      0 1px 2px 0 rgba(60, 64, 67, 0.3),
-      0 1px 3px 1px rgba(60, 64, 67, 0.15);
-  }
-
-  &:not(:disabled):hover .gsi-material-button-state {
-    background-color: #303030;
-    opacity: 8%;
-  }
-}
-
-.gsi-material-button:not([data-variant]) {
+/* Default variant */
+.gsi-material-button {
   -moz-user-select: none;
   -webkit-user-select: none;
   -ms-user-select: none;
@@ -151,7 +39,6 @@ The only modification is using `margin-inline-end` instead of `margin-right` to 
   vertical-align: middle;
   white-space: nowrap;
   width: 100%;
-  max-width: 400px;
   min-width: min-content;
 
   .gsi-material-button-icon {
@@ -183,6 +70,46 @@ The only modification is using `margin-inline-end` instead of `margin-right` to 
     overflow: visible;
     text-overflow: ellipsis;
     vertical-align: top;
+  }
+
+  &:disabled {
+    cursor: default;
+    background-color: #ffffff61;
+    border-color: #1f1f1f1f;
+
+    .gsi-material-button-contents,
+    .gsi-material-button-icon {
+      opacity: 0.4;
+    }
+  }
+
+  &:not(:disabled):active {
+    background-color: var(--ion-color-gray-light);
+  }
+}
+
+/* native_google variant override styles */
+.gsi-material-button[data-variant="native_google"] {
+  background-color: WHITE;
+  border: 1px solid #747775;
+  -webkit-border-radius: 20px;
+  border-radius: 20px;
+  color: #1f1f1f;
+  font-size: 14px;
+  height: 40px;
+  letter-spacing: 0.25px;
+  padding: 0 12px;
+  width: auto;
+  max-width: 400px;
+
+  .gsi-material-button-content-wrapper {
+    justify-content: space-between;
+  }
+
+  .gsi-material-button-contents {
+    -webkit-flex-grow: 1;
+    flex-grow: 1;
+    overflow: hidden;
   }
 
   .gsi-material-button-state {

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
@@ -19,8 +19,6 @@ Native Google variant reflects the example styling exactly
   box-sizing: border-box;
   color: black;
   cursor: pointer;
-  font-family: "Roboto", arial, sans-serif;
-  font-size: var(--buttons-font-size-small);
   height: 100%;
   letter-spacing: 0px;
   outline: none;
@@ -65,8 +63,9 @@ Native Google variant reflects the example styling exactly
   .gsi-material-button-contents {
     -webkit-flex-grow: 0;
     flex-grow: 0;
-    font-family: "Roboto", arial, sans-serif;
-    font-weight: 500;
+    font-family: inherit;
+    font-weight: var(--font-weight-bold);
+    font-size: var(--buttons-font-size-small);
     overflow: visible;
     text-overflow: ellipsis;
     vertical-align: top;
@@ -74,12 +73,11 @@ Native Google variant reflects the example styling exactly
 
   &:disabled {
     cursor: default;
-    background-color: #ffffff61;
-    border-color: #1f1f1f1f;
+    opacity: 0.4;
 
     .gsi-material-button-contents,
     .gsi-material-button-icon {
-      opacity: 0.4;
+      opacity: 1;
     }
   }
 
@@ -95,7 +93,6 @@ Native Google variant reflects the example styling exactly
   -webkit-border-radius: 20px;
   border-radius: 20px;
   color: #1f1f1f;
-  font-size: 14px;
   height: 40px;
   letter-spacing: 0.25px;
   padding: 0 12px;
@@ -107,6 +104,9 @@ Native Google variant reflects the example styling exactly
   }
 
   .gsi-material-button-contents {
+    font-family: "Roboto", arial, sans-serif;
+    font-weight: 500;
+    font-size: 14px;
     -webkit-flex-grow: 1;
     flex-grow: 1;
     overflow: hidden;
@@ -125,6 +125,7 @@ Native Google variant reflects the example styling exactly
 
   &:disabled {
     cursor: default;
+    opacity: 1;
     background-color: #ffffff61;
     border-color: #1f1f1f1f;
   }

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.scss
@@ -1,3 +1,5 @@
+$border-radius: var(--button-border-radius, var(--ion-border-radius-standard));
+
 /* 
 CSS adapted from https://developers.google.com/identity/branding-guidelines
 with Theme: Light; Shape: Pill.
@@ -13,8 +15,8 @@ Native Google variant reflects the example styling exactly
   background-color: white;
   background-image: none;
   border: 1px solid black;
-  -webkit-border-radius: var(--ion-border-radius-rounded);
-  border-radius: var(--ion-border-radius-rounded);
+  -webkit-border-radius: $border-radius;
+  border-radius: $border-radius;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   color: black;

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.ts
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.ts
@@ -1,12 +1,20 @@
-import { Component } from "@angular/core";
+import { Component, computed } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 import { AuthService } from "src/app/shared/services/auth/auth.service";
+import { FlowTypes } from "packages/data-models";
+import { getStringParamFromTemplateRow } from "src/app/shared/utils";
+
+interface IButtonGoogleSignInComponentParams {
+  variant: null | "native_google";
+}
+
 @Component({
   selector: "tmpl-button-google-sign-in",
   templateUrl: "./button-google-sign-in.component.html",
   styleUrls: ["./button-google-sign-in.component.scss"],
 })
 export class TmplButtonGoogleSignInComponent extends TemplateBaseComponent {
+  params = computed(() => this.getParams(this.parameterList()));
   // The button text is set as row value directly in the HTML template
 
   constructor(private authService: AuthService) {
@@ -16,5 +24,17 @@ export class TmplButtonGoogleSignInComponent extends TemplateBaseComponent {
   public async handleClick() {
     await this.authService.provider.signIn("google.com");
     this.triggerActions("click");
+  }
+
+  private getParams(
+    authorParams: FlowTypes.TemplateRow["parameter_list"]
+  ): IButtonGoogleSignInComponentParams {
+    return {
+      variant: getStringParamFromTemplateRow(
+        this._row,
+        "variant",
+        null
+      ) as IButtonGoogleSignInComponentParams["variant"],
+    };
   }
 }

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.ts
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.ts
@@ -2,10 +2,14 @@ import { Component, computed } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 import { AuthService } from "src/app/shared/services/auth/auth.service";
 import { FlowTypes } from "packages/data-models";
-import { getStringParamFromTemplateRow } from "src/app/shared/utils";
+import {
+  getBooleanParamFromTemplateRow,
+  getStringParamFromTemplateRow,
+} from "src/app/shared/utils";
 
 interface IButtonGoogleSignInComponentParams {
   variant: null | "native_google";
+  disabled: boolean;
 }
 
 @Component({
@@ -35,6 +39,7 @@ export class TmplButtonGoogleSignInComponent extends TemplateBaseComponent {
         "variant",
         null
       ) as IButtonGoogleSignInComponentParams["variant"],
+      disabled: getBooleanParamFromTemplateRow(this._row, "disabled", false),
     };
   }
 }

--- a/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.ts
+++ b/src/app/shared/components/template/components/button-google-sign-in/button-google-sign-in.component.ts
@@ -34,12 +34,8 @@ export class TmplButtonGoogleSignInComponent extends TemplateBaseComponent {
     authorParams: FlowTypes.TemplateRow["parameter_list"]
   ): IButtonGoogleSignInComponentParams {
     return {
-      variant: getStringParamFromTemplateRow(
-        this._row,
-        "variant",
-        null
-      ) as IButtonGoogleSignInComponentParams["variant"],
+      variant: getStringParamFromTemplateRow(this._row, "variant", null),
       disabled: getBooleanParamFromTemplateRow(this._row, "disabled", false),
-    };
+    } as IButtonGoogleSignInComponentParams;
   }
 }

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -1,5 +1,6 @@
 $background-primary: var(--button-background-primary, var(--gradient-primary-mid-vertical));
 $background-secondary: var(--button-background-secondary, var(--gradient-secondary-mid-vertical));
+$border-radius: var(--button-border-radius, var(--ion-border-radius-standard));
 
 :host {
   width: 100%;
@@ -23,7 +24,7 @@ ion-button {
   white-space: pre-line;
   min-height: var(--buttons-min-height);
   padding: var(--regular-margin) var(--tiny-padding) 0;
-  --border-radius: var(--ion-border-radius-standard);
+  --border-radius: #{$border-radius};
   --box-shadow: var(--ion-default-box-shadow);
   display: flex;
   width: fit-content;

--- a/src/theme/themes/default.scss
+++ b/src/theme/themes/default.scss
@@ -25,6 +25,7 @@
         // button-background-primary: var(--gradient-primary-mid-vertical),
         // button-background-secondary: var(--gradient-secondary-mid-vertical),
         // button-background-option: var(--gradient-primary-dark-vertical),
+        // button-border-radius: var(--ion-border-radius-standard),
         round-button-background-secondary-light: var(--ion-color-yellow),
         // round-button-background-secondary-mid: #fa9529,
         // round-button-background-secondary-dark: #F87023,

--- a/src/theme/themes/plh_facilitator_mx/_index.scss
+++ b/src/theme/themes/plh_facilitator_mx/_index.scss
@@ -45,6 +45,7 @@
       button-background-primary: var(--ion-color-primary-600),
       button-background-secondary: var(--ion-color-secondary),
       button-background-option: var(--ion-color-primary-800),
+      button-border-radius: var(--ion-border-radius-rounded),
       buttons-full-height: 48px,
       round-button-background-secondary-light: var(--ion-color-yellow),
       round-button-min-height: 48px,

--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -194,7 +194,6 @@
       height: var(--buttons-full-height);
       width: var(--buttons-full-width);
       margin: 0 auto;
-      --border-radius: var(--ion-border-radius-rounded);
       --box-shadow: none;
 
       font-size: var(--buttons-font-size-large);

--- a/src/theme/themes/plh_facilitator_my/index.scss
+++ b/src/theme/themes/plh_facilitator_my/index.scss
@@ -41,6 +41,7 @@
       button-background-primary: var(--ion-color-primary-700),
       button-background-secondary: var(--ion-color-secondary-600),
       button-background-option: var(--ion-color-secondary-700),
+      button-border-radius: var(--ion-border-radius-rounded),
       buttons-full-height: 56px,
       buttons-medium-height: 48px,
       round-button-background-secondary-light: var(--ion-color-yellow),

--- a/src/theme/themes/plh_facilitator_my/overrides.scss
+++ b/src/theme/themes/plh_facilitator_my/overrides.scss
@@ -214,7 +214,6 @@
       height: var(--buttons-full-height);
       width: var(--buttons-full-width);
       margin: 0 auto;
-      --border-radius: var(--ion-border-radius-rounded);
       --box-shadow: none;
 
       font-size: var(--buttons-font-size-large);

--- a/src/theme/themes/plh_facilitator_ph/_index.scss
+++ b/src/theme/themes/plh_facilitator_ph/_index.scss
@@ -43,6 +43,7 @@
       button-background-primary: var(--ion-color-primary-700),
       button-background-secondary: var(--color-accent-orange-60),
       button-background-option: var(--color-accent-orange-40),
+      button-border-radius: var(--ion-border-radius-rounded),
       buttons-full-height: 56px,
       buttons-medium-height: 48px,
       round-button-background-secondary-light: var(--ion-color-yellow),

--- a/src/theme/themes/plh_facilitator_ph/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_ph/_overrides.scss
@@ -215,7 +215,6 @@
       height: var(--buttons-full-height);
       width: var(--buttons-full-width);
       margin: 0 auto;
-      --border-radius: var(--ion-border-radius-rounded);
       --box-shadow: none;
 
       font-size: var(--buttons-font-size-large);

--- a/src/theme/themes/plh_kids_kw/_index.scss
+++ b/src/theme/themes/plh_kids_kw/_index.scss
@@ -73,6 +73,7 @@
       button-background-option: var(--ion-color-primary-800),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
+      button-border-radius: var(--ion-border-radius-rounded),
       combo-box-background-with-value: var(--ion-color-primary-300),
       display-group-background-banner-primary: var(--ion-color-primary-200),
       display-group-background-banner-secondary: var(--ion-color-secondary-300),

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -8,7 +8,6 @@
       height: var(--buttons-full-height);
       width: var(--buttons-full-width);
       margin: 0 auto;
-      --border-radius: var(--ion-border-radius-rounded);
       --box-shadow: none;
 
       font-size: var(--buttons-font-size-large);

--- a/src/theme/themes/plh_kids_teens_za/_index.scss
+++ b/src/theme/themes/plh_kids_teens_za/_index.scss
@@ -73,6 +73,7 @@
       button-background-option: var(--ion-color-primary-800),
       button-background-primary: var(--ion-color-primary-500),
       button-background-secondary: var(--ion-color-secondary),
+      button-border-radius: var(--ion-border-radius-rounded),
       combo-box-background-with-value: var(--ion-color-primary-300),
       display-group-background-banner-primary: var(--ion-color-primary-200),
       display-group-background-banner-secondary: var(--ion-color-secondary-300),

--- a/src/theme/themes/plh_kids_teens_za/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_za/_overrides.scss
@@ -8,7 +8,6 @@
       height: var(--buttons-full-height);
       width: var(--buttons-full-width);
       margin: 0 auto;
-      --border-radius: var(--ion-border-radius-rounded);
       --box-shadow: none;
 
       font-size: var(--buttons-font-size-large);


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds new default styling for the components `google_sign_in_button` and `apple_sign_in_button`. By default, the buttons will now be styled somewhat in keeping with our general button styles for visual consistently, whilst sticking within the guidelines provided by the respective brands (for an example of something similar, see the Airbnb example on https://github.com/ParentingForLifelongHealth/plh-facilitator-app-content/issues/91).

The previous default styling for these components, which is lifted exactly from the brands' own docs ([Apple](https://account.apple.com/signinwithapple/button) and [Google](https://developers.google.com/identity/branding-guidelines#render-html-button)) is still available under new variants for these components, `native_apple` and `native_google` respectively.

## Git Issues

Closes #3148
Closes #3075
Enables closure of https://github.com/ParentingForLifelongHealth/plh-facilitator-app-content/issues/91, pending authoring updates

## Screenshots/Videos

| template | before | after |
|---|---|---|
| [comp_apple_sign_in_button](https://docs.google.com/spreadsheets/d/1P6EhHmElOJOAoMH4h_vingVL82jyCfSTYPXj8eY2Iek/edit?gid=569531329#gid=569531329) | <img width="403" height="639" alt="Screenshot 2025-09-26 at 12 34 37" src="https://github.com/user-attachments/assets/b92049f4-cc69-460d-b1c1-9a6a1565a8a9" /> | <img width="403" height="639" alt="Screenshot 2025-09-26 at 12 35 35" src="https://github.com/user-attachments/assets/2684d254-9b38-44c5-9e8b-0fb1d4d9346d" /> |
| [comp_google_sign_in_button](https://docs.google.com/spreadsheets/d/1L_AjZYIqTd6ubSYlmyrbGcrpgYaSVybzm7aLt_VFAHw/edit?gid=569531329#gid=569531329) | <img width="404" height="638" alt="Screenshot 2025-09-26 at 12 36 18" src="https://github.com/user-attachments/assets/c1b94ca7-6dc4-4fe0-a5d2-70ff9c81f854" /> | <img width="356" height="633" alt="Screenshot 2025-09-26 at 12 36 43" src="https://github.com/user-attachments/assets/2f1ffe1e-3708-4434-b990-dbfe484eb334" /> |


