### PR TITLE
fix: remote asset pack can contain assets with no core version

### DIFF
--- a/packages/data-models/assets.model.ts
+++ b/packages/data-models/assets.model.ts
@@ -21,7 +21,7 @@ export interface IAssetOverrideProps {
 
 export interface IAssetEntry extends IAssetContentsEntryMinimal {
   /** id field is required to convert asset contents to and from data_list format */
-  id?: string;
+  id: string;
   /** Used to indicate that the asset pack contains only overrides for the associated file, not the default asset file */
   overridesOnly?: boolean;
   overrides?: {

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -194,6 +194,31 @@ export class DynamicDataService extends AsyncServiceBase {
     }
   }
 
+  /**
+   * Upsert a single row by merging partial data if the row exists, or inserting a new row if it doesn't.
+   * Unlike upsert(), this method merges data instead of replacing the entire row.
+   * Unlike update(), this method doesn't throw an error if the row doesn't exist.
+   */
+  public async upsertAndMerge<T extends { id: string }>(
+    flow_type: FlowTypes.FlowType,
+    flow_name: string,
+    row_id: string,
+    data: Partial<T>
+  ) {
+    console.log("upsertAndMerge", { flow_type, flow_name, row_id, data });
+    if (data) {
+      const { collectionName } = await this.ensureCollection(flow_type, flow_name);
+      const existingRow = await this.db.getDoc<any>(collectionName, row_id);
+      console.log("existingRow", existingRow);
+
+      if (existingRow) {
+        await this.update(flow_type, flow_name, row_id, data);
+      } else {
+        await this.insert(flow_type, flow_name, { id: row_id, ...data });
+      }
+    }
+  }
+
   /** Remove user_generated data row */
   public async remove(flow_type: FlowTypes.FlowType, flow_name: string, ids: string[]) {
     const { collectionName } = await this.ensureCollection(flow_type, flow_name);

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -377,7 +377,7 @@ export class RemoteAssetService extends AsyncServiceBase {
     const update = this.addFilePathToAssetEntry(assetEntry, filepath, overrideProps);
     // Update the core asset pack in dynamic data, adding an entry for the asset or
     // updating an existing entry if it already exists
-    await this.dynamicDataService.update<IAssetEntry>(
+    await this.dynamicDataService.upsertAndMerge<IAssetEntry>(
       "asset_pack",
       CORE_ASSET_PACK_NAME,
       assetEntry.id,


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where remote assets that have no corresponding core equivalent are not integrated correctly when downloaded as part of an asset pack.

## Git Issues

Closes #3153

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
